### PR TITLE
add counter for all resources scanned in control

### DIFF
--- a/armotypes/posturetypes.go
+++ b/armotypes/posturetypes.go
@@ -177,6 +177,7 @@ type PostureControlSummary struct {
 	FailedResourcesCount           int              `json:"failedResourcesCount"`
 	SkippedResourcesCount          int              `json:"skippedResourcesCount"`
 	WarningResourcesCount          int              `json:"warningResourcesCount"` // Deprecated
+	TotalScannedResourcesCount     *int             `json:"totalScannedResourcesCount"`
 	PreviousAffectedResourcesCount int              `json:"previousAffectedResourcesCount"`
 	PreviousFailedResourcesCount   int              `json:"previousFailedResourcesCount"`
 	PreviousSkippedResourcesCount  int              `json:"previousSkippedResourcesCount"`


### PR DESCRIPTION
Added as pointer so that for old scans we won't get 0 as default value, which is a valid value and can't be ignored