### PR TITLE
np fixes

### DIFF
--- a/armotypes/kubernetes_objects.go
+++ b/armotypes/kubernetes_objects.go
@@ -39,17 +39,8 @@ type KubernetesObject struct {
 	NetworkPolicyAppliedKubescape bool `json:"networkPolicyAppliedKubescape"`
 	NetworkPolicyStatusKnown      bool `json:"networkPolicyStatusKnown"`
 
+	NumberNetworkPoliciesApplied          int `json:"numberNetworkPoliciesApplied"`
+	NumberNetworkPoliciesAppliedKubescape int `json:"numberNetworkPoliciesAppliedKubescape"`
+
 	Labels map[string]string `json:"labels"`
-}
-
-func (ko *KubernetesObject) GetNetworkPolicyStatus() NetworkPolicyStatus {
-	if !ko.NetworkPolicyStatusKnown {
-		return StatusNetworkPolicyUknown
-	}
-
-	if ko.NetworkPolicyAppliedCustomer || ko.NetworkPolicyAppliedKubescape {
-		return StatusNetworkPolicyApplied
-	}
-
-	return StatusNetworkPolicyNotApplied
 }

--- a/armotypes/networkpolicies.go
+++ b/armotypes/networkpolicies.go
@@ -3,17 +3,18 @@ package armotypes
 // NetworkPoliciesWorkload is used store information about workloads
 // in the customer's clusters related to the NetworkPolicies feature
 type NetworkPoliciesWorkload struct {
-	Name                       string   `json:"name"`
-	Kind                       string   `json:"kind"`
-	Namespace                  string   `json:"namespace"`
-	ClusterName                string   `json:"cluster"`
-	ClusterShortName           string   `json:"clusterShortName"`
-	NetworkPolicyStatus        int      `json:"networkPolicyStatus"`
-	NetworkPolicyStatusMessage string   `json:"networkPolicyStatusMessage"`
+	Name                       string `json:"name"`
+	Kind                       string `json:"kind"`
+	CustomerGUID               string `json:"customerGUID"`
+	Namespace                  string `json:"namespace"`
+	ClusterName                string `json:"cluster"`
+	ClusterShortName           string `json:"clusterShortName"`
+	NetworkPolicyStatus        int    `json:"networkPolicyStatus"`
+	NetworkPolicyStatusMessage string `json:"networkPolicyStatusMessage"`
 }
 
 const (
-    MissingRuntimeInfo = 1
-    NetworkPolicyRequired = 2
-    NetworkPolicyApplied = 3
+	MissingRuntimeInfo    = 1
+	NetworkPolicyRequired = 2
+	NetworkPolicyApplied  = 3
 )


### PR DESCRIPTION
## Type
bug_fix


___

## Description
This PR includes changes to the `KubernetesObject` and `NetworkPoliciesWorkload` structs in the `armotypes` package. The main changes include:
- In `KubernetesObject`, the `GetNetworkPolicyStatus` function was removed. The `NetworkPolicyStatusKnown`, `NetworkPolicyAppliedCustomer`, and `NetworkPolicyAppliedKubescape` fields were replaced with `NumberNetworkPoliciesApplied` and `NumberNetworkPoliciesAppliedKubescape` fields.
- In `NetworkPoliciesWorkload`, a `CustomerGUID` field was added.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>kubernetes_objects.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        armotypes/kubernetes_objects.go<br><br>

**Removed the `GetNetworkPolicyStatus` function and replaced <br>the `NetworkPolicyStatusKnown`, <br>`NetworkPolicyAppliedCustomer`, and <br>`NetworkPolicyAppliedKubescape` fields with <br>`NumberNetworkPoliciesApplied` and <br>`NumberNetworkPoliciesAppliedKubescape` fields in the <br>`KubernetesObject` struct.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/196/files#diff-ed902e412315af13ce66142c7a0cebcb72e6badc5f0bba656a8b6b9db8688873"> +3/-12</a></td>

</tr>                    
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>networkpolicies.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        armotypes/networkpolicies.go<br><br>

**Added `CustomerGUID` field to the `NetworkPoliciesWorkload` <br>struct and made minor formatting changes.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/196/files#diff-edffc833afef72270a9815b6c2842d3d28e3eb3cefcae82601a76c0bd97bdbb4"> +11/-10</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>