### PR TITLE
extract method to validate a containerScanID

### DIFF
--- a/armotypes/portaltypesutils.go
+++ b/armotypes/portaltypesutils.go
@@ -286,3 +286,10 @@ func (p *PortalBase) GetUpdatedTime() *time.Time {
 	}
 	return &updatedTime
 }
+
+func ValidateContainerScanID(containerScanID string) bool {
+	if strings.Contains(containerScanID, "/") {
+		return false
+	}
+	return true
+}

--- a/armotypes/portaltypesutils_test.go
+++ b/armotypes/portaltypesutils_test.go
@@ -170,3 +170,33 @@ func TestAttributesDesignatorsFromImageTag(t *testing.T) {
 	assert.Equal(t, "", deisgs.Attributes[AttributeTag])
 	assert.Equal(t, 1, len(deisgs.Attributes))
 }
+
+func TestValidateContainerScanID(t *testing.T) {
+	type args struct {
+		containerScanID string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "valid containerScanID",
+			args: args{
+				containerScanID: "9711c327-1a08-487e-b24a-72128712ef2d",
+			},
+			want: true,
+		},
+		{
+			name: "containerScanID with a slash is invalid",
+			args: args{
+				containerScanID: "foo/bar",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, ValidateContainerScanID(tt.args.containerScanID), "ValidateContainerScanID(%v)", tt.args.containerScanID)
+		})
+	}
+}


### PR DESCRIPTION
Taken from https://github.com/armosec/careportsreceiver/blob/continious_development/k8sclusterhandler/containerscanreports.go#L61
I will then have 2 followup methods in careportsreceiver and kubevuln