### PR TITLE
SUB-4015 - change risk factors internet facing

### DIFF
--- a/armotypes/common.go
+++ b/armotypes/common.go
@@ -9,7 +9,7 @@ type GUID string
 type RiskFactor string
 
 const (
-	RiskFactorInternetFacing RiskFactor = "Internet facing"
+	RiskFactorExternalFacing RiskFactor = "External facing"
 	RiskFactorPrivileged     RiskFactor = "Privileged"
 	RiskFactorSecretAccess   RiskFactor = "Secret access"
 	RiskFactorDataAccess     RiskFactor = "Data access"
@@ -17,7 +17,7 @@ const (
 )
 
 var RiskFactorMapping = map[string]RiskFactor{
-	"C-0256": RiskFactorInternetFacing,
+	"C-0256": RiskFactorExternalFacing,
 	"C-0046": RiskFactorPrivileged,
 	"C-0057": RiskFactorPrivileged,
 	"C-0255": RiskFactorSecretAccess,

--- a/armotypes/common_test.go
+++ b/armotypes/common_test.go
@@ -14,7 +14,7 @@ func TestGetControlIDsByRiskFactors(t *testing.T) {
 	}{
 		{
 			name:     "Single Risk Factor",
-			input:    "Internet facing",
+			input:    "External facing",
 			expected: []string{"C-0256"},
 		},
 		{
@@ -64,7 +64,7 @@ func TestGetRiskFactors(t *testing.T) {
 		{
 			name:     "Multiple Risk Factors",
 			input:    []string{"C-0256", "C-0046", "C-0057", "C-0255"},
-			expected: []RiskFactor{RiskFactorInternetFacing, RiskFactorPrivileged, RiskFactorSecretAccess},
+			expected: []RiskFactor{RiskFactorExternalFacing, RiskFactorPrivileged, RiskFactorSecretAccess},
 		},
 		{
 			name:     "Empty controls list",
@@ -79,7 +79,7 @@ func TestGetRiskFactors(t *testing.T) {
 		{
 			name:     "Single Risk Factor",
 			input:    []string{"C-0256"},
-			expected: []RiskFactor{RiskFactorInternetFacing},
+			expected: []RiskFactor{RiskFactorExternalFacing},
 		},
 		{
 			name:     "No Risk Factors",


### PR DESCRIPTION
## **Type**
Enhancement


___

## **Description**
- The risk factor 'Internet Facing' has been renamed to 'External Facing' in the `common.go` file.
- The `RiskFactorMapping` has been updated to reflect this change.
- Corresponding test cases in `common_test.go` have been updated to use the new risk factor name.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Variables renaming</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>common.go</strong><dd><code>Renamed Risk Factor from 'Internet Facing' to 'External Facing'</code>&nbsp; &nbsp; </dd></summary>
<hr>

armotypes/common.go
- Renamed `RiskFactorInternetFacing` to `RiskFactorExternalFacing`.
- Updated `RiskFactorMapping` to reflect the new risk factor name.
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/222/files#diff-b068a137ca7a626e7b47f1ad240412c08daea90099c2e9851e9df06c9cb35412">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>common_test.go</strong><dd><code>Updated Test Cases for Risk Factor Renaming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/common_test.go
- Updated test cases to reflect the new risk factor name.
    </details>
  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/222/files#diff-ef6aa77a2e42be16d61cc6bfc317f1cec15585e73045056ad145fdfc9a76d6b3">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
