### PR TITLE
feat: add networkpolicies types

### DIFF
--- a/armotypes/networkpolicies.go
+++ b/armotypes/networkpolicies.go
@@ -13,7 +13,7 @@ type NetworkPoliciesWorkload struct {
 }
 
 const (
-    NetworkPolicyRequired = 0
-    NetworkPolicyApplied = 1
-    MissingRuntimeInfo = 2
+    MissingRuntimeInfo = 1
+    NetworkPolicyRequired = 2
+    NetworkPolicyApplied = 3
 )

--- a/armotypes/networkpolicies.go
+++ b/armotypes/networkpolicies.go
@@ -1,0 +1,19 @@
+package armotypes
+
+// NetworkPoliciesWorkload is used store information about workloads
+// in the customer's clusters related to the NetworkPolicies feature
+type NetworkPoliciesWorkload struct {
+	Name                       string   `json:"name"`
+	Kind                       string   `json:"kind"`
+	Namespace                  string   `json:"namespace"`
+	ClusterName                string   `json:"clusterName"`
+	ClusterShortName           string   `json:"clusterShortName"`
+	NetworkPolicyStatus        int      `json:"networkPolicyStatus"`
+	NetworkPolicyStatusMessage string   `json:"networkPolicyStatusMessage"`
+}
+
+const (
+    NetworkPolicyRequired = 0
+    NetworkPolicyApplied = 1
+    MissingRuntimeInfo = 2
+)


### PR DESCRIPTION
## type:
Enhancement

___
## description:
This PR introduces new types related to NetworkPolicies in the Go language. Specifically, it defines a new struct 'NetworkPoliciesWorkload' to store information about workloads in the customer's clusters related to the NetworkPolicies feature. It also introduces three new constants: 'MissingRuntimeInfo', 'NetworkPolicyRequired', and 'NetworkPolicyApplied'.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `armotypes/networkpolicies.go`: Added a new struct 'NetworkPoliciesWorkload' with fields to store information about workloads related to NetworkPolicies. Also, introduced three new constants for different network policy statuses.
</details>
