### PR TITLE
Add secret name

### DIFF
--- a/armotypes/registrytypes.go
+++ b/armotypes/registrytypes.go
@@ -20,6 +20,7 @@ type RegistryInfo struct {
 	IsHTTPs          bool       `json:"isHTTPs" bson:"isHTTPs"`
 	SkipTLSVerify    bool       `json:"skipTLSVerify" bson:"skipTLSVerify"`
 	AuthMethod       AuthMethod `json:"authMethod,omitempty" bson:"authMethod"`
+	SecretName       string     `json:"secret,omitempty" bson:"secret"`
 }
 
 type AuthMethod struct {

--- a/armotypes/registrytypes.go
+++ b/armotypes/registrytypes.go
@@ -20,7 +20,7 @@ type RegistryInfo struct {
 	IsHTTPs          *bool      `json:"isHTTPs,omitempty" bson:"isHTTPs"`
 	SkipTLSVerify    *bool      `json:"skipTLSVerify,omitempty" bson:"skipTLSVerify"`
 	AuthMethod       AuthMethod `json:"authMethod,omitempty" bson:"authMethod"`
-	SecretName       string     `json:"secret,omitempty" bson:"secret"`
+	SecretName       string     `json:"secretName,omitempty" bson:"secretName"`
 }
 
 type AuthMethod struct {


### PR DESCRIPTION
add SecretName to registry info. Needed for new flow of registry scanning with cronjob, where the credentials are store in unique secrets (per cronjob), and sent with the command.