### PR TITLE
add ProcessingStatusTimeout

### DIFF
--- a/armotypes/attackchainstypes.go
+++ b/armotypes/attackchainstypes.go
@@ -21,6 +21,7 @@ const (
 	ProcessingStatusProcessing ProcessingStatus = "processing"
 	ProcessingStatusDone       ProcessingStatus = "done"
 	ProcessingStatusFailed     ProcessingStatus = "failed"
+	ProcessingStatusTimeout    ProcessingStatus = "timeout"
 )
 
 type AttackChain struct {


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces a new status, 'timeout', to the ProcessingStatus enumeration in the attackchainstypes.go file. This will allow better handling and representation of timeout scenarios in the processing status of attack chains.

___
## PR Main Files Walkthrough:
`armotypes/attackchainstypes.go`: A new constant 'ProcessingStatusTimeout' of type 'ProcessingStatus' has been added to the existing enumeration.
