### PR TITLE
SUB-2869 | add ScanWithoutAccessKeyEvent

### DIFF
--- a/broadcastevents/events.go
+++ b/broadcastevents/events.go
@@ -17,19 +17,19 @@ type EventBase struct {
 }
 
 type AttackChainCreated struct {
-	EventBase        `json:",inline"`
-	ClusterName      string `json:"clusterName"`
-	ACId             string `json:"ACId"`
-	ACType           string `json:"ACType"`
-	ACFirstSeeing    string `json:"ACFirstSeeing"`
+	EventBase     `json:",inline"`
+	ClusterName   string `json:"clusterName"`
+	ACId          string `json:"ACId"`
+	ACType        string `json:"ACType"`
+	ACFirstSeeing string `json:"ACFirstSeeing"`
 }
 
 type AttackChainResolved struct {
-	EventBase        `json:",inline"`
-	ClusterName      string `json:"clusterName"`
-	ACId             string `json:"ACId"`
-	ACType           string `json:"ACType"`
-	ACFirstSeeing    string `json:"ACFirstSeeing"`
+	EventBase     `json:",inline"`
+	ClusterName   string `json:"clusterName"`
+	ACId          string `json:"ACId"`
+	ACType        string `json:"ACType"`
+	ACFirstSeeing string `json:"ACFirstSeeing"`
 }
 
 type AggregationEvent struct {
@@ -94,4 +94,9 @@ type AlertChannelEvent struct {
 	NewFix           string `json:"new fix is available for vulnerability,omitempty"`
 	Compliance       string `json:"compliance score has decreased,omitempty"`
 	NewAdmin         string `json:"new cluster admin was added,omitempty"`
+}
+
+type ScanWithoutAccessKeyEvent struct {
+	EventBase   `json:",inline"`
+	ClusterName string `json:"clusterName"`
 }

--- a/broadcastevents/events_test.go
+++ b/broadcastevents/events_test.go
@@ -117,3 +117,10 @@ func TestNewIgnoreRuleEvent(t *testing.T) {
 	assert.Equal(t, "id1,id2", event.IgnoredIds)
 	assert.Equal(t, 2, event.Resources)
 }
+
+func TestNewScanWithoutAccessKeyEvent(t *testing.T) {
+	event := NewScanWithoutAccessKeyEvent("testGUID", "cluster123")
+	assert.Equal(t, "testGUID", event.CustomerGUID)
+	assert.Equal(t, "cluster123", event.ClusterName)
+	assert.Equal(t, "ScanWithoutAccessKey", event.EventName)
+}

--- a/broadcastevents/factory.go
+++ b/broadcastevents/factory.go
@@ -310,3 +310,10 @@ func newAlertChannelDetailedEvent(customerGUID, name string, channel notificatio
 	}
 	return event
 }
+
+func NewScanWithoutAccessKeyEvent(customerGUID, clusterName string) ScanWithoutAccessKeyEvent {
+	return ScanWithoutAccessKeyEvent{
+		EventBase:   NewBaseEvent(customerGUID, "ScanWithoutAccessKey", nil),
+		ClusterName: clusterName,
+	}
+}


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces a new event type `ScanWithoutAccessKeyEvent` to the broadcast events. The changes include:
- Addition of `ScanWithoutAccessKeyEvent` struct in `broadcastevents/events.go`.
- Addition of a new test case for `ScanWithoutAccessKeyEvent` in `broadcastevents/events_test.go`.
- Addition of a new function `NewScanWithoutAccessKeyEvent` in `broadcastevents/factory.go` to create a new `ScanWithoutAccessKeyEvent`.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`broadcastevents/events.go`: Added a new struct `ScanWithoutAccessKeyEvent` with `EventBase` and `ClusterName` as fields.
`broadcastevents/events_test.go`: Added a new test case `TestNewScanWithoutAccessKeyEvent` to test the creation of a new `ScanWithoutAccessKeyEvent`.
`broadcastevents/factory.go`: Added a new function `NewScanWithoutAccessKeyEvent` to create a new `ScanWithoutAccessKeyEvent` with given `customerGUID` and `clusterName`.
</details>

___
## User Description:
Signed-off-by: refaelm <refaelm@armosec.io>
