### PR TITLE
attack chain structure updates

### DIFF
--- a/armotypes/attackchainstypes.go
+++ b/armotypes/attackchainstypes.go
@@ -14,20 +14,17 @@ const (
 	ProcessingStatusDone       ProcessingStatus = "done"
 )
 
-type AttackChainType struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-}
-
 type AttackChain struct {
-	Type             *AttackChainType             `json:"type"`
-	ClusterName      string                       `json:"clusterName"`
-	Resource         identifiers.PortalDesignator `json:"resource"`
-	AttackChainID    string                       `json:"attackChainID"` // name/cluster/resourceID
-	CustomerGUID     string                       `json:"customerGUID"`
-	AttackChainNodes AttackChainNode              `json:"attackChainNodes"`
-	UIStatus         *AttackChainUIStatus         `json:"uiStatus"`
-	LatestReportGUID string                       `json:"latestReportGUID"` // latest reportGUID in which this attack chain was identified
+	PortalBase       `json:",inline" bson:",inline"`
+	Resource         identifiers.PortalDesignator `json:"resource,omitempty" bson:"resource,omitempty"`
+	Description      string                       `json:"description,omitempty" bson:"description,omitempty"`
+	CreationTime     string                       `json:"creationTime,omitempty" bson:"creationTime,omitempty"`
+	AttackChainID    string                       `json:"attackChainID,omitempty" bson:"attackChainID,omitempty"` // name/cluster/resourceID
+	ClusterName      string                       `json:"clusterName,omitempty" bson:"clusterName,omitempty"`
+	CustomerGUID     string                       `json:"customerGUID,omitempty" bson:"customerGUID,omitempty"`
+	LatestReportGUID string                       `json:"latestReportGUID,omitempty" bson:"latestReportGUID,omitempty"` // latest reportGUID in which this attack chain was identified
+	UIStatus         *AttackChainUIStatus         `json:"uiStatus,omitempty" bson:"uiStatus,omitempty"`
+	AttackChainNodes AttackChainNode              `json:"attackChainNodes,omitempty" bson:"attackChainNodes,omitempty"`
 }
 
 type AttackChainNode struct {
@@ -48,8 +45,8 @@ type Vulnerabilities struct {
 // struct for UI support. All strings are timestamps
 type AttackChainUIStatus struct {
 	// fields updated by the BE
-	FirstSeen string `json:"firstSeen"` // timestamp of first scan in which the attack chain was identified
+	FirstSeen string `json:"firstSeen,omitempty" bson:"firstSeen,omitempty"` // timestamp of first scan in which the attack chain was identified
 	// fields updated by the UI
-	ViewedMainScreen string `json:"wasViewedMainScreen"` // if the attack chain was viewed by the user// New badge
-	ProcessingStatus string `json:"processingStatus"`    // "processing"/ "done"
+	ViewedMainScreen string `json:"wasViewedMainScreen,omitempty" bson:"wasViewedMainScreen,omitempty"` // if the attack chain was viewed by the user// New badge
+	ProcessingStatus string `json:"processingStatus,omitempty" bson:"processingStatus,omitempty"`       // "processing"/ "done"
 }


### PR DESCRIPTION
This PR adds bson to all fields in attack chains + adds `omitempty` to most fields.
This is to allow partial update of object in config-service.
In addition some mandatory fields were added in order to be aligned with config-service architecture