### PR TITLE
add score fields

### DIFF
--- a/armotypes/vulnerabilitytypes.go
+++ b/armotypes/vulnerabilitytypes.go
@@ -78,12 +78,18 @@ type Vulnerability struct {
 	Exploitable    string                     `json:"exploitable"`
 	ComponentsInfo []VulnerabilitiesComponent `json:"componentsInfo"`
 	IsFixable      bool                       `json:"isFixable"`
-	CvssInfo       []CvssInfo                 `json:"cvssInfo"`
+	CvssInfo       CvssInfo                   `json:"cvssInfo"`
 	EpssInfo       EpssInfo                   `json:"epssInfo"`
 	CisaKevInfo    CisaKevInfo                `json:"cisaKevInfo"`
 }
 
 type CvssInfo struct {
+	BaseScore    float64 `json:"baseScore"`
+	ScoreVersion string  `json:"scoreVersion"`
+	CVSS         []Cvss  `json:"cvss"`
+}
+
+type Cvss struct {
 	Vector              string                 `json:"vector"`
 	Version             string                 `json:"version"`
 	Source              string                 `json:"source"`


### PR DESCRIPTION
## Type
Enhancement


___

## Description
This PR introduces two new fields in the `Vulnerability` struct:
- `BaseScore`: A float64 field to store the base score of the vulnerability.
- `ScoreVersion`: A string field to store the version of the scoring system used.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>vulnerabilitytypes.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        armotypes/vulnerabilitytypes.go<br><br>

**Two new fields `BaseScore` and `ScoreVersion` have been <br>added to the `Vulnerability` struct.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/199/files#diff-cac55976184cdb0c77ddde7ecbabd7411490f34df3e11868dd0e67e370c01830"> +2/-0</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

## User description
Signed-off-by: refaelm <refaelm@armosec.io>
