### PR TITLE
change ScanWithoutAccessKey event name

### DIFF
--- a/broadcastevents/events_test.go
+++ b/broadcastevents/events_test.go
@@ -122,5 +122,5 @@ func TestNewScanWithoutAccessKeyEvent(t *testing.T) {
 	event := NewScanWithoutAccessKeyEvent("testGUID", "cluster123")
 	assert.Equal(t, "testGUID", event.CustomerGUID)
 	assert.Equal(t, "cluster123", event.ClusterName)
-	assert.Equal(t, "ScanWithoutAccessKey", event.EventName)
+	assert.Equal(t, "ClusterScanWithoutAccessKey", event.EventName)
 }

--- a/broadcastevents/factory.go
+++ b/broadcastevents/factory.go
@@ -313,7 +313,7 @@ func newAlertChannelDetailedEvent(customerGUID, name string, channel notificatio
 
 func NewScanWithoutAccessKeyEvent(customerGUID, clusterName string) ScanWithoutAccessKeyEvent {
 	return ScanWithoutAccessKeyEvent{
-		EventBase:   NewBaseEvent(customerGUID, "ScanWithoutAccessKey", nil),
+		EventBase:   NewBaseEvent(customerGUID, "ClusterScanWithoutAccessKey", nil),
 		ClusterName: clusterName,
 	}
 }


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR updates the event name from 'ScanWithoutAccessKey' to 'ClusterScanWithoutAccessKey'. The changes are reflected in both the event creation and the corresponding test.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `broadcastevents/events_test.go`: The test for the 'ScanWithoutAccessKey' event has been updated to reflect the new event name 'ClusterScanWithoutAccessKey'.
- `broadcastevents/factory.go`: The event name in the 'NewScanWithoutAccessKeyEvent' function has been changed from 'ScanWithoutAccessKey' to 'ClusterScanWithoutAccessKey'.
</details>

___
## User Description:
Signed-off-by: refaelm <refaelm@armosec.io>
