### PR TITLE
add attackChainState to portal cluster

### DIFF
--- a/armotypes/portaltypes.go
+++ b/armotypes/portaltypes.go
@@ -57,6 +57,12 @@ type PortalCluster struct {
 	SubscriptionDate string            `json:"subscription_date,omitempty" bson:"subscription_date,omitempty"`
 	LastLoginDate    string            `json:"last_login_date,omitempty" bson:"last_login_date,omitempty"`
 	InstallationData *InstallationData `json:"installationData" bson:"installationData,omitempty"`
+	AttackChainState *AttackChainState `json:"attackChainState,omitempty" bson:"attackChainState,omitempty"`
+}
+
+type AttackChainState struct {
+	LastPostureScanTriggered string `json:"lastScanTriggered,omitempty" bson:"lastScanTriggered,omitempty"`
+	LastTimeEngineCompleted  string `json:"lastTimeEngineCompleted,omitempty" bson:"lastTimeEngineCompleted,omitempty"`
 }
 
 type RelevantImageVulnerabilitiesConfiguration string

--- a/armotypes/portaltypes.go
+++ b/armotypes/portaltypes.go
@@ -57,10 +57,13 @@ type PortalCluster struct {
 	SubscriptionDate string            `json:"subscription_date,omitempty" bson:"subscription_date,omitempty"`
 	LastLoginDate    string            `json:"last_login_date,omitempty" bson:"last_login_date,omitempty"`
 	InstallationData *InstallationData `json:"installationData" bson:"installationData,omitempty"`
-	AttackChainState *AttackChainState `json:"attackChainState,omitempty" bson:"attackChainState,omitempty"`
 }
 
-type AttackChainState struct {
+type ClusterAttackChainState struct {
+	PortalBase               `json:",inline" bson:"inline"`
+	CreationDate             string `json:"creationDate,omitempty" bson:"creationDate,omitempty"`
+	ClusterName              string `json:"clusterName,omitempty" bson:"clusterName,omitempty"`
+	CustomerGUID             string `json:"customerGUID,omitempty" bson:"customerGUID,omitempty"`
 	LastPostureScanTriggered string `json:"lastPostureScanTriggered,omitempty" bson:"lastPostureScanTriggered,omitempty"`
 	LastTimeEngineCompleted  string `json:"lastTimeEngineCompleted,omitempty" bson:"lastTimeEngineCompleted,omitempty"`
 }

--- a/armotypes/portaltypes.go
+++ b/armotypes/portaltypes.go
@@ -61,7 +61,7 @@ type PortalCluster struct {
 }
 
 type AttackChainState struct {
-	LastPostureScanTriggered string `json:"lastScanTriggered,omitempty" bson:"lastScanTriggered,omitempty"`
+	LastPostureScanTriggered string `json:"lastPostureScanTriggered,omitempty" bson:"lastPostureScanTriggered,omitempty"`
 	LastTimeEngineCompleted  string `json:"lastTimeEngineCompleted,omitempty" bson:"lastTimeEngineCompleted,omitempty"`
 }
 

--- a/armotypes/portaltypes.go
+++ b/armotypes/portaltypes.go
@@ -61,7 +61,7 @@ type PortalCluster struct {
 
 type ClusterAttackChainState struct {
 	PortalBase               `json:",inline" bson:"inline"`
-	CreationDate             string `json:"creationDate,omitempty" bson:"creationDate,omitempty"`
+	CreationTime             string `json:"creationTime,omitempty" bson:"creationTime,omitempty"`
 	ClusterName              string `json:"clusterName,omitempty" bson:"clusterName,omitempty"`
 	CustomerGUID             string `json:"customerGUID,omitempty" bson:"customerGUID,omitempty"`
 	LastPostureScanTriggered string `json:"lastPostureScanTriggered,omitempty" bson:"lastPostureScanTriggered,omitempty"`


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces a new struct, ClusterAttackChainState, to the PortalCluster. This struct includes fields such as CreationTime, ClusterName, CustomerGUID, LastPostureScanTriggered, and LastTimeEngineCompleted. These additions will enhance the functionality of the PortalCluster by providing more detailed information about the state of the attack chain.

___
## PR Main Files Walkthrough:
`armotypes/portaltypes.go`: Added a new struct, ClusterAttackChainState, with fields for CreationTime, ClusterName, CustomerGUID, LastPostureScanTriggered, and LastTimeEngineCompleted.
