### PR TITLE
bump docker/docker version

### DIFF
--- a/apis/interfaces.go
+++ b/apis/interfaces.go
@@ -3,7 +3,7 @@ package apis
 import (
 	"net/http"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/registry"
 )
 
 // Connector - interface for any connector (BE/Portal and so on)
@@ -27,9 +27,9 @@ type Connector interface {
 type ImageScanCommand interface {
 	GetWlid() string
 	GetImageHash() string
-	GetCreds() *types.AuthConfig
-	GetCredentialsList() []types.AuthConfig
-	SetCredentialsList([]types.AuthConfig)
+	GetCreds() *registry.AuthConfig
+	GetCredentialsList() []registry.AuthConfig
+	SetCredentialsList([]registry.AuthConfig)
 	GetArgs() map[string]interface{}
 	SetArgs(map[string]interface{})
 	GetSession() SessionChain

--- a/apis/websocketdatastructures.go
+++ b/apis/websocketdatastructures.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"github.com/armosec/armoapi-go/identifiers"
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/registry"
 )
 
 // Commands contains a collection of commands for the in-cluster components
@@ -93,12 +93,12 @@ type WebsocketScanCommand struct {
 	// Deprecated: Credentials to the Container Registry that holds the image to be scanned
 	//
 	// Kept for backward compatibility
-	Credentials *types.AuthConfig `json:"credentials,omitempty"`
+	Credentials *registry.AuthConfig `json:"credentials,omitempty"`
 }
 
 type ImageScanParams struct {
 	// A list of credentials for private Container Registries that store images to be scanned
-	Credentialslist []types.AuthConfig `json:"credentialsList,omitempty"`
+	Credentialslist []registry.AuthConfig `json:"credentialsList,omitempty"`
 	// Arguments to pass to the scan command
 	//
 	// Example: {"useHTTP": true, "skipTLSVerify": true, "registryName": "", "repository": "", "tag": ""}

--- a/apis/websocketmethods.go
+++ b/apis/websocketmethods.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/armosec/armoapi-go/identifiers"
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/registry"
 )
 
 const (
@@ -135,11 +135,11 @@ func (r *RegistryScanCommand) GetWlid() string {
 	return ""
 }
 
-func (r *RegistryScanCommand) GetCredentialsList() []types.AuthConfig {
+func (r *RegistryScanCommand) GetCredentialsList() []registry.AuthConfig {
 	return r.ImageScanParams.Credentialslist
 }
 
-func (r *RegistryScanCommand) SetCredentialsList(credentialslist []types.AuthConfig) {
+func (r *RegistryScanCommand) SetCredentialsList(credentialslist []registry.AuthConfig) {
 	r.ImageScanParams.Credentialslist = credentialslist
 }
 
@@ -183,7 +183,7 @@ func (r *RegistryScanCommand) SetParentJobID(parentJobID string) {
 	r.ImageScanParams.ParentJobID = parentJobID
 }
 
-func (r *RegistryScanCommand) GetCreds() *types.AuthConfig {
+func (r *RegistryScanCommand) GetCreds() *registry.AuthConfig {
 	return nil
 }
 
@@ -195,11 +195,11 @@ func (r *RegistryScanCommand) GetImageHash() string {
 
 var _ ImageScanCommand = &WebsocketScanCommand{}
 
-func (c *WebsocketScanCommand) GetCredentialsList() []types.AuthConfig {
+func (c *WebsocketScanCommand) GetCredentialsList() []registry.AuthConfig {
 	return c.Credentialslist
 }
 
-func (c *WebsocketScanCommand) SetCredentialsList(credentialslist []types.AuthConfig) {
+func (c *WebsocketScanCommand) SetCredentialsList(credentialslist []registry.AuthConfig) {
 	c.Credentialslist = credentialslist
 }
 
@@ -247,7 +247,7 @@ func (c *WebsocketScanCommand) GetImageHash() string {
 	return c.ImageHash
 }
 
-func (c *WebsocketScanCommand) GetCreds() *types.AuthConfig {
+func (c *WebsocketScanCommand) GetCreds() *registry.AuthConfig {
 	return c.Credentials
 }
 

--- a/apis/websocketmethods_test.go
+++ b/apis/websocketmethods_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/registry"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -46,11 +46,11 @@ func TestRegistryScanCommandGetWlid(t *testing.T) {
 }
 
 func TestRegistryScanCommandGetCredentialsList(t *testing.T) {
-	r := &RegistryScanCommand{ImageScanParams: ImageScanParams{Credentialslist: []types.AuthConfig{{
+	r := &RegistryScanCommand{ImageScanParams: ImageScanParams{Credentialslist: []registry.AuthConfig{{
 		Username: "username",
 		Password: "password",
 	}}}}
-	expected := []types.AuthConfig{{
+	expected := []registry.AuthConfig{{
 		Username: "username",
 		Password: "password",
 	}}
@@ -61,7 +61,7 @@ func TestRegistryScanCommandGetCredentialsList(t *testing.T) {
 
 func TestRegistryScanCommandSetCredentialsList(t *testing.T) {
 	r := &RegistryScanCommand{}
-	expected := []types.AuthConfig{{
+	expected := []registry.AuthConfig{{
 		Username: "username",
 		Password: "password",
 	}}
@@ -231,7 +231,7 @@ func TestWebsocketScanCommandGetCreds(t *testing.T) {
 	creds := w.GetCreds()
 	assert.Nil(t, creds)
 
-	w.Credentials = &types.AuthConfig{
+	w.Credentials = &registry.AuthConfig{
 		Username: "user",
 	}
 	assert.Equal(t, "user", w.GetCreds().Username)
@@ -244,12 +244,12 @@ func TestWebsocketScanCommandGetImageHash(t *testing.T) {
 }
 
 func TestWebsocketScanCommandGetCredentialsList(t *testing.T) {
-	authConfig := types.AuthConfig{
+	authConfig := registry.AuthConfig{
 		Username:      "user1",
 		Password:      "password1",
 		ServerAddress: "https://registry1.com",
 	}
-	expected := []types.AuthConfig{authConfig}
+	expected := []registry.AuthConfig{authConfig}
 
 	cmd := &WebsocketScanCommand{
 		ImageScanParams: ImageScanParams{
@@ -269,12 +269,12 @@ func TestWebsocketScanCommandGetCredentialsList(t *testing.T) {
 }
 
 func TestWebsocketScanCommandSetCredentialsList(t *testing.T) {
-	authConfig := types.AuthConfig{
+	authConfig := registry.AuthConfig{
 		Username:      "user1",
 		Password:      "password1",
 		ServerAddress: "https://registry1.com",
 	}
-	expected := []types.AuthConfig{authConfig}
+	expected := []registry.AuthConfig{authConfig}
 
 	cmd := &WebsocketScanCommand{}
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/armosec/utils-go v0.0.20
 	github.com/armosec/utils-k8s-go v0.0.16
 	github.com/coreos/go-oidc v2.2.1+incompatible
-	github.com/docker/docker v24.0.5+incompatible
+	github.com/docker/docker v25.0.0+incompatible
 	github.com/francoispqt/gojay v1.2.13
 	github.com/google/uuid v1.3.0
 	github.com/stretchr/testify v1.8.4
@@ -21,8 +21,6 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/docker/go-connections v0.4.0 // indirect
-	github.com/docker/go-units v0.5.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,12 +25,8 @@ github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/docker/docker v24.0.5+incompatible h1:WmgcE4fxyI6EEXxBRxsHnZXrO1pQ3smi0k/jho4HLeY=
-github.com/docker/docker v24.0.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
-github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
-github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
-github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/docker/docker v25.0.0+incompatible h1:g9b6wZTblhMgzOT2tspESstfw6ySZ9kdm94BLDKaZac=
+github.com/docker/docker v25.0.0+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=


### PR DESCRIPTION
## **Type**
Enhancement


___

## **Description**
- Updated Docker dependency from version `v24.0.5` to `v25.0.0` in `go.mod` and `go.sum`
- Updated import path for Docker types from `github.com/docker/docker/api/types` to `github.com/docker/docker/api/types/registry` in multiple files
- Updated method signatures, struct fields, function bodies, and test cases to use the new import path


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>interfaces.go</strong><dd><code>Update Docker types import path in interfaces.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apis/interfaces.go
- Updated import path for Docker types from <br>  `github.com/docker/docker/api/types` to <br>  `github.com/docker/docker/api/types/registry`
- Updated method signatures to use the new import path
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/218/files#diff-debec5a8d755ca6ff7447da2273c5a4959bab4607997ae99fd887328d4cff8b9">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>websocketdatastructures.go</strong><dd><code>Update Docker types import path in websocketdatastructures.go</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apis/websocketdatastructures.go
- Updated import path for Docker types from <br>  `github.com/docker/docker/api/types` to <br>  `github.com/docker/docker/api/types/registry`
- Updated struct fields to use the new import path
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/218/files#diff-aabd3544557446fefee6fd0bad18ef16e5749b409dbe5157d286ab4868ff3b3b">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>websocketmethods.go</strong><dd><code>Update Docker types import path in websocketmethods.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apis/websocketmethods.go
- Updated import path for Docker types from <br>  `github.com/docker/docker/api/types` to <br>  `github.com/docker/docker/api/types/registry`
- Updated method signatures and function bodies to use the new import `<br>  `path
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/218/files#diff-a22ac9789f1fc666e0ebb9850cc11187fbb3766e5fd50757a8492996bef06f05">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Bump Docker version in go.mod</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.mod
- Updated Docker version from `v24.0.5` to `v25.0.0`
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/218/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>go.sum</strong><dd><code>Bump Docker version in go.sum</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.sum
- Updated Docker version from `v24.0.5` to `v25.0.0`
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/218/files#diff-3295df7234525439d778f1b282d146a4f1ff6b415248aaac074e8042d9f42d63">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>websocketmethods_test.go</strong><dd><code>Update Docker types import path in websocketmethods_test.go</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apis/websocketmethods_test.go
- Updated import path for Docker types from <br>  `github.com/docker/docker/api/types` to <br>  `github.com/docker/docker/api/types/registry`
- Updated test cases to use the new import path
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/218/files#diff-08326ebe57e0a8798c0b1e4e84854bcdacaa18c78a8f45d5cd56b30c12e21d70">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
