### PR TITLE
add attackChainsLastScan to customer state

### DIFF
--- a/armotypes/portaltypes.go
+++ b/armotypes/portaltypes.go
@@ -172,9 +172,10 @@ type NodeUsage struct {
 
 // CustomerState holds the state of the customer, used for UI purposes
 type CustomerState struct {
-	Onboarding     *CustomerOnboarding      `json:"onboarding,omitempty" bson:"onboarding,omitempty"`
-	GettingStarted *GettingStartedChecklist `json:"gettingStarted,omitempty" bson:"gettingStarted,omitempty"`
-	NodeUsage      *NodeUsage               `json:"nodeUsage,omitempty" bson:"nodeUsage,omitempty"`
+	Onboarding           *CustomerOnboarding      `json:"onboarding,omitempty" bson:"onboarding,omitempty"`
+	GettingStarted       *GettingStartedChecklist `json:"gettingStarted,omitempty" bson:"gettingStarted,omitempty"`
+	NodeUsage            *NodeUsage               `json:"nodeUsage,omitempty" bson:"nodeUsage,omitempty"`
+	AttackChainsLastScan string                   `json:"attackChainsLastScan,omitempty" bson:"attackChainsLastScan,omitempty"`
 }
 
 type User struct {


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces a new field 'attackChainsLastScan' to the 'CustomerState' struct in 'portaltypes.go'. This field will hold the timestamp of the last scan of attack chains, providing additional information about the customer's state.

___
## PR Main Files Walkthrough:
`armotypes/portaltypes.go`: Added a new field 'attackChainsLastScan' of type string to the 'CustomerState' struct. This field is optional and can be omitted in JSON and BSON formats.
