### PR TITLE
SUB-3580 | change remove provider config logic to set empty slice

### DIFF
--- a/notifications/usersnotificationsmethods.go
+++ b/notifications/usersnotificationsmethods.go
@@ -165,7 +165,7 @@ func (nc *NotificationsConfig) RemoveAlertChannel(collaborationId string) error 
 
 func (nc *NotificationsConfig) RemoveProviderConfig(provider ChannelProvider) error {
 	if _, exists := nc.AlertChannels[provider]; exists {
-		delete(nc.AlertChannels, provider)
+		nc.AlertChannels[provider] = make([]AlertChannel, 0)
 		return nil
 	}
 	return fmt.Errorf("provider with identifier %v not found", provider)


### PR DESCRIPTION
## Type
Enhancement, Tests


___

## Description
This PR updates the logic for removing a provider configuration in the notifications system. Previously, the provider configuration was deleted from the AlertChannels map. Now, instead of deleting the configuration, an empty slice is set for the provider key in the AlertChannels map. This change is aimed at preventing potential issues with nil map entries. 
Additionally, a comprehensive set of tests has been added to validate the behavior of the updated RemoveProviderConfig function under various scenarios.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>usersnotificationsmethods.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        notifications/usersnotificationsmethods.go<br><br>
        <strong>The RemoveProviderConfig function has been updated to set an <br>empty slice for the provider key in the AlertChannels map <br>instead of deleting the key-value pair.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/182/files#diff-bd80e935c4d7aac4288a9af3ea42ff64e94e4be2fe1ab3e04acd7dea54941f42"> +1/-1</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>usernotificationreporttypes_test.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        notifications/usernotificationreporttypes_test.go<br><br>
        <strong>Added a new test function, TestRemoveProviderConfig, to <br>validate the behavior of the updated RemoveProviderConfig <br>function under various scenarios.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/182/files#diff-92da85d08813f4a45402cbec67a90e38c48dff5e60c62bae944e177adfe8bd41"> +105/-0</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

## User description
Signed-off-by: refaelm <refaelm@armosec.io>
