### PR TITLE
comparing ac node description and name

### DIFF
--- a/armotypes/attackchainstypes.go
+++ b/armotypes/attackchainstypes.go
@@ -80,6 +80,10 @@ func (a *AttackChainNode) Equals(b *AttackChainNode) bool {
 		return b.Vulnerabilities[i].ContainerName < b.Vulnerabilities[j].ContainerName
 	})
 
+	if a.Description != b.Description || a.Name != b.Name {
+		return false
+	}
+
 	// Recursively sort and compare NextNodes
 	for i := range a.NextNodes {
 		if !a.NextNodes[i].Equals(&b.NextNodes[i]) {


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR enhances the equality check for AttackChainNode in Go by adding a comparison for the 'Description' and 'Name' fields. Previously, these fields were not considered in the equality check.

___
## PR Main Files Walkthrough:
`armotypes/attackchainstypes.go`: Added a condition in the Equals method of the AttackChainNode struct to compare the 'Description' and 'Name' fields of the two nodes. If they are not equal, the method will return false, indicating that the nodes are not identical.
