### PR TITLE
SUB-3576 - Ignore rule - the user cannot edit from "dates" to "never"…

### DIFF
--- a/armotypes/postureexceptionpolicytypes.go
+++ b/armotypes/postureexceptionpolicytypes.go
@@ -24,7 +24,7 @@ type PostureExceptionPolicy struct {
 	Resources       []identifiers.PortalDesignator  `json:"resources" bson:"resources,omitempty"`
 	PosturePolicies []PosturePolicy                 `json:"posturePolicies,omitempty" bson:"posturePolicies,omitempty"`
 	Reason          *string                         `json:"reason,omitempty" bson:"reason,omitempty"`
-	ExpirationDate  *time.Time                      `json:"expirationDate,omitempty" bson:"expirationDate,omitempty"`
+	ExpirationDate  *time.Time                      `json:"expirationDate,omitempty" bson:"expirationDate"`
 	CreatedBy       string                          `json:"createdBy,omitempty" bson:"createdBy,omitempty"`
 }
 

--- a/armotypes/vulnerabilityexceptionpolicytypes.go
+++ b/armotypes/vulnerabilityexceptionpolicytypes.go
@@ -38,7 +38,7 @@ type VulnerabilityExceptionPolicy struct {
 	// min: 1
 	VulnerabilityPolicies []VulnerabilityPolicy `json:"vulnerabilities" bson:"vulnerabilities,omitempty"`
 	Reason                string                `json:"reason,omitempty" bson:"reason,omitempty"`
-	ExpirationDate        *time.Time            `json:"expirationDate,omitempty" bson:"expirationDate,omitempty"`
+	ExpirationDate        *time.Time            `json:"expirationDate,omitempty" bson:"expirationDate"`
 	ExpiredOnFix          *bool                 `json:"expiredOnFix,omitempty" bson:"expiredOnFix,omitempty"`
 	CreatedBy             string                `json:"createdBy,omitempty" bson:"createdBy,omitempty"`
 }


### PR DESCRIPTION
## **User description**
… status


___

## **Type**
Bug fix


___

## **Description**
- This PR addresses a bug where the user could not edit the `ExpirationDate` field from "dates" to "never" status.
- The `omitempty` tag has been removed from the `ExpirationDate` field in both the `PostureExceptionPolicy` and `VulnerabilityExceptionPolicy` structs.
- This change ensures that the `ExpirationDate` field is always present in the serialized JSON, even if its value is null.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>postureexceptionpolicytypes.go</strong><dd><code>Update ExpirationDate field in PostureExceptionPolicy struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/postureexceptionpolicytypes.go
- Removed the `omitempty` tag from the `ExpirationDate` field in the <br>  `PostureExceptionPolicy` struct.
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/219/files#diff-43b0aa7c3fe4a631648481af18411e1e75cbe507d842245ca971a41028c586e9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>vulnerabilityexceptionpolicytypes.go</strong><dd><code>Update ExpirationDate field in VulnerabilityExceptionPolicy struct</code></dd></summary>
<hr>

armotypes/vulnerabilityexceptionpolicytypes.go
- Removed the `omitempty` tag from the `ExpirationDate` field in the <br>  `VulnerabilityExceptionPolicy` struct.
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/219/files#diff-b736e009b22035944c5c2a0c5cbccade1886251511ee70d252a9cf0f95a0ba4e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
