### PR TITLE
export func

### DIFF
--- a/armotypes/attackchainstypesutils.go
+++ b/armotypes/attackchainstypesutils.go
@@ -1,10 +1,10 @@
 package armotypes
 
-// getControlIDsFromAllNodes is a recursive func that returns a list of controlIDs from all nodes in the attack chain
-func (attackChainNode *AttackChainNode) getControlIDsFromAllNodes(controlIDs []string) []string {
+// GetControlIDsFromAllNodes is a recursive func that returns a list of controlIDs from all nodes in the attack chain
+func (attackChainNode *AttackChainNode) GetControlIDsFromAllNodes(controlIDs []string) []string {
 	controlIDs = append(controlIDs, attackChainNode.ControlIDs...)
 	for i := range attackChainNode.NextNodes {
-		controlIDs = attackChainNode.NextNodes[i].getControlIDsFromAllNodes(controlIDs)
+		controlIDs = attackChainNode.NextNodes[i].GetControlIDsFromAllNodes(controlIDs)
 	}
 	return controlIDs
 }

--- a/armotypes/attackchainstypesutils_test.go
+++ b/armotypes/attackchainstypesutils_test.go
@@ -98,7 +98,7 @@ func TestGetControlIDsFromAllNodes(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to unmarshal node: %v", err)
 			}
-			result := node.getControlIDsFromAllNodes([]string{})
+			result := node.GetControlIDsFromAllNodes([]string{})
 			if !reflect.DeepEqual(result, tc.expectedResult) {
 				t.Fatalf("expected: %v, got: %v", tc.expectedResult, result)
 			}


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR changes the visibility of the function `getControlIDsFromAllNodes` in the `attackchainstypesutils.go` file from private to public. The function is now named `GetControlIDsFromAllNodes`. The corresponding test file `attackchainstypesutils_test.go` is also updated to reflect this change.

___
## PR Main Files Walkthrough:
`armotypes/attackchainstypesutils.go`: The function `getControlIDsFromAllNodes` has been renamed to `GetControlIDsFromAllNodes`, changing its visibility from private to public.
`armotypes/attackchainstypesutils_test.go`: Updated the test function `TestGetControlIDsFromAllNodes` to call the now public function `GetControlIDsFromAllNodes` instead of the previously private `getControlIDsFromAllNodes`.
