### PR TITLE
added resourceHash

### DIFF
--- a/armotypes/kubernetes_objects.go
+++ b/armotypes/kubernetes_objects.go
@@ -9,6 +9,7 @@ import (
 // KubernetesObject represents a single Kubernetes object, either native or kubescape CRD
 type KubernetesObject struct {
 	Designators       identifiers.PortalDesignator `json:"designators"`
+	ResourceHash      string                       `json:"resourceHash"`
 	ResourceObjectRef string                       `json:"resourceObjectRef"`
 	ResourceVersion   string                       `json:"resourceVersion"`
 	Checksum          string                       `json:"checksum"`


### PR DESCRIPTION
## Type
Enhancement


___

## Description
This PR introduces a new field, `ResourceHash`, to the `KubernetesObject` struct. This field will be used to store the hash of the resource, providing a unique identifier for each Kubernetes object.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>kubernetes_objects.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        armotypes/kubernetes_objects.go<br><br>
        <strong>Added a new field `ResourceHash` to the `KubernetesObject` <br>struct.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/184/files#diff-ed902e412315af13ce66142c7a0cebcb72e6badc5f0bba656a8b6b9db8688873"> +1/-0</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>