### PR TITLE
rm apiversion from resource hash

### DIFF
--- a/identifiers/designators.go
+++ b/identifiers/designators.go
@@ -139,12 +139,11 @@ type AttributesDesignators struct {
 }
 
 func CalcResourceHash(customerGUID string, identifiers map[string]string) string {
-	hash := (fmt.Sprintf("%s/%s/%s/%s/%s/%s",
+	hash := (fmt.Sprintf("%s/%s/%s/%s/%s",
 		customerGUID,
 		strings.ToLower(identifiers[AttributeKind]),
 		strings.ToLower(identifiers[AttributeName]),
 		strings.ToLower(identifiers[AttributeNamespace]),
-		strings.ToLower(identifiers[AttributeApiVersion]),
 		strings.ToLower(identifiers[AttributeCluster])))
 
 	return hash


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR removes the API version from the resource hash calculation function in the identifiers/designators.go file. The change simplifies the hash calculation by only considering the customer GUID, kind, name, namespace, and cluster.

___
## PR Main Files Walkthrough:
`identifiers/designators.go`: Removed the API version from the resource hash calculation function.
