### PR TITLE
add S3ObjectPath

### DIFF
--- a/identifiers/raw_resource_loc.go
+++ b/identifiers/raw_resource_loc.go
@@ -1,0 +1,13 @@
+package identifiers
+
+// S3 object path; support in bytes range
+type S3ObjectPath struct {
+	Bucket string         `json:"bucket"`
+	Key    string         `json:"key"`
+	Range  *S3ObjectRange `json:"range,omitempty"`
+}
+
+type S3ObjectRange struct {
+	Start int64 `json:"start"`
+	End   int64 `json:"end"`
+}


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces a new struct, `S3ObjectPath`, to the `identifiers` package. The `S3ObjectPath` struct is designed to represent an S3 object path and includes support for byte ranges. It contains three fields: `Bucket` and `Key` for the S3 object location, and an optional `Range` field for specifying a byte range.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`identifiers/raw_resource_loc.go`: Added a new file 'raw_resource_loc.go' in the 'identifiers' package. This file contains two new structs: `S3ObjectPath` and `S3ObjectRange`. `S3ObjectPath` represents an S3 object path with fields for the bucket, key, and an optional range. `S3ObjectRange` represents a byte range with fields for the start and end of the range.
</details>
