### PR TITLE
update network policy status structs

### DIFF
--- a/armotypes/kubernetes_objects.go
+++ b/armotypes/kubernetes_objects.go
@@ -6,14 +6,6 @@ import (
 	"github.com/armosec/armoapi-go/identifiers"
 )
 
-type NetworkPolicyStatus int
-
-const (
-	StatusNetworkPolicyApplied    NetworkPolicyStatus = 1
-	StatusNetworkPolicyNotApplied NetworkPolicyStatus = 2
-	StatusNetworkPolicyUknown     NetworkPolicyStatus = 3
-)
-
 // KubernetesObject represents a single Kubernetes object, either native or kubescape CRD
 type KubernetesObject struct {
 	Designators       identifiers.PortalDesignator `json:"designators"`
@@ -33,14 +25,11 @@ type KubernetesObject struct {
 	RelatedNamespace       string `json:"relatedNamespace"`
 	RelatedAPIVersion      string `json:"relatedAPIVersion"`
 	RelatedResourceVersion string `json:"relatedResourceVersion"`
-	NetworkPolicyStatus    string `json:"networkPolicyStatus"` // DEPRECATED
 
-	NetworkPolicyAppliedCustomer  bool `json:"networkPolicyAppliedCustomer"`
-	NetworkPolicyAppliedKubescape bool `json:"networkPolicyAppliedKubescape"`
-	NetworkPolicyStatusKnown      bool `json:"networkPolicyStatusKnown"`
-
-	NumberNetworkPoliciesApplied          int `json:"numberNetworkPoliciesApplied"`
-	NumberNetworkPoliciesAppliedKubescape int `json:"numberNetworkPoliciesAppliedKubescape"`
+	NetworkPolicyStatus NetworkPolicyStatus `json:"networkPolicyStatus"`
 
 	Labels map[string]string `json:"labels"`
+
+	// used for network policies
+	PodSelectorLabels map[string]string `json:"podSelectorLabels"`
 }

--- a/armotypes/networkpolicies.go
+++ b/armotypes/networkpolicies.go
@@ -1,20 +1,22 @@
 package armotypes
 
+type NetworkPolicyStatus int
+
+const (
+	MissingRuntimeInfo    NetworkPolicyStatus = 1
+	NetworkPolicyRequired NetworkPolicyStatus = 2
+	NetworkPolicyApplied  NetworkPolicyStatus = 3
+)
+
 // NetworkPoliciesWorkload is used store information about workloads
 // in the customer's clusters related to the NetworkPolicies feature
 type NetworkPoliciesWorkload struct {
-	Name                       string `json:"name"`
-	Kind                       string `json:"kind"`
-	CustomerGUID               string `json:"customerGUID"`
-	Namespace                  string `json:"namespace"`
-	ClusterName                string `json:"cluster"`
-	ClusterShortName           string `json:"clusterShortName"`
-	NetworkPolicyStatus        int    `json:"networkPolicyStatus"`
-	NetworkPolicyStatusMessage string `json:"networkPolicyStatusMessage"`
+	Name                       string              `json:"name"`
+	Kind                       string              `json:"kind"`
+	CustomerGUID               string              `json:"customerGUID"`
+	Namespace                  string              `json:"namespace"`
+	ClusterName                string              `json:"cluster"`
+	ClusterShortName           string              `json:"clusterShortName"`
+	NetworkPolicyStatus        NetworkPolicyStatus `json:"networkPolicyStatus"`
+	NetworkPolicyStatusMessage string              `json:"networkPolicyStatusMessage"`
 }
-
-const (
-	MissingRuntimeInfo    = 1
-	NetworkPolicyRequired = 2
-	NetworkPolicyApplied  = 3
-)


### PR DESCRIPTION
## Type
enhancement


___

## Description
This PR involves changes to the `NetworkPolicyStatus` in two Go files. The main changes include:
- Removal of the `NetworkPolicyStatus` enum and related constants from `kubernetes_objects.go`.
- Modification of the `NetworkPolicyStatus` field in the `KubernetesObject` struct from string to `NetworkPolicyStatus` type.
- Removal of some fields related to network policy in `kubernetes_objects.go` and addition of a new field `PodSelectorLabels`.
- Addition of the `NetworkPolicyStatus` enum and related constants to `networkpolicies.go`.
- Modification of the `NetworkPolicyStatus` field in the `NetworkPoliciesWorkload` struct from int to `NetworkPolicyStatus` type.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>kubernetes_objects.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        armotypes/kubernetes_objects.go<br><br>

**The `NetworkPolicyStatus` enum and related constants were <br>removed from this file. The `NetworkPolicyStatus` field in <br>the `KubernetesObject` struct was changed from string to <br>`NetworkPolicyStatus` type. Some fields related to network <br>policy were removed, and a new field `PodSelectorLabels` was <br>added.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/202/files#diff-ed902e412315af13ce66142c7a0cebcb72e6badc5f0bba656a8b6b9db8688873"> +4/-15</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>networkpolicies.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        armotypes/networkpolicies.go<br><br>

**The `NetworkPolicyStatus` enum and related constants were <br>added to this file. The `NetworkPolicyStatus` field in the <br>`NetworkPoliciesWorkload` struct was changed from int to <br>`NetworkPolicyStatus` type.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/202/files#diff-edffc833afef72270a9815b6c2842d3d28e3eb3cefcae82601a76c0bd97bdbb4"> +16/-14</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>