### PR TITLE
sub-2516 - Slack notification models

### DIFF
--- a/armotypes/customerslackconfigurations.go
+++ b/armotypes/customerslackconfigurations.go
@@ -2,28 +2,13 @@ package armotypes
 
 type AlertLevel string
 
-const (
-	AlertInfo     AlertLevel = "info"
-	AlertCritical AlertLevel = "critical"
-	AlertError    AlertLevel = "error"
-)
-
-type SlackSettings struct {
-	Token         string `json:"token" bson:"token"`
-	Alert2Channel `json:",inline,omitempty" bson:"inline,omitempty"`
-	Notifications `json:"notifications,omitempty" bson:"notifications,omitempty"`
-}
-
-type Alert2Channel struct {
-	Critical []SlackChannel `json:"criticalChannels,omitempty" bson:"criticalChannels,omitempty"`
-	Error    []SlackChannel `json:"errorChannels,omitempty" bson:"errorChannels,omitempty"`
-	Info     []SlackChannel `json:"infoChannels,omitempty" bson:"infoChannels,omitempty"`
+type SlackChannels struct {
+	Channels []SlackChannel `json:"channels"`
 }
 
 type SlackChannel struct {
-	ChannelID   string     `json:"channelID" bson:"channelID"`
-	ChannelName string     `json:"channelName" bson:"channelName"`
-	AlertLevel  AlertLevel `json:"alertLevel" bson:"alertLevel"`
+	ChannelID   string `json:"channelID"   bson:"channelID"`
+	ChannelName string `json:"channelName" bson:"channelName"`
 }
 
 type SlackNotification struct {

--- a/armotypes/customerslackconfigurations.go
+++ b/armotypes/customerslackconfigurations.go
@@ -15,7 +15,6 @@ type SlackChannels struct {
 	Channels []SlackChannel `json:"channels"`
 }
 
-// todo : check bson anotate
 type SlackChannel struct {
 	ChannelID   string `json:"id"   bson:"channelID"`
 	ChannelName string `json:"name" bson:"channelName"`

--- a/armotypes/customerslackconfigurations.go
+++ b/armotypes/customerslackconfigurations.go
@@ -16,8 +16,8 @@ type SlackChannels struct {
 }
 
 type SlackChannel struct {
-	ChannelID   string `json:"id"   bson:"channelID"`
-	ChannelName string `json:"name" bson:"channelName"`
+	ChannelID   string `json:"id"`
+	ChannelName string `json:"name"`
 }
 
 type SlackChannelStatus struct {

--- a/armotypes/customerslackconfigurations.go
+++ b/armotypes/customerslackconfigurations.go
@@ -1,14 +1,32 @@
 package armotypes
 
-type AlertLevel string
+type SlackSettings struct {
+	Token         string `json:"token" bson:"token"`
+	Alert2Channel `json:",inline,omitempty" bson:"inline,omitempty"`
+	Notifications `json:"notifications,omitempty" bson:"notifications,omitempty"`
+}
 
+type Alert2Channel struct {
+	Critical []SlackChannel `json:"criticalChannels,omitempty" bson:"criticalChannels,omitempty"`
+	Error    []SlackChannel `json:"errorChannels,omitempty" bson:"errorChannels,omitempty"`
+	Info     []SlackChannel `json:"infoChannels,omitempty" bson:"infoChannels,omitempty"`
+}
 type SlackChannels struct {
 	Channels []SlackChannel `json:"channels"`
 }
 
+// todo : check bson anotate
 type SlackChannel struct {
-	ChannelID   string `json:"channelID"   bson:"channelID"`
-	ChannelName string `json:"channelName" bson:"channelName"`
+	ChannelID   string `json:"id"   bson:"channelID"`
+	ChannelName string `json:"name" bson:"channelName"`
+}
+
+type SlackChannelStatus struct {
+	ChannelID string `json:"channelID"   bson:"channelID"`
+	Exists    bool   `json:"exists" bson:"channelName"`
+}
+type SlackChannelStatusRequest struct {
+	ChannelID string `json:"channelID"   bson:"channelID"`
 }
 
 type SlackNotification struct {

--- a/armotypes/customerslackconfigurations.go
+++ b/armotypes/customerslackconfigurations.go
@@ -11,6 +11,7 @@ type Alert2Channel struct {
 	Error    []SlackChannel `json:"errorChannels,omitempty" bson:"errorChannels,omitempty"`
 	Info     []SlackChannel `json:"infoChannels,omitempty" bson:"infoChannels,omitempty"`
 }
+
 type SlackChannels struct {
 	Channels []SlackChannel `json:"channels"`
 }
@@ -18,14 +19,6 @@ type SlackChannels struct {
 type SlackChannel struct {
 	ChannelID   string `json:"id"`
 	ChannelName string `json:"name"`
-}
-
-type SlackChannelStatus struct {
-	ChannelID string `json:"channelID"   bson:"channelID"`
-	Exists    bool   `json:"exists" bson:"channelName"`
-}
-type SlackChannelStatusRequest struct {
-	ChannelID string `json:"channelID"   bson:"channelID"`
 }
 
 type SlackNotification struct {

--- a/armotypes/oauth2types.go
+++ b/armotypes/oauth2types.go
@@ -1,0 +1,12 @@
+package armotypes
+
+type ConnectedStatus string
+
+const (
+	Connected    ConnectedStatus = "connected"
+	Disconnected ConnectedStatus = "disconnected"
+)
+
+type ProviderConnectionStatus struct {
+	Status ConnectedStatus `json:"status"`
+}


### PR DESCRIPTION
## type:
Refactoring

___
## description:
This PR involves a significant refactoring of the Slack notification models in the `armotypes/customerslackconfigurations.go` file. The main changes include:
- Removal of the `AlertLevel` type and its constants.
- Removal of the `SlackSettings` and `Alert2Channel` types.
- Introduction of a new `SlackChannels` type, which contains a slice of `SlackChannel`.
- Modification of the `SlackChannel` type to remove the `AlertLevel` field.
- No changes were made to the `SlackNotification` type.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `armotypes/customerslackconfigurations.go`: The `AlertLevel` type and its constants were removed. The `SlackSettings` and `Alert2Channel` types were also removed. A new `SlackChannels` type was introduced, which contains a slice of `SlackChannel`. The `SlackChannel` type was modified to remove the `AlertLevel` field. The `SlackNotification` type remained unchanged.
</details>
