### PR TITLE
fix: change name of np attribute

### DIFF
--- a/armotypes/networkpolicies.go
+++ b/armotypes/networkpolicies.go
@@ -6,7 +6,7 @@ type NetworkPoliciesWorkload struct {
 	Name                       string   `json:"name"`
 	Kind                       string   `json:"kind"`
 	Namespace                  string   `json:"namespace"`
-	ClusterName                string   `json:"clusterName"`
+	ClusterName                string   `json:"cluster"`
 	ClusterShortName           string   `json:"clusterShortName"`
 	NetworkPolicyStatus        int      `json:"networkPolicyStatus"`
 	NetworkPolicyStatusMessage string   `json:"networkPolicyStatusMessage"`


### PR DESCRIPTION
## Type
bug_fix


___

## Description
This PR addresses a naming issue in the NetworkPoliciesWorkload struct. The attribute 'clusterName' has been renamed to 'cluster' to improve consistency and readability.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>networkpolicies.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        armotypes/networkpolicies.go<br><br>
        <strong>The 'clusterName' attribute in the NetworkPoliciesWorkload <br>struct has been renamed to 'cluster'.</strong>
      </ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/185/files#diff-edffc833afef72270a9815b6c2842d3d28e3eb3cefcae82601a76c0bd97bdbb4"> +1/-1</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>