### PR TITLE
remove old postgres baseReport

### DIFF
--- a/postgresmodels/containerscan.go
+++ b/postgresmodels/containerscan.go
@@ -41,7 +41,6 @@ type VulnerabilityFinding struct {
 
 type VulnerabilityScanSummary struct {
 	BaseModel
-	BaseReport
 	ScanKind                   string
 	ImageScanId                string `gorm:"primaryKey"`
 	ContainerSpecId            string

--- a/postgresmodels/pagination.go
+++ b/postgresmodels/pagination.go
@@ -2,20 +2,6 @@ package postgresmodels
 
 import "github.com/lib/pq"
 
-type BaseReport struct {
-	// TotalChunksExpected and TotalChunksRecieved are used to track the progress of the report.
-
-	// Total number of chunks expected. Will be populated with the (ReportNumber of the LastReport + 1) (IsLastReport == true)
-	// If not known yet (i.e. IsLastReport not recieved yet), will be set to -1
-	TotalChunksExpected int
-
-	//specify the total number of chunks recieved so far - will be increment by one on each chunk recieved.
-	TotalChunksRecieved int
-
-	// set to True when TotalChunksExpected == TotalChunksRecieved
-	Completed bool
-}
-
 type ReportStatus struct {
 	BaseModel
 	ReportIdentifier      string `gorm:"primaryKey"` // reportGUID or imageScanID+timestamp


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR removes the old postgres BaseReport structure from the codebase. The BaseReport was previously used in the VulnerabilityScanSummary and other parts of the code. This change is likely part of a larger refactoring effort to streamline the codebase and remove unused or redundant structures.

___
## PR Main Files Walkthrough:
`postgresmodels/containerscan.go`: The BaseReport has been removed from the VulnerabilityScanSummary structure. Other fields in the structure remain unchanged.
`postgresmodels/pagination.go`: The entire BaseReport structure has been removed from the file. The ReportStatus structure remains in the file, with no changes.
