### PR TITLE
SUB-3576 - Ignore rule - the user cannot edit from "dates" to "never"…

### DIFF
--- a/armotypes/postureexceptionpolicytypes.go
+++ b/armotypes/postureexceptionpolicytypes.go
@@ -24,7 +24,7 @@ type PostureExceptionPolicy struct {
 	Resources       []identifiers.PortalDesignator  `json:"resources" bson:"resources,omitempty"`
 	PosturePolicies []PosturePolicy                 `json:"posturePolicies,omitempty" bson:"posturePolicies,omitempty"`
 	Reason          *string                         `json:"reason,omitempty" bson:"reason,omitempty"`
-	ExpirationDate  *time.Time                      `json:"expirationDate,omitempty" bson:"expirationDate,omitempty"`
+	ExpirationDate  *time.Time                      `json:"expirationDate,omitempty" bson:"expirationDate"`
 	CreatedBy       string                          `json:"createdBy,omitempty" bson:"createdBy,omitempty"`
 }
 

--- a/armotypes/vulnerabilityexceptionpolicytypes.go
+++ b/armotypes/vulnerabilityexceptionpolicytypes.go
@@ -38,7 +38,7 @@ type VulnerabilityExceptionPolicy struct {
 	// min: 1
 	VulnerabilityPolicies []VulnerabilityPolicy `json:"vulnerabilities" bson:"vulnerabilities,omitempty"`
 	Reason                string                `json:"reason,omitempty" bson:"reason,omitempty"`
-	ExpirationDate        *time.Time            `json:"expirationDate,omitempty" bson:"expirationDate,omitempty"`
+	ExpirationDate        *time.Time            `json:"expirationDate" bson:"expirationDate,omitempty"`
 	ExpiredOnFix          *bool                 `json:"expiredOnFix,omitempty" bson:"expiredOnFix,omitempty"`
 	CreatedBy             string                `json:"createdBy,omitempty" bson:"createdBy,omitempty"`
 }


### PR DESCRIPTION
## **User description**
… status


___

## **Type**
bug_fix


___

## **Description**
- Fixed an issue where `ExpirationDate` was not always serialized in BSON for both `PostureExceptionPolicy` and `VulnerabilityExceptionPolicy`.
- Ensured consistency in the serialization of `ExpirationDate` across different policy types.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>postureexceptionpolicytypes.go</strong><dd><code>Ensure ExpirationDate Serialization in PostureExceptionPolicy</code></dd></summary>
<hr>

armotypes/postureexceptionpolicytypes.go
<li>Made <code>ExpirationDate</code> BSON serialization always required in <br><code>PostureExceptionPolicy</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/237/files#diff-43b0aa7c3fe4a631648481af18411e1e75cbe507d842245ca971a41028c586e9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>vulnerabilityexceptionpolicytypes.go</strong><dd><code>Adjust ExpirationDate Serialization in VulnerabilityExceptionPolicy</code></dd></summary>
<hr>

armotypes/vulnerabilityexceptionpolicytypes.go
<li>Adjusted <code>ExpirationDate</code> BSON serialization to be always required in <br><code>VulnerabilityExceptionPolicy</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/237/files#diff-b736e009b22035944c5c2a0c5cbccade1886251511ee70d252a9cf0f95a0ba4e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

