### PR TITLE
field name change

### DIFF
--- a/armotypes/posturetypes.go
+++ b/armotypes/posturetypes.go
@@ -75,7 +75,7 @@ type PostureFrameworkOverTimeCoord struct {
 type PostureFrameworkSummary struct {
 	Name             string           `json:"name"`
 	Score            float32          `json:"value"`
-	ComplianceScore  float32          `json:"complianceScore"`
+	ComplianceScore  float32          `json:"complianceScorev1"`
 	ImprovementScore float32          `json:"improvementScore"`
 	TotalControls    int              `json:"totalControls"`
 	FailedControls   int              `json:"failedControls"`


### PR DESCRIPTION
This will fix mapping problem to elastic, `complianceScore` is already mapped as long (by default) and `complianceScorev1` will now be mapped as float as needed.