### PR TITLE
docs: Add Websocket-related annotations

### DIFF
--- a/apis/clusterapis.go
+++ b/apis/clusterapis.go
@@ -9,19 +9,29 @@ const (
 )
 
 // Supported NotificationTypes
+//
+// swagger:enum NotificationPolicyType
 type NotificationPolicyType string
 
 const (
-	TypeValidateRules              NotificationPolicyType = "validateRules"
-	TypeExecPostureScan            NotificationPolicyType = "execPostureScan"
-	TypeUpdateRules                NotificationPolicyType = "updateRules"
-	TypeRunKubescapeJob            NotificationPolicyType = "runKubescapeJob"
-	TypeRunKubescape               NotificationPolicyType = "kubescapeScan"
-	TypeSetKubescapeCronJob        NotificationPolicyType = "setKubescapeCronJob"
-	TypeUpdateKubescapeCronJob     NotificationPolicyType = "updateKubescapeCronJob"
-	TypeDeleteKubescapeCronJob     NotificationPolicyType = "deleteKubescapeCronJob"
-	TypeSetVulnScanCronJob         NotificationPolicyType = "setVulnScanCronJob"
-	TypeUpdateVulnScanCronJob      NotificationPolicyType = "updateVulnScanCronJob"
+	TypeValidateRules NotificationPolicyType = "validateRules"
+	// Execute a posture scan
+	TypeExecPostureScan NotificationPolicyType = "execPostureScan"
+	TypeUpdateRules     NotificationPolicyType = "updateRules"
+	TypeRunKubescapeJob NotificationPolicyType = "runKubescapeJob"
+	// Trigger a Kubescape scan
+	TypeRunKubescape NotificationPolicyType = "kubescapeScan"
+	// Create a CronJob that runs a Kubescape scan
+	TypeSetKubescapeCronJob NotificationPolicyType = "setKubescapeCronJob"
+	// Update a CronJob that runs a Kubescape scan
+	TypeUpdateKubescapeCronJob NotificationPolicyType = "updateKubescapeCronJob"
+	// Delete a CronJob that runs a Kubescape scan
+	TypeDeleteKubescapeCronJob NotificationPolicyType = "deleteKubescapeCronJob"
+	// Create a CronJob that runs a Vulnerability Scan
+	TypeSetVulnScanCronJob NotificationPolicyType = "setVulnScanCronJob"
+	// Update a CronJob that runs a Vulnerability Scan
+	TypeUpdateVulnScanCronJob NotificationPolicyType = "updateVulnScanCronJob"
+	// Delete a CronJob that runs a Vulnerability Scan
 	TypeDeleteVulnScanCronJob      NotificationPolicyType = "deleteVulnScanCronJob"
 	TypeUpdateWorkload             NotificationPolicyType = "update"
 	TypeAttachWorkload             NotificationPolicyType = "Attach"
@@ -36,9 +46,14 @@ const (
 	TypeRestartWorkload            NotificationPolicyType = "restart"
 	TypeEncryptSecret              NotificationPolicyType = "encryptSecret"
 	TypeDecryptSecret              NotificationPolicyType = "decryptSecret"
-	TypeScanImages                 NotificationPolicyType = "scan"
-	TypeScanRegistry               NotificationPolicyType = "scanRegistry"
-	TypeSetRegistryScanCronJob     NotificationPolicyType = "setRegistryScanCronJob"
-	TypeUpdateRegistryScanCronJob  NotificationPolicyType = "updateRegistryScanCronJob"
-	TypeDeleteRegistryScanCronJob  NotificationPolicyType = "deleteRegistryScanCronJob"
+	// Trigger an image scan
+	TypeScanImages NotificationPolicyType = "scan"
+	// Trigger a registry scan
+	TypeScanRegistry NotificationPolicyType = "scanRegistry"
+	// Create a CronJob that runs registry scans
+	TypeSetRegistryScanCronJob NotificationPolicyType = "setRegistryScanCronJob"
+	// Update a CronJob that runs registry scans
+	TypeUpdateRegistryScanCronJob NotificationPolicyType = "updateRegistryScanCronJob"
+	// Delete a CronJob that runs registry scans
+	TypeDeleteRegistryScanCronJob NotificationPolicyType = "deleteRegistryScanCronJob"
 )

--- a/apis/websocketdatastructures.go
+++ b/apis/websocketdatastructures.go
@@ -7,34 +7,57 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
-// Commands list of commands received from websocket
+// Commands contains a collection of commands for the in-cluster components
 type Commands struct {
+	// A list of commands to execute
+	//
+	// Example: [ { "CommandName": "scanRegistry", "args": { "registryInfo-v1": { "registryName": "quay.io/armosec" } } } ]
 	Commands []Command `json:"commands"`
 }
 
-// Command structure of command received from websocket
+// Command describes an individual command for the in-cluster components
 type Command struct {
-	// basic command
+	// Name of the command
+	//
+	// Example: updateRules
 	CommandName NotificationPolicyType `json:"commandName"`
-	ResponseID  string                 `json:"responseID,omitempty"`
+	// ID of the response
+	//
+	// Example: 49cfe0a0-9fab-4e54-a6e4-7b27e566d3cd
+	ResponseID string `json:"responseID,omitempty"`
 
-	// command designators
+	// Designators for the command
+	//
+	// Designators select the targets to which the command applies.
 	Designators []armotypes.PortalDesignator `json:"designators,omitempty"`
 	Wlid        string                       `json:"wlid,omitempty"`
 	WildWlid    string                       `json:"wildWlid,omitempty"`
 	Sid         string                       `json:"sid,omitempty"`
 	WildSid     string                       `json:"wildSid,omitempty"`
-	JobTracking JobTracking                  `json:"jobTracking,omitempty"`
+	// Job tracking context for
+	JobTracking JobTracking `json:"jobTracking,omitempty"`
 
-	// command extra data
+	// Arguments for the command
 	Args map[string]interface{} `json:"args,omitempty"`
 }
 
+// JobTracking describes a context in which the job is executing
+// It is used to track job execution source and context: what spawned it, when and under what circumstances.
 type JobTracking struct {
-	JobID            string    `json:"jobID,omitempty"`
-	ParentID         string    `json:"parentAction,omitempty"`
-	LastActionNumber int       `json:"numSeq,omitempty"`
-	Timestamp        time.Time `json:"timestamp,omitempty"`
+	// ID of the current job
+	//
+	// Example: 0f2c8611-ba99-40e5-af21-2bc3823e3283
+	JobID string `json:"jobID,omitempty"`
+	// ID of the parent job
+	//
+	// Example: 6ecfe560-104c-4e7b-8cd3-ee3cbc3b58fb
+	ParentID string `json:"parentAction,omitempty"`
+	// Number of the last action
+	//
+	// Example: 2
+	LastActionNumber int `json:"numSeq,omitempty"`
+	// Timestamp of the latest action
+	Timestamp time.Time `json:"timestamp,omitempty"`
 }
 
 // WebsocketScanCommand is a command that triggers a scan for vulnerabilities.

--- a/apis/websocketdatastructures.go
+++ b/apis/websocketdatastructures.go
@@ -37,21 +37,58 @@ type JobTracking struct {
 	Timestamp        time.Time `json:"timestamp,omitempty"`
 }
 
-// WebsocketScanCommand trigger scan thru the websocket
+// WebsocketScanCommand is a command that triggers a scan for vulnerabilities.
 type WebsocketScanCommand struct {
+	// Current session context
+	//
+	// Used for correlating requests in the logs.
+	Session SessionChain `json:"session,omitempty"`
+	// Tag of the image to scan
+	//
+	// Example: nginx:latest
+	ImageTag string `json:"imageTag"`
+	// ID of a workload that is running the image you want to scan
+	//
+	// Example: wlid://cluster-marina/namespace-default/deployment-nginx
+	Wlid string `json:"wlid"`
+	// Has the provided image been previously scanned or not?
+	//
+	// An image will only be scanned if it has not been scanned previously (value is `false`).
+	// If an image has been previously scanned (value is `true`), it will not be scanned again.
+	//
+	// Example: false
+	IsScanned bool `json:"isScanned"`
+	// Name of the container that contains an image to be scanned
+	//
+	// Example: nginx
+	ContainerName string `json:"containerName"`
+	// ID of the scanning Job
+	//
+	// Example: 7b04592b-665a-4e47-a9c9-65b2b3cabb49
+	JobID string `json:"jobID,omitempty"`
+	// ID of the Parent Job — a job that initiated the current job
+	//
+	// Example: 825f0a9e-34a9-4727-b81a-6e1bf3a63725
+	ParentJobID string `json:"parentJobID,omitempty"`
+	// The last action received from the Websocket
+	//
+	// Example: 2
+	LastAction int `json:"actionIDN"`
+	// Hash of the image to scan
+	//
+	// Example: bcae378eacedab83da66079d9366c8f5df542d7ed9ab23bf487e3e1a8481375d
+	ImageHash string `json:"imageHash"`
+	// Deprecated: Credentials to the Container Registry that holds the image to be scanned
+	//
+	// Kept for backward compatibility
+	Credentials *types.AuthConfig `json:"credentials,omitempty"`
+	// A list of credentials for private Container Registries that store images to be scanned
+	Credentialslist []types.AuthConfig `json:"credentialsList,omitempty"`
+	// Arguments to pass to the scan command
+	//
+	// Example: {"useHTTP": true, "skipTLSVerify": true, "registryName": "", "repository": "", "tag": ""}
+	Args map[string]interface{} `json:"args,omitempty"`
 	// CustomerGUID string `json:"customerGUID"`
-	Session         SessionChain           `json:"session,omitempty"`
-	ImageTag        string                 `json:"imageTag"`
-	Wlid            string                 `json:"wlid"`
-	IsScanned       bool                   `json:"isScanned"`
-	ContainerName   string                 `json:"containerName"`
-	JobID           string                 `json:"jobID,omitempty"`
-	ParentJobID     string                 `json:"parentJobID,omitempty"`
-	LastAction      int                    `json:"actionIDN"`
-	ImageHash       string                 `json:"imageHash"`
-	Credentials     *types.AuthConfig      `json:"credentials,omitempty"`
-	Credentialslist []types.AuthConfig     `json:"credentialsList,omitempty"`
-	Args            map[string]interface{} `json:"args,omitempty"`
 }
 
 type SafeMode struct {

--- a/armotypes/portaltypes.go
+++ b/armotypes/portaltypes.go
@@ -19,25 +19,30 @@ type PortalBase struct {
 	Attributes map[string]interface{} `json:"attributes,omitempty"` // could be string
 }
 
+// Type of the designator
+//
+// swagger:enum DesignatorType
 type DesignatorType string
 
 // Supported designators
 const (
 	DesignatorAttributes DesignatorType = "Attributes"
 	DesignatorAttribute  DesignatorType = "Attribute" // Deprecated
-	/*
-		WorkloadID format.
-		k8s format: wlid://cluster-<cluster>/namespace-<namespace>/<kind>-<name>
-		native format: wlid://datacenter-<datacenter>/project-<project>/native-<name>
-	*/
+	// WorkloadID format.
+	//
+	// Has two formats:
+	//  1. Kubernetes format: wlid://cluster-<cluster>/namespace-<namespace>/<kind>-<name>
+	//  2. Native format: wlid://datacenter-<datacenter>/project-<project>/native-<name>
 	DesignatorWlid DesignatorType = "Wlid"
-	/*
-		Wild card - subset of wlid. e.g.
-		1. Include cluster:
-			wlid://cluster-<cluster>/
-		2. Include cluster and namespace (filter out all other namespaces):
-			wlid://cluster-<cluster>/namespace-<namespace>/
-	*/
+	// A WorkloadID wildcard expression.
+	//
+	// A wildcard expression that includes a cluster:
+	//
+	//  wlid://cluster-<cluster>/
+	//
+	// An expression that includes a cluster and namespace (filters out all other namespaces):
+	//
+	//  wlid://cluster-<cluster>/namespace-<namespace>/
 	DesignatorWildWlid      DesignatorType = "WildWlid"
 	DesignatorWlidContainer DesignatorType = "WlidContainer"
 	DesignatorWlidProcess   DesignatorType = "WlidProcess"
@@ -104,13 +109,17 @@ const (
 	AttributeHostSensor           = "hostSensor"
 )
 
-// PortalDesignator represented single designation options
+// PortalDesignator represents a single designation option
 type PortalDesignator struct {
-	DesignatorType DesignatorType    `json:"designatorType"`
-	WLID           string            `json:"wlid,omitempty"`
-	WildWLID       string            `json:"wildwlid,omitempty"`
-	SID            string            `json:"sid,omitempty"`
-	Attributes     map[string]string `json:"attributes"`
+	DesignatorType DesignatorType `json:"designatorType"`
+	// A specific Workload ID
+	WLID string `json:"wlid,omitempty"`
+	// An expression that describes applicable workload IDs
+	WildWLID string `json:"wildwlid,omitempty"`
+	// A specific Secret ID
+	SID string `json:"sid,omitempty"`
+	// Attributes that describe the targets
+	Attributes map[string]string `json:"attributes"`
 }
 
 // Worker nodes attribute related consts


### PR DESCRIPTION
# What this PR changes

This PR adds annotations to structs used in the Websocket component. It helps generate the OpenAPI specs from Go source.

# Additional comments for the reviewer

This branch has been checked out from #17 and includes its commits, so it’s probably better to either merge #17 first or just this PR.