### PR TITLE
minor fix

### DIFF
--- a/armotypes/attackchainstypes.go
+++ b/armotypes/attackchainstypes.go
@@ -51,8 +51,8 @@ type AttackChainUIStatus struct {
 	// fields updated by the BE
 	FirstSeen string `json:"firstSeen,omitempty" bson:"firstSeen,omitempty"` // timestamp of first scan in which the attack chain was identified
 	// fields updated by the UI
-	ViewedMainScreen string `json:"wasViewedMainScreen,omitempty" bson:"wasViewedMainScreen,omitempty"` // if the attack chain was viewed by the user// New badge
-	ProcessingStatus string `json:"processingStatus,omitempty" bson:"processingStatus,omitempty"`       // "processing"/ "done"
+	ViewedMainScreen string `json:"viewedMainScreen,omitempty" bson:"viewedMainScreen,omitempty"` // if the attack chain was viewed by the user// New badge
+	ProcessingStatus string `json:"processingStatus,omitempty" bson:"processingStatus,omitempty"` // "processing"/ "done"
 }
 
 // --------- Ingesters structs and consts -------------

--- a/armotypes/attackchainstypes.go
+++ b/armotypes/attackchainstypes.go
@@ -71,7 +71,7 @@ const (
 	MsgPropAction            = "action"
 	MsgPropActionValueUpdate = "update"
 
-	viewedMainScreenField = "viewedMainScreen"
+	ViewedMainScreenField = "viewedMainScreen"
 	ProcessingStatusField = "processingStatus"
 )
 

--- a/armotypes/attackchainstypes.go
+++ b/armotypes/attackchainstypes.go
@@ -71,8 +71,8 @@ const (
 	MsgPropAction            = "action"
 	MsgPropActionValueUpdate = "update"
 
-	WasViewedMainScreenField = "wasViewedMainScreen"
-	ProcessingStatusField    = "processingStatus"
+	viewedMainScreenField = "viewedMainScreen"
+	ProcessingStatusField = "processingStatus"
 )
 
 // struct for ConsumerAttackChainsStatesUpdate ingester as payloads


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR includes a minor refactoring in the `armotypes/attackchainstypes.go` file. The constant `WasViewedMainScreenField` has been renamed to `viewedMainScreenField` to adhere to the Go naming conventions.

___
## PR Main Files Walkthrough:
`armotypes/attackchainstypes.go`: The constant `WasViewedMainScreenField` has been renamed to `viewedMainScreenField`.
