### PR TITLE
Fix events time in posture events 

### DIFF
--- a/broadcastevents/events_test.go
+++ b/broadcastevents/events_test.go
@@ -1,6 +1,8 @@
 package broadcastevents
 
 import (
+	_ "embed"
+	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
@@ -16,6 +18,9 @@ func TestNewBaseEvent(t *testing.T) {
 	assert.Equal(t, "testEvent", event.EventName)
 }
 
+//go:embed fixtures/alertChannel.json
+var alertChannelJSON []byte
+
 func TestNewAlertChannelDeletedEvent(t *testing.T) {
 	event := NewAlertChannelDeletedEvent("testGUID", "testName", "testProvider")
 	assert.Equal(t, "testName", event.Name)
@@ -23,12 +28,37 @@ func TestNewAlertChannelDeletedEvent(t *testing.T) {
 }
 
 func TestNewAlertChannelCreatedEvent(t *testing.T) {
-	channel := notifications.AlertChannel{
-		ChannelType: notifications.CollaborationTypeTeams,
+	var channel notifications.AlertChannel
+	err := json.Unmarshal(alertChannelJSON, &channel)
+	if err != nil {
+		t.Error(err)
 	}
 	event := NewAlertChannelCreatedEvent("testGUID", "testName", channel)
+	assert.Equal(t, "AlertChannelCreated", event.EventName)
 	assert.Equal(t, "testName", event.Name)
 	assert.Equal(t, "teams", event.Type)
+	assert.Equal(t, "testGUID", event.CustomerGUID)
+	assert.Equal(t, "Low and above", event.NewVulnerability)
+	assert.Equal(t, "High and above", event.NewFix)
+	assert.Equal(t, "true", event.NewAdmin)
+}
+
+func TestNewAlertChannelUpdatedEvent(t *testing.T) {
+	var channel notifications.AlertChannel
+	err := json.Unmarshal(alertChannelJSON, &channel)
+	if err != nil {
+		t.Error(err)
+	}
+	event := NewAlertChannelUpdatedEvent("testGUID", "testName", channel)
+	assert.Equal(t, "testName", event.Name)
+	assert.Equal(t, "teams", event.Type)
+	assert.Equal(t, "testGUID", event.CustomerGUID)
+	assert.Equal(t, "AlertChannelUpdated", event.EventName)
+	assert.Equal(t, "Low and above", event.NewVulnerability)
+	assert.Equal(t, "High and above", event.NewFix)
+	assert.Equal(t, "true", event.NewAdmin)
+	assert.Equal(t, "25%", event.Compliance)
+
 }
 
 func TestNewPostureExceptionEvent(t *testing.T) {

--- a/broadcastevents/events_test.go
+++ b/broadcastevents/events_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNewBaseEvent(t *testing.T) {
-	event := NewBaseEvent("testGUID", "testEvent")
+	event := NewBaseEvent("testGUID", "testEvent", nil)
 	assert.Equal(t, "testGUID", event.CustomerGUID)
 	assert.Equal(t, "testEvent", event.EventName)
 }
@@ -88,10 +88,11 @@ func TestNewLoginEvent(t *testing.T) {
 }
 
 func TestNewClusterImageScanSessionStartedEvent(t *testing.T) {
-	eventTime := time.Now()
+	eventTime := time.Now().Add(-time.Hour * 24)
 	event := NewClusterImageScanSessionStartedEvent("testJobId", "testClusterName", "testCustomerId", eventTime)
 	assert.Equal(t, "testJobId", event.JobID)
 	assert.Equal(t, "testClusterName", event.ClusterName)
+	assert.Equal(t, eventTime, event.EventTime)
 }
 
 // ... Add more tests for other methods ...

--- a/broadcastevents/factory.go
+++ b/broadcastevents/factory.go
@@ -28,8 +28,11 @@ const (
 	AlertChannelPrefix = "AlertChannel"
 )
 
-func NewBaseEvent(customerGUID, eventName string) EventBase {
+func NewBaseEvent(customerGUID, eventName string, eventTime *time.Time) EventBase {
 	now := time.Now().UTC()
+	if eventTime != nil {
+		now = *eventTime
+	}
 	nowDate := now.Format("2006-01-02")
 	nowMonth := now.Format("2006-01")
 	_, nowWeekOfTheYear := now.ISOWeek()
@@ -45,7 +48,7 @@ func NewBaseEvent(customerGUID, eventName string) EventBase {
 
 func NewAlertChannelDeletedEvent(customerGUID, name, provider string) AlertChannelEvent {
 	return AlertChannelEvent{
-		EventBase: NewBaseEvent(customerGUID, AlertChannelPrefix+"Deleted"),
+		EventBase: NewBaseEvent(customerGUID, AlertChannelPrefix+"Deleted", nil),
 		Name:      name,
 		Type:      provider,
 	}
@@ -114,7 +117,7 @@ func NewFeatureFlagsEvent(customerGUID, userEmail, userName, userPreferredName s
 
 func NewLoginEvent(customerGUID, email, name, preferredName string) LoginEvent {
 	return LoginEvent{
-		EventBase:         NewBaseEvent(customerGUID, "UserLoggedIn"),
+		EventBase:         NewBaseEvent(customerGUID, "UserLoggedIn", nil),
 		Email:             email,
 		UserName:          name,
 		PreferredUserName: preferredName,
@@ -123,7 +126,7 @@ func NewLoginEvent(customerGUID, email, name, preferredName string) LoginEvent {
 
 func NewClusterImageScanSessionStartedEvent(jobId, clusterName, customerId string, timeStarted time.Time) AggregationEvent {
 	return AggregationEvent{
-		EventBase:   NewBaseEvent(customerId, "ClusterImageScanSessionStarted"),
+		EventBase:   NewBaseEvent(customerId, "ClusterImageScanSessionStarted", &timeStarted),
 		JobID:       jobId,
 		ClusterName: clusterName,
 	}
@@ -131,7 +134,7 @@ func NewClusterImageScanSessionStartedEvent(jobId, clusterName, customerId strin
 
 func NewRegistryImageScanSessionStartedEvent(jobId string, customerId string, timeStarted time.Time) AggregationEvent {
 	aggEvent := AggregationEvent{
-		EventBase: NewBaseEvent(customerId, "RegistryImageScanSessionStarted"),
+		EventBase: NewBaseEvent(customerId, "RegistryImageScanSessionStarted", &timeStarted),
 		JobID:     jobId,
 	}
 	return aggEvent
@@ -139,14 +142,14 @@ func NewRegistryImageScanSessionStartedEvent(jobId string, customerId string, ti
 
 func NewImageScanEventHookNotify(customerGUID, jobId string, scanTime time.Time) AggregationEvent {
 	return AggregationEvent{
-		EventBase: NewBaseEvent(customerGUID, "ContainerImageScanSubmitted"),
+		EventBase: NewBaseEvent(customerGUID, "ContainerImageScanSubmitted", &scanTime),
 		JobID:     jobId,
 	}
 }
 
 func NewGitRepositoryRiskScanEvent(customerGUID, jodID, reportGUID, clusterName string, eventTime time.Time) AggregationEvent {
 	return AggregationEvent{
-		EventBase:   NewBaseEvent(customerGUID, "RepoRiskScanSubmitted"),
+		EventBase:   NewBaseEvent(customerGUID, "RepoRiskScanSubmitted", &eventTime),
 		JobID:       jodID,
 		ReportGUID:  reportGUID,
 		ClusterName: clusterName,
@@ -155,7 +158,7 @@ func NewGitRepositoryRiskScanEvent(customerGUID, jodID, reportGUID, clusterName 
 
 func NewClusterRiskScanV2Event(customerGUID, jobID, reportGUID, clusterName, kubescapeVersion, cloudProvider, K8sVersion, helmVersion string, numOfWorkerNodes int, scanTime time.Time) AggregationEvent {
 	aggEvent := AggregationEvent{
-		EventBase:   NewBaseEvent(customerGUID, "RiskScanSubmitted"),
+		EventBase:   NewBaseEvent(customerGUID, "RiskScanSubmitted", &scanTime),
 		JobID:       jobID,
 		ReportGUID:  reportGUID,
 		ClusterName: clusterName,
@@ -170,7 +173,7 @@ func NewClusterRiskScanV2Event(customerGUID, jobID, reportGUID, clusterName, kub
 
 func NewHelmInstalledEvent(clusterName, customerGUID string, installationData *armotypes.InstallationData) HelmInstalledEvent {
 	aggEvent := HelmInstalledEvent{
-		EventBase:        NewBaseEvent(customerGUID, "HelmInstalled"),
+		EventBase:        NewBaseEvent(customerGUID, "HelmInstalled", nil),
 		ClusterName:      clusterName,
 		InstallationData: installationData,
 	}
@@ -181,7 +184,7 @@ func NewKubescapePodRunningConditionErrorEvent(clusterName, customerId, objId, c
 	// TODO: add objId, reason, meassage to the event
 	return PodInTroubleConditionEvent{
 		PodInTroubleEvent: PodInTroubleEvent{
-			EventBase:   NewBaseEvent(customerId, "KubescapePodRunningError"),
+			EventBase:   NewBaseEvent(customerId, "KubescapePodRunningError", nil),
 			ClusterName: clusterName,
 			ObjId:       objId,
 			Reason:      reason,
@@ -195,7 +198,7 @@ func NewKubescapePodRunningContainerErrorEvent(clusterName, customerId, objId, c
 	// TODO: add objId, reason, meassage to the event
 	return PodInTroubleContainerEvent{
 		PodInTroubleEvent: PodInTroubleEvent{
-			EventBase:   NewBaseEvent(customerId, "KubescapePodRunningError"),
+			EventBase:   NewBaseEvent(customerId, "KubescapePodRunningError", nil),
 			ClusterName: clusterName,
 			ObjId:       objId,
 			Reason:      reason,
@@ -210,7 +213,7 @@ func NewKubescapePodRunningContainerErrorEvent(clusterName, customerId, objId, c
 func NewKubescapePodPendingConditionErrorEvent(clusterName, customerId, objId, condition, reason, meassage string) PodInTroubleConditionEvent {
 	return PodInTroubleConditionEvent{
 		PodInTroubleEvent: PodInTroubleEvent{
-			EventBase:   NewBaseEvent(customerId, "KubescapePodPendingError"),
+			EventBase:   NewBaseEvent(customerId, "KubescapePodPendingError", nil),
 			ClusterName: clusterName,
 			ObjId:       objId,
 			Reason:      reason,
@@ -223,7 +226,7 @@ func NewKubescapePodPendingConditionErrorEvent(clusterName, customerId, objId, c
 func NewKubescapePodPendingContainerErrorEvent(clusterName, customerId, objId, conainerName, reason, meassage string, exitCode, restartCount int32) PodInTroubleContainerEvent {
 	return PodInTroubleContainerEvent{
 		PodInTroubleEvent: PodInTroubleEvent{
-			EventBase:   NewBaseEvent(customerId, "KubescapePodPendingError"),
+			EventBase:   NewBaseEvent(customerId, "KubescapePodPendingError", nil),
 			ClusterName: clusterName,
 			ObjId:       objId,
 			Reason:      reason,
@@ -270,7 +273,7 @@ func newIgnoreRuleEvent(customerGUID string, changeMethod string, ruleType Ignor
 
 func newAlertChannelDetailedEvent(customerGUID, name string, channel notifications.AlertChannel, eventOp string) AlertChannelEvent {
 	event := AlertChannelEvent{
-		EventBase:   NewBaseEvent(customerGUID, AlertChannelPrefix+eventOp),
+		EventBase:   NewBaseEvent(customerGUID, AlertChannelPrefix+eventOp, nil),
 		Name:        name,
 		Type:        string(channel.ChannelType),
 		AllClusters: ptr.To(len(channel.Scope) == 0),

--- a/broadcastevents/fixtures/alertChannel.json
+++ b/broadcastevents/fixtures/alertChannel.json
@@ -1,0 +1,38 @@
+{
+    "channelType": "teams",
+    "scope": [
+        {
+            "cluster": "cluster1",
+            "namespaces": [
+                "ns1",
+                "ns2",
+                "kubescape"
+            ]
+        }
+    ],
+    "collaborationConfigId": "teamsCollabGUID",
+    "notifications": [
+        {
+            "notificationType": "containerScanPush:newVulnerability",
+            "parameters": {
+                "minSeverity": 200
+            }
+        },
+        {
+            "notificationType": "containerScanPush:vulnerabilityNewFix",
+            "parameters": {
+                "minSeverity": 400
+            }
+        },
+        {
+            "notificationType": "push:complianceDrift",
+            "parameters": {
+                "driftPercentage": 25
+            }
+        },
+        {
+            "notificationType": "push:newClusterAdmin",
+            "parameters": {}
+        }
+    ]
+}


### PR DESCRIPTION
## PR Type:
Bug fix, Enhancement

___
## PR Description:
This PR introduces several changes mainly in `broadcastevents` package. It adds enhancements and fixes in event time handling and alert channel events. The changes include the ability to set a specific event time instead of always using the current time, and improvements in the creation of alert channel events. It also includes tests for these changes.

___
## PR Main Files Walkthrough:
`broadcastevents/events_test.go`: Added new tests for the updated functions in the `broadcastevents` package. The tests cover the creation of new base events and alert channel events. Also, a new JSON fixture for alert channel is used in the tests.
`broadcastevents/factory.go`: Made several changes in the functions that create new events. The `NewBaseEvent` function now accepts an optional `eventTime` parameter. If provided, this time is used as the event time; otherwise, the current time is used. The functions `NewAlertChannelCreatedEvent` and `NewAlertChannelUpdatedEvent` now use a helper function to avoid code duplication. The helper function `newAlertChannelDetailedEvent` creates a detailed alert channel event with the provided operation (created or updated).
`broadcastevents/fixtures/alertChannel.json`: Added a new JSON fixture for an alert channel. This fixture is used in the tests for creating new alert channel events.
