### PR TITLE
SUB-3331 | change severity score type to int

### DIFF
--- a/armotypes/postureexceptionpolicytypes.go
+++ b/armotypes/postureexceptionpolicytypes.go
@@ -33,7 +33,7 @@ type PosturePolicy struct {
 	ControlName   string `json:"controlName,omitempty" bson:"controlName,omitempty"`
 	ControlID     string `json:"controlID,omitempty" bson:"controlID,omitempty"`
 	RuleName      string `json:"ruleName,omitempty" bson:"ruleName,omitempty"`
-	SeverityScore string `json:"severityScore,omitempty" bson:"severityScore,omitempty"`
+	SeverityScore int    `json:"severityScore,omitempty" bson:"severityScore,omitempty"`
 }
 
 func (exceptionPolicy *PostureExceptionPolicy) IsAlertOnly() bool {

--- a/armotypes/vulnerabilityexceptionpolicytypes.go
+++ b/armotypes/vulnerabilityexceptionpolicytypes.go
@@ -47,7 +47,7 @@ type VulnerabilityPolicy struct {
 	// The name of the vulnerability
 	// Example: CVE-2022-28128
 	Name          string `json:"name" bson:"name"`
-	SeverityScore string `json:"severityScore,omitempty" bson:"severityScore,omitempty"`
+	SeverityScore int    `json:"severityScore,omitempty" bson:"severityScore,omitempty"`
 }
 
 func (exceptionPolicy *VulnerabilityExceptionPolicy) IsAlertOnly() bool {


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR changes the data type of the 'SeverityScore' field in the 'PosturePolicy' and 'VulnerabilityPolicy' structures from string to integer. This change is made in two files:
- armotypes/postureexceptionpolicytypes.go
- armotypes/vulnerabilityexceptionpolicytypes.go

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `armotypes/postureexceptionpolicytypes.go`: Changed the data type of 'SeverityScore' in 'PosturePolicy' structure from string to integer.
- `armotypes/vulnerabilityexceptionpolicytypes.go`: Changed the data type of 'SeverityScore' in 'VulnerabilityPolicy' structure from string to integer.
</details>

___
## User Description:
Signed-off-by: refaelm <refaelm@armosec.io>
