### PR TITLE
change cvss score fields types

### DIFF
--- a/armotypes/vulnerabilitytypes.go
+++ b/armotypes/vulnerabilitytypes.go
@@ -93,9 +93,9 @@ type Cvss struct {
 	Vector              string                 `json:"vector"`
 	Version             string                 `json:"version"`
 	Source              string                 `json:"source"`
-	BaseScore           int                    `json:"baseScore"`
-	ExploitabiltiyScore int                    `json:"exploitabiltiyScore"`
-	ImpactScore         int                    `json:"ImpactScore"`
+	BaseScore           float64                `json:"baseScore"`
+	ExploitabiltiyScore float64                `json:"exploitabiltiyScore"`
+	ImpactScore         float64                `json:"ImpactScore"`
 	ExploitabilityInfo  CvssExploitabilityInfo `json:"exploitabilityInfo"`
 	ImpactInfo          CvssImpactInfo         `json:"impactInfo"`
 }


### PR DESCRIPTION
## Type
enhancement


___

## Description
This PR includes an enhancement to the `Cvss` struct in the `armotypes/vulnerabilitytypes.go` file. Specifically, the data types of the following fields have been changed from `int` to `float64`:
- `BaseScore`
- `ExploitabiltiyScore`
- `ImpactScore`


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Data types change</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>vulnerabilitytypes.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        armotypes/vulnerabilitytypes.go<br><br>

**The types of `BaseScore`, `ExploitabiltiyScore`, and <br>`ImpactScore` fields in the `Cvss` struct have been changed <br>from `int` to `float64`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/200/files#diff-cac55976184cdb0c77ddde7ecbabd7411490f34df3e11868dd0e67e370c01830"> +3/-3</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

## User description
Signed-off-by: refaelm <refaelm@armosec.io>
