### PR TITLE
Fix cluster name field

### DIFF
--- a/armotypes/vulnerabilitytypes.go
+++ b/armotypes/vulnerabilitytypes.go
@@ -23,7 +23,7 @@ type VulnerabilityWorkload struct {
 	Name             string              `json:"name"`
 	Namespace        string              `json:"namespace"`
 	Kind             string              `json:"kind"`
-	ClusterName      string              `json:"clusterName"`
+	Cluster          string              `json:"cluster"`
 	ClusterShortName string              `json:"clusterShortName"`
 	LastScanTime     time.Time           `json:"lastScanTime"`
 	CustomerGUID     string              `json:"customerGUID"`


### PR DESCRIPTION
## Type
bug_fix


___

## Description
- The PR primarily addresses a bug fix in the `VulnerabilityWorkload` struct in the `armotypes/vulnerabilitytypes.go` file.
- The `ClusterName` field has been renamed to `Cluster` to fix an issue.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>vulnerabilitytypes.go&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        armotypes/vulnerabilitytypes.go<br><br>

**The `ClusterName` field in the `VulnerabilityWorkload` <br>struct has been renamed to `Cluster`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/204/files#diff-cac55976184cdb0c77ddde7ecbabd7411490f34df3e11868dd0e67e370c01830"> +1/-1</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>