### PR TITLE
remove ACName

### DIFF
--- a/broadcastevents/events.go
+++ b/broadcastevents/events.go
@@ -19,7 +19,6 @@ type EventBase struct {
 type AttackChainCreated struct {
 	EventBase        `json:",inline"`
 	ClusterName      string `json:"clusterName"`
-	ACName           string `json:"ACName"`
 	ACId             string `json:"ACId"`
 	ACType           string `json:"ACType"`
 	ACFirstSeeing    string `json:"ACFirstSeeing"`
@@ -28,7 +27,6 @@ type AttackChainCreated struct {
 type AttackChainResolved struct {
 	EventBase        `json:",inline"`
 	ClusterName      string `json:"clusterName"`
-	ACName           string `json:"ACName"`
 	ACId             string `json:"ACId"`
 	ACType           string `json:"ACType"`
 	ACFirstSeeing    string `json:"ACFirstSeeing"`


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR removes the 'ACName' field from the 'AttackChainCreated' and 'AttackChainResolved' structs in the 'broadcastevents/events.go' file. This change simplifies the structure and removes potentially redundant information.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`broadcastevents/events.go`: Removed the 'ACName' field from the 'AttackChainCreated' and 'AttackChainResolved' structs.
</details>
