### PR TITLE
Add user input commands to armotypes package

### DIFF
--- a/armotypes/userinputcommands.go
+++ b/armotypes/userinputcommands.go
@@ -1,0 +1,28 @@
+package armotypes
+
+const (
+	// msgKeys
+	CommandKey            = "command"
+	UserInputMessageIDKey = "userInputMessageID"
+	ErrorKey              = "error"
+	ReplyTopicKey         = "replyTopic"
+	TimestampKey          = "timestamp"
+)
+
+type UserInputCommand string
+
+const (
+	UserInputCommandDeleteCluster                               = UserInputCommand("delete-cluster")
+	UserInputCommandDeleteAllCustomerData                       = UserInputCommand("delete-all-customer-data")
+	UserInputCommandMarkForDeletionRegistryScan                 = UserInputCommand("mark-for-deletion-registry-scan")
+	UserInputCommandStoreContainerScanningSummaryStub           = UserInputCommand("store-container-scanning-summary-stub")
+	UserInputCommandMarkForDeletionKubernetesResources          = UserInputCommand("mark-for-deletion-kubernetes-resources")
+	UserInputCommandMarkForDeletionContainerScanSummary         = UserInputCommand("mark-for-deletion-container-scan-summary")
+	UserInputCommandMarkForDeletionClusterPostureReport         = UserInputCommand("mark-for-deletion-cluster-posture-report")
+	UserInputCommandMarkForDeletionRepositoryPostureReport      = UserInputCommand("mark-for-deletion-repository-posture-report")
+	UserInputCommandMarkForDeletionRegistryScanVulnerabilities  = UserInputCommand("mark-for-deletion-registry-scan-vulnerabilities")
+	UserInputCommandMarkForDeletionContainerScanVulnerabilities = UserInputCommand("mark-for-deletion-container-scan-vulnerabilities")
+	UserInputCommandStoreExceptionSecurityRisk                  = UserInputCommand("store-exception-security-risk")
+	UserInputCommandUpdateExceptionSecurityRisk                 = UserInputCommand("update-exception-security-risk")
+	UserInputCommandMarkForDeletionExceptionSecurityRisk        = UserInputCommand("mark-for-deletion-exception-security-risk")
+)


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Introduced a new set of user input commands in the `armotypes` package to support various operations like deleting clusters, customer data, and handling security risks.
- Defined essential message keys and a new string type `UserInputCommand` for better structuring and handling of user commands.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>userinputcommands.go</strong><dd><code>Add User Input Commands for Operations in armotypes Package</code></dd></summary>
<hr>

armotypes/userinputcommands.go
<li>Introduced constants for message keys such as <code>CommandKey</code>, <br><code>UserInputMessageIDKey</code>, <code>ErrorKey</code>, <code>ReplyTopicKey</code>, and <code>TimestampKey</code>.<br> <li> Defined <code>UserInputCommand</code> type as a string.<br> <li> Added various user input commands like <code>UserInputCommandDeleteCluster</code>, <br><code>UserInputCommandDeleteAllCustomerData</code>, and others for different <br>deletion and update operations.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/248/files#diff-139479ccac2050d5c9bb43957900e06f49a83958b9938c908d974cda9f696cf5">+28/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

