### PR TITLE
added RelatedResourceVersion to KubernetesObject

### DIFF
--- a/armotypes/kubernetes_objects.go
+++ b/armotypes/kubernetes_objects.go
@@ -18,9 +18,10 @@ type KubernetesObject struct {
 	OwnerReferenceKind string `json:"ownerReferenceKind"`
 
 	// related only to kubescape DRDs.
-	RelatedName       string `json:"relatedName"`
-	RelatedKind       string `json:"relatedKind"`
-	RelatedAPIGroup   string `json:"relatedAPIGroup"`
-	RelatedNamespace  string `json:"relatedNamespace"`
-	RelatedAPIVersion string `json:"relatedAPIVersion"`
+	RelatedName            string `json:"relatedName"`
+	RelatedKind            string `json:"relatedKind"`
+	RelatedAPIGroup        string `json:"relatedAPIGroup"`
+	RelatedNamespace       string `json:"relatedNamespace"`
+	RelatedAPIVersion      string `json:"relatedAPIVersion"`
+	RelatedResourceVersion string `json:"relatedResourceVersion"`
 }


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces an enhancement to the KubernetesObject struct in the armotypes package. Specifically, it adds a new field, `RelatedResourceVersion`, to store the version of the related resource.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `armotypes/kubernetes_objects.go`: Added a new field `RelatedResourceVersion` to the `KubernetesObject` struct. This field is intended to store the version of the related Kubernetes resource.
</details>
