### PR TITLE
adding AC structs

### DIFF
--- a/broadcastevents/events.go
+++ b/broadcastevents/events.go
@@ -19,7 +19,6 @@ type EventBase struct {
 type AttackChainCreated struct {
 	EventBase        `json:",inline"`
 	ClusterName      string `json:"clusterName"`
-	HelmChartVersion string `json:"helmChartVersion,omitempty"`
 	KSVersion        string `json:"kubescapeVersion,omitempty"`
 	ACName           string `json:"ACName"`
 	ACId             string `json:"ACId"`
@@ -30,7 +29,6 @@ type AttackChainCreated struct {
 type AttackChainResolved struct {
 	EventBase        `json:",inline"`
 	ClusterName      string `json:"clusterName"`
-	HelmChartVersion string `json:"helmChartVersion,omitempty"`
 	KSVersion        string `json:"kubescapeVersion,omitempty"`
 	ACName           string `json:"ACName"`
 	ACId             string `json:"ACId"`

--- a/broadcastevents/events.go
+++ b/broadcastevents/events.go
@@ -16,6 +16,28 @@ type EventBase struct {
 	EventWeekOfTheYear int    `json:"eventWeekOfTheYear,omitempty"`
 }
 
+type AttackChainCreated struct {
+	EventBase        `json:",inline"`
+	ClusterName      string `json:"clusterName"`
+	HelmChartVersion string `json:"helmChartVersion,omitempty"`
+	KSVersion        string `json:"kubescapeVersion,omitempty"`
+	ACName           string `json:"ACName"`
+	ACId             string `json:"ACId"`
+	ACType           string `json:"ACType"`
+	ACFirstSeeing    string `json:"ACFirstSeeing"`
+}
+
+type AttackChainResolved struct {
+	EventBase        `json:",inline"`
+	ClusterName      string `json:"clusterName"`
+	HelmChartVersion string `json:"helmChartVersion,omitempty"`
+	KSVersion        string `json:"kubescapeVersion,omitempty"`
+	ACName           string `json:"ACName"`
+	ACId             string `json:"ACId"`
+	ACType           string `json:"ACType"`
+	ACFirstSeeing    string `json:"ACFirstSeeing"`
+}
+
 type AggregationEvent struct {
 	EventBase        `json:",inline"`
 	JobID            string `json:"jobID"`


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces two new structs to the broadcast events in the Go codebase: `AttackChainCreated` and `AttackChainResolved`. These structs are designed to handle events related to the creation and resolution of attack chains, respectively. Each struct includes fields for the event base, cluster name, Helm chart version, Kubescape version, attack chain name, ID, type, and first sighting.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`broadcastevents/events.go`: Added two new structs `AttackChainCreated` and `AttackChainResolved` to handle events related to attack chains. Each struct includes fields for the event base, cluster name, Helm chart version, Kubescape version, attack chain name, ID, type, and first sighting.
</details>
