### PR TITLE
SUB 2871

### DIFF
--- a/armotypes/postureexceptionpolicytypes.go
+++ b/armotypes/postureexceptionpolicytypes.go
@@ -33,6 +33,7 @@ type PosturePolicy struct {
 	ControlName   string `json:"controlName,omitempty" bson:"controlName,omitempty"`
 	ControlID     string `json:"controlID,omitempty" bson:"controlID,omitempty"`
 	RuleName      string `json:"ruleName,omitempty" bson:"ruleName,omitempty"`
+	Severity      string `json:"severity,omitempty" bson:"severity,omitempty"`
 }
 
 func (exceptionPolicy *PostureExceptionPolicy) IsAlertOnly() bool {

--- a/armotypes/postureexceptionpolicytypes.go
+++ b/armotypes/postureexceptionpolicytypes.go
@@ -29,11 +29,11 @@ type PostureExceptionPolicy struct {
 }
 
 type PosturePolicy struct {
-	FrameworkName string `json:"frameworkName" bson:"frameworkName"`
-	ControlName   string `json:"controlName,omitempty" bson:"controlName,omitempty"`
-	ControlID     string `json:"controlID,omitempty" bson:"controlID,omitempty"`
-	RuleName      string `json:"ruleName,omitempty" bson:"ruleName,omitempty"`
-	Severity      string `json:"severity,omitempty" bson:"severity,omitempty"`
+	FrameworkName string  `json:"frameworkName" bson:"frameworkName"`
+	ControlName   string  `json:"controlName,omitempty" bson:"controlName,omitempty"`
+	ControlID     string  `json:"controlID,omitempty" bson:"controlID,omitempty"`
+	RuleName      string  `json:"ruleName,omitempty" bson:"ruleName,omitempty"`
+	BaseScore     float32 `json:"baseScore,omitempty" bson:"baseScore,omitempty"`
 }
 
 func (exceptionPolicy *PostureExceptionPolicy) IsAlertOnly() bool {

--- a/armotypes/postureexceptionpolicytypes.go
+++ b/armotypes/postureexceptionpolicytypes.go
@@ -29,11 +29,11 @@ type PostureExceptionPolicy struct {
 }
 
 type PosturePolicy struct {
-	FrameworkName string  `json:"frameworkName" bson:"frameworkName"`
-	ControlName   string  `json:"controlName,omitempty" bson:"controlName,omitempty"`
-	ControlID     string  `json:"controlID,omitempty" bson:"controlID,omitempty"`
-	RuleName      string  `json:"ruleName,omitempty" bson:"ruleName,omitempty"`
-	BaseScore     float32 `json:"baseScore,omitempty" bson:"baseScore,omitempty"`
+	FrameworkName string `json:"frameworkName" bson:"frameworkName"`
+	ControlName   string `json:"controlName,omitempty" bson:"controlName,omitempty"`
+	ControlID     string `json:"controlID,omitempty" bson:"controlID,omitempty"`
+	RuleName      string `json:"ruleName,omitempty" bson:"ruleName,omitempty"`
+	SeverityScore string `json:"severityScore,omitempty" bson:"severityScore,omitempty"`
 }
 
 func (exceptionPolicy *PostureExceptionPolicy) IsAlertOnly() bool {

--- a/armotypes/vulnerabilityexceptionpolicytypes.go
+++ b/armotypes/vulnerabilityexceptionpolicytypes.go
@@ -46,8 +46,8 @@ type VulnerabilityExceptionPolicy struct {
 type VulnerabilityPolicy struct {
 	// The name of the vulnerability
 	// Example: CVE-2022-28128
-	Name     string `json:"name" bson:"name"`
-	Severity string `json:"severity,omitempty" bson:"severity,omitempty"`
+	Name          string `json:"name" bson:"name"`
+	SeverityScore string `json:"severityScore,omitempty" bson:"severityScore,omitempty"`
 }
 
 func (exceptionPolicy *VulnerabilityExceptionPolicy) IsAlertOnly() bool {

--- a/armotypes/vulnerabilityexceptionpolicytypes.go
+++ b/armotypes/vulnerabilityexceptionpolicytypes.go
@@ -46,7 +46,8 @@ type VulnerabilityExceptionPolicy struct {
 type VulnerabilityPolicy struct {
 	// The name of the vulnerability
 	// Example: CVE-2022-28128
-	Name string `json:"name" bson:"name"`
+	Name     string `json:"name" bson:"name"`
+	Severity string `json:"severity,omitempty" bson:"severity,omitempty"`
 }
 
 func (exceptionPolicy *VulnerabilityExceptionPolicy) IsAlertOnly() bool {


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces the following enhancements:
- Adds a 'SeverityScore' field to the 'PosturePolicy' struct in 'postureexceptionpolicytypes.go'
- Adds a 'SeverityScore' field to the 'VulnerabilityPolicy' struct in 'vulnerabilityexceptionpolicytypes.go'

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `armotypes/postureexceptionpolicytypes.go`: Added a 'SeverityScore' field to the 'PosturePolicy' struct.
- `armotypes/vulnerabilityexceptionpolicytypes.go`: Added a 'SeverityScore' field to the 'VulnerabilityPolicy' struct.
</details>

___
## User Description:
- SUB-2871 | add severity to PosturePolicy
- SUB-2922 | add severity to VulnerabilityPolicy
- SUB-2922 | use const and change to baseScore
- SUB-2922 | add severityScore field
