### PR TITLE
Refactor exception policy and identifiers***

### DIFF
--- a/armotypes/exceptionpolicy.go
+++ b/armotypes/exceptionpolicy.go
@@ -2,17 +2,19 @@ package armotypes
 
 import (
 	"time"
+
+	"github.com/armosec/armoapi-go/identifiers"
 )
 
 type BaseExceptionPolicy struct {
-	ExceptionPolicyHash string `json:"exceptionPolicyHash,omitempty" bson:"exceptionPolicyHash,omitempty"`
-	PolicyType          string `json:"policyType,omitempty" bson:"policyType,omitempty"`
+	PortalBase `json:",inline" bson:"inline"`
+	PolicyType string `json:"policyType,omitempty" bson:"policyType,omitempty"`
 
 	// IDs of the policies (SecurityRiskID, ControlID, etc.)
-	PolicyIDs                []string   `json:"policyIDs,omitempty" bson:"policyIDs,omitempty"`
-	CreationTime             string     `json:"creationTime,omitempty" bson:"creationTime,omitempty"`
-	Reason                   string     `json:"reason,omitempty" bson:"reason,omitempty"`
-	ExpirationTime           *time.Time `json:"expirationTime,omitempty" bson:"expirationTime,omitempty"`
-	CreatedBy                string     `json:"createdBy,omitempty" bson:"createdBy,omitempty"`
-	ExceptionPolicyResources []Resource `json:"exceptionPolicyResources,omitempty" bson:"exceptionPolicyResources,omitempty"`
+	PolicyIDs      []string                       `json:"policyIDs,omitempty" bson:"policyIDs,omitempty"`
+	CreationTime   string                         `json:"creationTime,omitempty" bson:"creationTime,omitempty"`
+	Reason         string                         `json:"reason,omitempty" bson:"reason,omitempty"`
+	ExpirationTime *time.Time                     `json:"expirationTime,omitempty" bson:"expirationTime,omitempty"`
+	CreatedBy      string                         `json:"createdBy,omitempty" bson:"createdBy,omitempty"`
+	Resources      []identifiers.PortalDesignator `json:"resources" bson:"resources,omitempty"`
 }

