### PR TITLE
add container to attack chain

### DIFF
--- a/armotypes/attackchainstypes.go
+++ b/armotypes/attackchainstypes.go
@@ -45,8 +45,9 @@ type AttackChainNode struct {
 }
 
 type Vulnerabilities struct {
-	ImageScanID string   `json:"imageScanID" bson:"imageScanID,omitempty"`
-	Names       []string `json:"names" bson:"names,omitempty"` // CVE names
+	ContainerName string   `json:"containerName" bson:"containerName,omitempty"`
+	ImageScanID   string   `json:"imageScanID" bson:"imageScanID,omitempty"`
+	Names         []string `json:"names" bson:"names,omitempty"` // CVE names
 }
 
 // struct for UI support. All strings are timestamps

--- a/identifiers/designators.go
+++ b/identifiers/designators.go
@@ -141,11 +141,11 @@ type AttributesDesignators struct {
 func CalcResourceHash(customerGUID string, identifiers map[string]string) string {
 	hash := (fmt.Sprintf("%s/%s/%s/%s/%s/%s",
 		customerGUID,
-		identifiers[AttributeKind],
-		identifiers[AttributeName],
-		identifiers[AttributeNamespace],
-		identifiers[AttributeApiVersion],
-		identifiers[AttributeCluster]))
+		strings.ToLower(identifiers[AttributeKind]),
+		strings.ToLower(identifiers[AttributeName]),
+		strings.ToLower(identifiers[AttributeNamespace]),
+		strings.ToLower(identifiers[AttributeApiVersion]),
+		strings.ToLower(identifiers[AttributeCluster])))
 
 	return hash
 }


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces two main changes. Firstly, it adds a 'ContainerName' field to the 'Vulnerabilities' struct in the 'attackchainstypes.go' file. This will allow for better tracking and identification of vulnerabilities. Secondly, it modifies the 'CalcResourceHash' function in the 'designators.go' file to convert all identifiers to lower case before calculating the resource hash. This ensures consistency in hash calculation regardless of the case of the input identifiers.

___
## PR Main Files Walkthrough:
`armotypes/attackchainstypes.go`: Added 'ContainerName' field to the 'Vulnerabilities' struct. This will store the name of the container associated with the vulnerability.
`identifiers/designators.go`: Modified 'CalcResourceHash' function to convert all identifiers to lower case before calculating the resource hash. This ensures consistency in hash calculation.
