### PR TITLE
remove ksersion

### DIFF
--- a/broadcastevents/events.go
+++ b/broadcastevents/events.go
@@ -19,7 +19,6 @@ type EventBase struct {
 type AttackChainCreated struct {
 	EventBase        `json:",inline"`
 	ClusterName      string `json:"clusterName"`
-	KSVersion        string `json:"kubescapeVersion,omitempty"`
 	ACName           string `json:"ACName"`
 	ACId             string `json:"ACId"`
 	ACType           string `json:"ACType"`
@@ -29,7 +28,6 @@ type AttackChainCreated struct {
 type AttackChainResolved struct {
 	EventBase        `json:",inline"`
 	ClusterName      string `json:"clusterName"`
-	KSVersion        string `json:"kubescapeVersion,omitempty"`
 	ACName           string `json:"ACName"`
 	ACId             string `json:"ACId"`
 	ACType           string `json:"ACType"`


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR removes the 'KSVersion' field from the 'AttackChainCreated' and 'AttackChainResolved' structs in the 'broadcastevents/events.go' file. The 'KSVersion' field was previously used to store the version of 'kubescape', but it seems it's no longer needed.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`broadcastevents/events.go`: The 'KSVersion' field has been removed from the 'AttackChainCreated' and 'AttackChainResolved' structs.
</details>