--- a/identifiers/designators.go
+++ b/identifiers/designators.go
@@ -135,13 +135,14 @@ var IgnoreLabels = []string{AttributeCluster, AttributeNamespace}
 
 // AttributeDesignators describe a kubernetes object, with its labels.
 type AttributesDesignators struct {
-	cluster    string
-	namespace  string
-	kind       string
-	name       string
-	path       string
-	labels     map[string]string
-	resourceID string
+	cluster         string
+	namespace       string
+	kind            string
+	name            string
+	path            string
+	labels          map[string]string
+	resourceID      string
+	k8sResourceHash string
 }
 
 func CalcResourceHash(customerGUID string, identifiers map[string]string) string {

--- a/identifiers/designators_methods.go
+++ b/identifiers/designators_methods.go
@@ -40,6 +40,12 @@ func (designator *PortalDesignator) GetResourceID() string {
 	return attributes.resourceID
 }
 
+func (designator *PortalDesignator) GetK8sResourceHash() string {
+	attributes := designator.DigestPortalDesignator()
+	return attributes.k8sResourceHash
+
+}
+
 // DigestPortalDesignator - get cluster namespace and labels from designator
 func (designator *PortalDesignator) DigestPortalDesignator() AttributesDesignators {
 	switch designator.DesignatorType {
@@ -85,6 +91,8 @@ func (designator *PortalDesignator) DigestAttributesDesignator() AttributesDesig
 			attributes.path = v
 		case AttributeResourceID:
 			attributes.resourceID = v
+		case AttributeK8sResourceHash:
+			attributes.k8sResourceHash = v
 		default:
 			attributes.labels[k] = v
 		}

--- a/identifiers/designators_methods_test.go
+++ b/identifiers/designators_methods_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var attribute = map[string]string{AttributeCluster: "cluster1", AttributeNamespace: "namespace1", AttributeKind: "kind1", AttributeName: "name1", AttributePath: "path1", AttributeResourceID: "resourceID1"}
+var attribute = map[string]string{AttributeCluster: "cluster1", AttributeNamespace: "namespace1", AttributeKind: "kind1", AttributeName: "name1", AttributePath: "path1", AttributeResourceID: "resourceID1", AttributeK8sResourceHash: "12345"}
 var portalDesignator = PortalDesignator{DesignatorType: DesignatorAttribute, Attributes: attribute}
 
 func TestGetCluster(t *testing.T) {
@@ -46,6 +46,12 @@ func TestGetResourceID(t *testing.T) {
 	er := attribute[AttributeResourceID]
 	path := portalDesignator.GetResourceID()
 	assert.Equal(t, er, path)
+}
+
+func TestGetK8sResourceHash(t *testing.T) {
+	er := attribute[AttributeK8sResourceHash]
+	id := portalDesignator.GetK8sResourceHash()
+	assert.Equal(t, er, id)
 }
 
 func TestAttributesDesignatorsFromWLID(t *testing.T) {

--- a/identifiers/utils.go
+++ b/identifiers/utils.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"hash/fnv"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 // CalcHashFNV calculates the hash (FNV) of the string
@@ -19,8 +21,11 @@ func CalcResourceHashFNV(customerGUID, cluster, kind, name, namespace, apiVersio
 
 }
 
-func CalcSecurityRiskExceptionHash(customerGUID, securityRiskID string) string {
-	strLower := strings.ToLower(fmt.Sprintf("%s/%s", customerGUID, securityRiskID))
-	return CalcHashFNV(strLower)
+func GenerateExceptionUID() (string, error) {
+	newUUID, err := uuid.NewUUID()
+	if err != nil {
+		return "", err
+	}
 
+	return newUUID.String(), nil
 }


### PR DESCRIPTION
## **Type**
enhancement, bug_fix


___

## **Description**
- Refactored `BaseExceptionPolicy` to use `PortalBase` and updated resource references to use `identifiers.PortalDesignator`.
- Extended `AttributesDesignators` with a new field `k8sResourceHash` to enhance Kubernetes resource identification.
- Introduced a new method `GetK8sResourceHash` in `PortalDesignator` for accessing Kubernetes resource hash values.
- Updated tests to include new `AttributeK8sResourceHash` and added a specific test for the new hash retrieval method.
- Replaced the exception hash calculation method with a new UUID generation function for exception identifiers.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>exceptionpolicy.go</strong><dd><code>Refactor BaseExceptionPolicy Structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/exceptionpolicy.go
<li>Integrated <code>PortalBase</code> struct into <code>BaseExceptionPolicy</code>.<br> <li> Replaced <code>ExceptionPolicyResources</code> with <code>Resources</code> of type <br><code>[]identifiers.PortalDesignator</code>.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/247/files#diff-caad82220352ce147efd4dd0a9c88fe53f490b95f422f245566071bcf50281e9">+10/-8</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>designators.go</strong><dd><code>Extend AttributesDesignators with k8sResourceHash</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

identifiers/designators.go
- Added `k8sResourceHash` field to `AttributesDesignators`.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/247/files#diff-1fa951f2afa0b1a811fe2233157fcf72c968052a5b1e2e5460f3987d11424aad">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>designators_methods.go</strong><dd><code>Add K8sResourceHash Handling in Designator Methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

identifiers/designators_methods.go
<li>Added <code>GetK8sResourceHash</code> method to <code>PortalDesignator</code>.<br> <li> Included handling for <code>AttributeK8sResourceHash</code> in <br><code>DigestAttributesDesignator</code>.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/247/files#diff-c881b21a73e7954883e31c62957d9e99092b0c5c9a5d818cb853b3296317bf41">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>utils.go</strong><dd><code>Replace Exception Hash Calculation with UUID Generation</code>&nbsp; &nbsp; </dd></summary>
<hr>

identifiers/utils.go
<li>Removed <code>CalcSecurityRiskExceptionHash</code> function.<br> <li> Added <code>GenerateExceptionUID</code> function using UUID.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/247/files#diff-5b7ab5d6e5e09e0926a897d5b035904fb8e139a9aca621d2c125967287ea15b2">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>designators_methods_test.go</strong><dd><code>Update Tests to Cover K8sResourceHash</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

identifiers/designators_methods_test.go
<li>Updated test data to include <code>AttributeK8sResourceHash</code>.<br> <li> Added a test for <code>GetK8sResourceHash</code>.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/247/files#diff-12cd41b32373e189376f67d48c0faa180148c8a9b234d10fc9cdafdce1131805">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

