### PR TITLE
stable "multiple providers with single channel each" test

### DIFF
--- a/notifications/usernotificationreporttypes_test.go
+++ b/notifications/usernotificationreporttypes_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"k8s.io/utils/ptr"
 	"reflect"
+	"sort"
 	"testing"
 	"time"
 
@@ -622,9 +623,16 @@ func TestGetAllChannels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.config.GetAllChannels()
+			sortAlertChannelsByType(got)
 			if !reflect.DeepEqual(got, tt.expected) {
 				t.Errorf("GetAllChannels() = %v, want %v", got, tt.expected)
 			}
 		})
 	}
+}
+
+func sortAlertChannelsByType(channels []AlertChannel) {
+	sort.Slice(channels, func(i, j int) bool {
+		return channels[i].ChannelType < channels[j].ChannelType
+	})
 }


### PR DESCRIPTION
## PR Type:
Tests

___
## PR Description:
This PR aims to stabilize the "multiple providers with single channel each" test. It introduces a sorting function to ensure the order of alert channels, which helps in consistent comparison of results.

___
## PR Main Files Walkthrough:
`notifications/usernotificationreporttypes_test.go`: Added a new function 'sortAlertChannelsByType' to sort alert channels by their type. This function is used in the 'TestGetAllChannels' test to sort the 'got' result before comparing it with the expected result. This ensures that the test results are consistent regardless of the order of alert channels.

___
## User Description:
Signed-off-by: refaelm <refaelm@armosec.io>
