### PR TITLE
network policie status

### DIFF
--- a/armotypes/kubernetes_objects.go
+++ b/armotypes/kubernetes_objects.go
@@ -6,6 +6,14 @@ import (
 	"github.com/armosec/armoapi-go/identifiers"
 )
 
+type NetworkPolicyStatus int
+
+const (
+	StatusNetworkPolicyApplied    NetworkPolicyStatus = 1
+	StatusNetworkPolicyNotApplied NetworkPolicyStatus = 2
+	StatusNetworkPolicyUknown     NetworkPolicyStatus = 3
+)
+
 // KubernetesObject represents a single Kubernetes object, either native or kubescape CRD
 type KubernetesObject struct {
 	Designators       identifiers.PortalDesignator `json:"designators"`
@@ -19,12 +27,29 @@ type KubernetesObject struct {
 	OwnerReferenceKind string `json:"ownerReferenceKind"`
 
 	// related only to kubescape DRDs.
-	RelatedName            string            `json:"relatedName"`
-	RelatedKind            string            `json:"relatedKind"`
-	RelatedAPIGroup        string            `json:"relatedAPIGroup"`
-	RelatedNamespace       string            `json:"relatedNamespace"`
-	RelatedAPIVersion      string            `json:"relatedAPIVersion"`
-	RelatedResourceVersion string            `json:"relatedResourceVersion"`
-	NetworkPolicyStatus    string            `json:"networkPolicyStatus"`
-	Labels                 map[string]string `json:"labels"`
+	RelatedName            string `json:"relatedName"`
+	RelatedKind            string `json:"relatedKind"`
+	RelatedAPIGroup        string `json:"relatedAPIGroup"`
+	RelatedNamespace       string `json:"relatedNamespace"`
+	RelatedAPIVersion      string `json:"relatedAPIVersion"`
+	RelatedResourceVersion string `json:"relatedResourceVersion"`
+	NetworkPolicyStatus    string `json:"networkPolicyStatus"` // DEPRECATED
+
+	NetworkPolicyAppliedCustomer  bool `json:"networkPolicyAppliedCustomer"`
+	NetworkPolicyAppliedKubescape bool `json:"networkPolicyAppliedKubescape"`
+	NetworkPolicyStatusKnown      bool `json:"networkPolicyStatusKnown"`
+
+	Labels map[string]string `json:"labels"`
+}
+
+func (ko *KubernetesObject) GetNetworkPolicyStatus() NetworkPolicyStatus {
+	if !ko.NetworkPolicyStatusKnown {
+		return StatusNetworkPolicyUknown
+	}
+
+	if ko.NetworkPolicyAppliedCustomer || ko.NetworkPolicyAppliedKubescape {
+		return StatusNetworkPolicyApplied
+	}
+
+	return StatusNetworkPolicyNotApplied
 }


### PR DESCRIPTION
## Type
Enhancement


___

## Description
This PR enhances the handling of network policy status in Kubernetes objects. The main changes include:
- Introduction of a new enumeration `NetworkPolicyStatus` to represent the status of a network policy.
- Deprecation of the `NetworkPolicyStatus` field in the `KubernetesObject` struct.
- Addition of three new boolean fields to the `KubernetesObject` struct: `NetworkPolicyAppliedCustomer`, `NetworkPolicyAppliedKubescape`, and `NetworkPolicyStatusKnown`.
- Addition of a new method `GetNetworkPolicyStatus` to the `KubernetesObject` struct that returns the network policy status based on the new boolean fields.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>kubernetes_objects.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        armotypes/kubernetes_objects.go<br><br>

**The PR introduces a new enumeration `NetworkPolicyStatus` <br>with three states: `StatusNetworkPolicyApplied`, <br>`StatusNetworkPolicyNotApplied`, and <br>`StatusNetworkPolicyUknown`. The `KubernetesObject` struct <br>has been updated to include three new boolean fields: <br>`NetworkPolicyAppliedCustomer`, <br>`NetworkPolicyAppliedKubescape`, and <br>`NetworkPolicyStatusKnown`. The `NetworkPolicyStatus` field <br>has been marked as deprecated. A new method <br>`GetNetworkPolicyStatus` has been added to the <br>`KubernetesObject` struct that returns the network policy <br>status based on the new boolean fields.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/191/files#diff-ed902e412315af13ce66142c7a0cebcb72e6badc5f0bba656a8b6b9db8688873"> +33/-8</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>