### PR TITLE
sub-3604 - Add workload id

### DIFF
--- a/armotypes/vulnerabilitytypes.go
+++ b/armotypes/vulnerabilitytypes.go
@@ -19,6 +19,7 @@ type VulnerabilityJobParams struct {
 }
 
 type VulnerabilityWorkload struct {
+	Wlid             string              `json:"wlid"`
 	Name             string              `json:"name"`
 	Namespace        string              `json:"namespace"`
 	Kind             string              `json:"kind"`


### PR DESCRIPTION
## Type
Enhancement


___

## Description
- Added a new field `Wlid` to the `VulnerabilityWorkload` struct in the `armotypes/vulnerabilitytypes.go` file. This field will be used to store the workload id.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>vulnerabilitytypes.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        armotypes/vulnerabilitytypes.go<br><br>

**Added a new field `Wlid` to the `VulnerabilityWorkload` <br>struct.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/197/files#diff-cac55976184cdb0c77ddde7ecbabd7411490f34df3e11868dd0e67e370c01830"> +1/-0</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>