### PR TITLE
Add 'Kind' field to SecurityIssueResource struct

### DIFF
--- a/armotypes/securityrisks.go
+++ b/armotypes/securityrisks.go
@@ -91,6 +91,7 @@ type SecurityIssueResource struct {
 	Cluster   string `json:"cluster"`
 	Namespace string `json:"namespace"`
 	Name      string `json:"name"`
+	Kind      string `json:"kind"`
 }
 
 type SecurityIssuesSummary struct {


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added a new `Kind` field to the `SecurityIssueResource` struct. This field specifies the type of the Kubernetes resource, enhancing the struct's descriptiveness and utility in security risk assessments.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>securityrisks.go</strong><dd><code>Add 'Kind' Field to SecurityIssueResource Struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/securityrisks.go
<li>Added <code>Kind</code> field to <code>SecurityIssueResource</code> struct to include the type <br>of the Kubernetes resource.<br>


</details>
    

  </td>
  <td><a href="https:/armosec/armoapi-go/pull/243/files#diff-981dc5ae17066e45bdc7512f27f6bdcb6632757826f636039b2b88aaf83e8166">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

