### PR TITLE
docs: document WebSocketScanCommand and SessionChain structs

### DIFF
--- a/apis/websocketdatastructures.go
+++ b/apis/websocketdatastructures.go
@@ -37,21 +37,58 @@ type JobTracking struct {
 	Timestamp        time.Time `json:"timestamp,omitempty"`
 }
 
-// WebsocketScanCommand trigger scan thru the websocket
+// WebsocketScanCommand is a command that triggers a scan for vulnerabilities.
 type WebsocketScanCommand struct {
+	// Current session context
+	//
+	// Used for correlating requests in the logs.
+	Session SessionChain `json:"session,omitempty"`
+	// Tag of the image to scan
+	//
+	// Example: nginx:latest
+	ImageTag string `json:"imageTag"`
+	// ID of a workload that is running the image you want to scan
+	//
+	// Example: wlid://cluster-marina/namespace-default/deployment-nginx
+	Wlid string `json:"wlid"`
+	// Has the provided image been previously scanned or not?
+	//
+	// An image will only be scanned if it has not been scanned previously (value is `false`).
+	// If an image has been previously scanned (value is `true`), it will not be scanned again.
+	//
+	// Example: false
+	IsScanned bool `json:"isScanned"`
+	// Name of the container that contains an image to be scanned
+	//
+	// Example: nginx
+	ContainerName string `json:"containerName"`
+	// ID of the scanning Job
+	//
+	// Example: 7b04592b-665a-4e47-a9c9-65b2b3cabb49
+	JobID string `json:"jobID,omitempty"`
+	// ID of the Parent Job — a job that initiated the current job
+	//
+	// Example: 825f0a9e-34a9-4727-b81a-6e1bf3a63725
+	ParentJobID string `json:"parentJobID,omitempty"`
+	// The last action received from the Websocket
+	//
+	// Example: 2
+	LastAction int `json:"actionIDN"`
+	// Hash of the image to scan
+	//
+	// Example: bcae378eacedab83da66079d9366c8f5df542d7ed9ab23bf487e3e1a8481375d
+	ImageHash string `json:"imageHash"`
+	// Deprecated: Credentials to the Container Registry that holds the image to be scanned
+	//
+	// Kept for backward compatibility
+	Credentials *types.AuthConfig `json:"credentials,omitempty"`
+	// A list of credentials for private Container Registries that store images to be scanned
+	Credentialslist []types.AuthConfig `json:"credentialsList,omitempty"`
+	// Arguments to pass to the scan command
+	//
+	// Example: {"useHTTP": true, "skipTLSVerify": true, "registryName": "", "repository": "", "tag": ""}
+	Args map[string]interface{} `json:"args,omitempty"`
 	// CustomerGUID string `json:"customerGUID"`
-	Session         SessionChain           `json:"session,omitempty"`
-	ImageTag        string                 `json:"imageTag"`
-	Wlid            string                 `json:"wlid"`
-	IsScanned       bool                   `json:"isScanned"`
-	ContainerName   string                 `json:"containerName"`
-	JobID           string                 `json:"jobID,omitempty"`
-	ParentJobID     string                 `json:"parentJobID,omitempty"`
-	LastAction      int                    `json:"actionIDN"`
-	ImageHash       string                 `json:"imageHash"`
-	Credentials     *types.AuthConfig      `json:"credentials,omitempty"`
-	Credentialslist []types.AuthConfig     `json:"credentialsList,omitempty"`
-	Args            map[string]interface{} `json:"args,omitempty"`
 }
 
 type SafeMode struct {


### PR DESCRIPTION
# What this PR changes

This PR adds documenting comments to the `WebSocketScanCommand` and `SessionChain` structs. These comments are needed so we can automatically generate an OpenAPI spec in downstream packages. And it helps to expand the documentation, too :)

Please note that I documented these structs to the best of my understanding, and it might be wrong. So please feel free to correct anything.