### PR TITLE
SUB-3621 - Slack alerts - Wrong CVE link for GHSA vuln

### DIFF
--- a/containerscan/commonadapters_test.go
+++ b/containerscan/commonadapters_test.go
@@ -1,0 +1,30 @@
+package containerscan
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestToFlatVulnerabilities_EmptyReport(t *testing.T) {
+	report := &ScanResultReport{}
+	vulns := report.ToFlatVulnerabilities()
+	if len(vulns) != 0 {
+		t.Errorf("Expected 0 vulnerabilities, got %d", len(vulns))
+	}
+}
+
+func TestGetVulnLink_GitHub(t *testing.T) {
+	report := &ScanResultReport{}
+	link := report.getVulnLink("GHSA-xxxx-xxxx-xxxx")
+	if !strings.HasPrefix(link, "https://github.com/advisories/") {
+		t.Errorf("Expected GitHub advisory link, got %s", link)
+	}
+}
+
+func TestGetVulnLink_NVD(t *testing.T) {
+	report := &ScanResultReport{}
+	link := report.getVulnLink("CVE-2023-0001")
+	if !strings.HasPrefix(link, "https://nvd.nist.gov/vuln/detail/") {
+		t.Errorf("Expected NVD link, got %s", link)
+	}
+}


### PR DESCRIPTION
## Type
bug_fix, tests


___

## Description
- Fixed the issue where the wrong CVE link was generated for GHSA vulnerabilities. Now, the correct link is generated based on the vulnerability name.
- Added tests to ensure the correct generation of vulnerability links and the correct transformation of vulnerabilities to a flat structure.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>commonadapters.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        containerscan/commonadapters.go<br><br>

**A new function `getVulnLink` was added to generate the <br>correct vulnerability link based on the vulnerability name. <br>If the vulnerability name starts with "GHSA-", a GitHub <br>advisory link is generated, otherwise, a NVD link is <br>generated. This function is used to set the `RelevantLinks` <br>and `Vulnerability` link in the `ToFlatVulnerabilities` <br>function.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/187/files#diff-27100e1dfbe8290ea213327c2a026cd2329e55d5eb75c70cdcf2603c3c8e323f"> +12/-3</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>commonadapters_test.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        containerscan/commonadapters_test.go<br><br>

**Added new test cases for the `ToFlatVulnerabilities` and <br>`getVulnLink` functions. The tests check the correct <br>generation of vulnerability links and the correct <br>transformation of vulnerabilities to a flat structure.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/187/files#diff-e2728da6779b27d63560e98d06f76a5e36f1f0a02c71b1fabbf9774678496233"> +30/-0</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>