### PR TITLE
support related resources

### DIFF
--- a/armotypes/posturetypes.go
+++ b/armotypes/posturetypes.go
@@ -306,6 +306,7 @@ type PostureSummary struct {
 	DeleteStatus RecordStatus `json:"deletionStatus,omitempty"`
 }
 type PosturePaths struct {
+	ResourceID string `json:"resourceID,omitempty"` // resource on which the remediation needs to be applied
 	// must have FailedPath or FixPath, not both
 	FailedPath string  `json:"failedPath,omitempty"`
 	FixPath    FixPath `json:"fixPath,omitempty"`
@@ -323,6 +324,7 @@ type PostureReportResultRaw struct {
 	ControlID             string           `json:"controlID"`
 	ControlConfigurations []ControlInputs  `json:"controlConfigurations,omitempty"`
 	HighlightsPaths       []PosturePaths   `json:"highlightsPaths"`
+	RelatedResourcesIDs   []string         `json:"relatedResourcesID,omitempty"`
 }
 type RawResource struct {
 	Designators  PortalDesignator `json:"designators"`


### PR DESCRIPTION
This PR adds:
1. The resourceID that a posturePath needs to be applied to (failPath/fixPath/fixCommand)
2. A list of IDs of all resources related to a certain resource in the context of failing a certain control