### PR TITLE
add generic request struct

### DIFF
--- a/armotypes/pagination_structs.go
+++ b/armotypes/pagination_structs.go
@@ -87,10 +87,12 @@ type RespTotal64 struct {
 	Relation string `json:"relation"`
 }
 
+type V2ListResponse V2ListResponseGeneric[interface{}]
+
 // V2ListResponse holds the response of some list request with some metadata
-type V2ListResponse struct {
-	Total    RespTotal   `json:"total"`
-	Response interface{} `json:"response"`
+type V2ListResponseGeneric[T any] struct {
+	Total    RespTotal `json:"total"`
+	Response T         `json:"response"`
 	// Cursor for quick access to the next page. Not supported yet
 	Cursor string `json:"cursor"`
 }


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR introduces a new generic request structure in the pagination structs file. The new structure, `V2ListResponseGeneric`, is designed to hold the response of a list request along with some metadata. This change improves the flexibility and reusability of the code by allowing the response to be of any type.

___
## PR Main Files Walkthrough:
`armotypes/pagination_structs.go`: Replaced the existing `V2ListResponse` structure with a new generic structure `V2ListResponseGeneric`. The new structure accepts any type 'T' for the 'Response' field. Also, a type alias `V2ListResponse` has been added for `V2ListResponseGeneric[interface{}]`.

___
## User Description:
Signed-off-by: refaelm <refaelm@armosec.io>
