### PR TITLE
add ProcessingStatus to ClusterAttackChainState

### DIFF
--- a/armotypes/portaltypes.go
+++ b/armotypes/portaltypes.go
@@ -61,10 +61,11 @@ type PortalCluster struct {
 
 type ClusterAttackChainState struct {
 	PortalBase               `json:",inline" bson:"inline"`
-	CreationTime             string `json:"creationTime,omitempty" bson:"creationTime,omitempty"`
-	ClusterName              string `json:"clusterName,omitempty" bson:"clusterName,omitempty"`
-	LastPostureScanTriggered string `json:"lastPostureScanTriggered,omitempty" bson:"lastPostureScanTriggered,omitempty"`
-	LastTimeEngineCompleted  string `json:"lastTimeEngineCompleted,omitempty" bson:"lastTimeEngineCompleted,omitempty"`
+	CreationTime             string           `json:"creationTime,omitempty" bson:"creationTime,omitempty"`
+	ClusterName              string           `json:"clusterName,omitempty" bson:"clusterName,omitempty"`
+	LastPostureScanTriggered string           `json:"lastPostureScanTriggered,omitempty" bson:"lastPostureScanTriggered,omitempty"`
+	LastTimeEngineCompleted  string           `json:"lastTimeEngineCompleted,omitempty" bson:"lastTimeEngineCompleted,omitempty"`
+	ProcessingStatus         ProcessingStatus `json:"processingStatus,omitempty" bson:"processingStatus,omitempty"`
 }
 
 type RelevantImageVulnerabilitiesConfiguration string


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces a new field, ProcessingStatus, to the ClusterAttackChainState struct in the armotypes/portaltypes.go file. This field will provide additional information about the processing status of the cluster attack chain state.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`armotypes/portaltypes.go`: Added a new field, ProcessingStatus, to the ClusterAttackChainState struct. This field is optional and can be omitted in JSON and BSON formats.
</details>
