### PR TITLE
Migrate from dash be

### DIFF
--- a/apis/websocketmethodutils.go
+++ b/apis/websocketmethodutils.go
@@ -23,8 +23,5 @@ func getSIDFromArgs(args map[string]interface{}) (string, error) {
 	if !ok || sid == "" {
 		return "", fmt.Errorf("sid found in args but empty")
 	}
-	// if _, err := secrethandling.SplitSecretID(sid); err != nil {
-	// 	return "", err
-	// }
 	return sid, nil
 }

--- a/armotypes/microservice_info.go
+++ b/armotypes/microservice_info.go
@@ -1,0 +1,130 @@
+package armotypes
+
+import (
+	"time"
+
+	core "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CAContainerMetrics holds data of single container which runs in multiple pods
+type CAContainerMetrics struct {
+	core.Container    `json:",inline"`
+	CAIntegrityStatus int `json:"caIntegrityStatus"`
+}
+
+// MicroserviceExtraDetails represent an overview of microservice, services, container data
+// and cloud data
+type MicroserviceExtraDetails struct {
+	CAMicroserviceOverviewMetadata `json:",inline"`
+	NumOfContainers                int                `json:"NumOfContainers"`
+	Labels                         map[string]string  `json:"labels,omitempty"`
+	Annotations                    map[string]string  `json:"annotations,omitempty"`
+	ContainersSummary              []ContainerSummary `json:"containers"`
+	ExternalFacing                 bool               `json:"isExternalFacingMS"`
+}
+
+// ContainerSummary - a must have summarized info of containers
+type ContainerSummary struct {
+	Name         string  `json:"name"`
+	Image        string  `json:"image"`
+	IsPrivileged bool    `json:"root"`
+	Probes       []Probe `json:"probes,omitempty"`
+	Limitations  `json:"limitations,omitempty"`
+}
+
+// Probe - represent the various container probes
+type Probe struct {
+	Type string `json:"type"` // e,g liveness/readiness/<w.e>
+	Data string `json:"data"` // actual probe data/settings
+}
+
+// Limitations - container defined limitations
+type Limitations struct {
+	CPU    int64 `json:"cpu,omitempty"`
+	Memory int64 `json:"memory,omitempty"`
+	Disk   int64 `json:"disk,omitempty"`
+}
+
+// CAMicroserviceOverview represnets it's name
+type CAMicroserviceOverview struct {
+	CAMicroserviceOverviewMetadata `json:",inline"`
+}
+
+// CAMicroserviceOverviewMetadata represnets it's name
+type CAMicroserviceOverviewMetadata struct {
+	CAK8SMeta     `json:",inline"`
+	WLID          string   `json:"wlid"`
+	Datacenter    string   `json:"datacenter,omitempty"`
+	OVNamespace   string   `json:"namespace,omitempty"`
+	Project       string   `json:"project,omitempty"`
+	Orchestrator  string   `json:"orchestrator"`
+	Kind          string   `json:"kind"`
+	OperationType string   `json:"operationType"`
+	OVName        string   `json:"name"`
+	Categories    []string `json:"categories"`
+	DisplayName   string   `json:"displayName,omitempty"`
+	CloudProvider string   `json:"cloudProvider"`
+}
+
+// CAK8SMeta holds common metadata about k8s objects
+type CAK8SMeta struct {
+	CustomerGUID   string    `json:"customerGUID"`
+	CAClusterName  string    `json:"caClusterName,omitempty"`
+	LastUpdateTime time.Time `json:"caLastUpdate"`
+	IsActive       bool      `json:"isActive"`
+}
+
+// MicroserviceMetadataView represent the model to return in metadata request
+type MicroserviceMetadataView struct {
+	CAMicroserviceOverviewMetadata
+	metav1.ObjectMeta `json:"metadata"`
+	Ancestor          K8SAncestor       `json:"uptreeOwner,omitempty"`
+	UsageType         string            `json:"usageType,omitempty"`
+	Categories        map[string]bool   `json:"categories"`
+	CALabels          map[string]string `json:"caLabels"`
+}
+
+// MicroserviceInfo single microservice with CA metrics
+type MicroserviceInfo struct {
+	MicroserviceMetadataView `json:",inline"`
+	PodSpecID                int64 `json:"podSpecId"` // will be sent from the cluster-agent to reconize this spec
+	core.PodSpec             `json:"spec"`
+	core.PodStatus           `json:"status" yaml:"status"`
+	Containers               []CAContainerMetrics `json:"containers,omitempty"`
+	K8SPodObjects            []K8SPodObject       `json:"k8sPodObjects,omitempty"`
+	CAStartTime              time.Time            `json:"caStartTime"`
+}
+
+// K8SAncestor represents the kind of the microservice inside the k8s cluster
+type K8SAncestor struct {
+	Name           string      `json:"name"`
+	Kind           string      `json:"kind"`
+	FullDeclaraion interface{} `json:"ownerData,omitempty"`
+}
+
+// K8SPodObject represents actuall pod which run on particular node of the cluster
+type K8SPodObject struct {
+	CAK8SMeta         `json:",inline"`
+	Name              string      `json:"podName"`
+	CreatedAt         time.Time   `json:"startedAt,omitempty"`
+	TerminatedAt      *time.Time  `json:"terminatedAt,omitempty"`
+	PodIP             string      `json:"podIP"`
+	NodeName          string      `json:"nodeName"`
+	Namespace         string      `json:"namespace"`
+	NominatedNodeName string      `json:"nominatedNodeName"`
+	Ancestor          K8SAncestor `json:"uptreeOwner,omitempty"`
+	PodSpecID         int64       `json:"podSpecId"`
+	PodStatus         string      `json:"podStatus"`
+	// ContainerStatuses  map[string]string `json:"containerStatuses"`
+}
+
+// ContainersStatusData holds the status of containers in runtime. This including the docker image tag + image hash
+type ContainersStatusData map[string]map[string]string
+
+// K8SNamespace represents single k8s namespace in cluster
+type K8SNamespace struct {
+	CAK8SMeta      `json:",inline"`
+	Name           string `json:"name"`
+	core.Namespace `json:",inline"`
+}

--- a/armotypes/microservice_info_method.go
+++ b/armotypes/microservice_info_method.go
@@ -1,0 +1,36 @@
+package armotypes
+
+import (
+	"fmt"
+	"strings"
+)
+
+// GetContainerImageDetails extract the docker image details of specific container in list
+func (contsImages *ContainersStatusData) GetContainerImageDetails(contName string) (string, string, error) {
+	imageID := ""
+	imageHash := ""
+	if contImagesData, ok := (*contsImages)[contName]; ok {
+		if contImageTag, ok := contImagesData["image"]; ok {
+			imageID = contImageTag
+		} else {
+			return "", "", fmt.Errorf("failed to find imageID of container '%s' in contsImages. Full data: %v", contName, contsImages)
+		}
+		if contImageHash, ok := contImagesData["imageID"]; ok {
+			lIdx := strings.LastIndex(contImageHash, ":")
+			if lIdx < 0 {
+				return "", "", fmt.Errorf("failed to find ':' in imageHash of container '%s' in contsImages. Full data: %v", contName, contsImages)
+			}
+			imageHash = contImageHash[lIdx+1:]
+		} else {
+			return "", "", fmt.Errorf("failed to find imageHash of container '%s' in contsImages. Full data: %v", contName, contsImages)
+		}
+	} else {
+		return "", "", fmt.Errorf("failed to find images of container '%s' in contsImages. Full data: %v", contName, contsImages)
+	}
+	return imageID, imageHash, nil
+}
+
+// GetShortName returns the last 2 parts of the microservice
+func (msi *MicroserviceInfo) GetShortName() string {
+	return fmt.Sprintf("%s/%s", msi.Ancestor.Kind, msi.Ancestor.Name)
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/stripe/stripe-go/v74 v74.28.0
 	golang.org/x/exp v0.0.0-20230728194245-b0cb94b80691
 	golang.org/x/oauth2 v0.10.0
+	k8s.io/api v0.27.4
+	k8s.io/apimachinery v0.27.4
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 )
 
@@ -43,7 +45,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.5.0 // indirect
-	k8s.io/apimachinery v0.27.4 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -81,9 +81,11 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -112,6 +114,7 @@ github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
+github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=
@@ -254,8 +257,8 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=
@@ -274,6 +277,8 @@ grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJd
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+k8s.io/api v0.27.4 h1:0pCo/AN9hONazBKlNUdhQymmnfLRbSZjd5H5H3f0bSs=
+k8s.io/api v0.27.4/go.mod h1:O3smaaX15NfxjzILfiln1D8Z3+gEYpjEpiNA/1EVK1Y=
 k8s.io/apimachinery v0.27.4 h1:CdxflD4AF61yewuid0fLl6bM4a3q04jWel0IlP+aYjs=
 k8s.io/apimachinery v0.27.4/go.mod h1:XNfZ6xklnMCOGGFNqXG7bUrQCoR04dh/E7FprV6pb+E=
 k8s.io/klog/v2 v2.100.1 h1:7WCHKK6K8fNhTqfBhISHQ97KrnJNFZMcQvKp7gP/tmg=


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR focuses on migrating microservice types from the dash backend to the current repository. It introduces new types and methods related to microservices in the `armotypes` package. Additionally, it updates the `go.mod` and `go.sum` files to include new dependencies required for these changes.

___
## PR Main Files Walkthrough:
`apis/websocketmethodutils.go`: Removed commented out code related to secret handling.
`armotypes/microservice_info.go`: Added a large number of new types related to microservices, including `CAContainerMetrics`, `MicroserviceExtraDetails`, `ContainerSummary`, `Probe`, `Limitations`, `CAMicroserviceOverview`, `CAMicroserviceOverviewMetadata`, `CAK8SMeta`, `MicroserviceMetadataView`, `MicroserviceInfo`, `K8SAncestor`, `K8SPodObject`, `ContainersStatusData`, and `K8SNamespace`.
`armotypes/microservice_info_method.go`: Introduced new methods `GetContainerImageDetails` and `GetShortName` for the `ContainersStatusData` and `MicroserviceInfo` types respectively.
`go.mod`: Added new dependencies `k8s.io/api` and `k8s.io/apimachinery`.
`go.sum`: Updated the checksums for the new dependencies.
