### PR TITLE
Update SecurityIssue struct in securityrisks.go

### DIFF
--- a/armotypes/securityrisks.go
+++ b/armotypes/securityrisks.go
@@ -150,15 +150,16 @@ type ISecurityIssue interface {
 }
 
 type SecurityIssue struct {
-	ISecurityIssue  `json:",inline,omitempty"`
-	Cluster         string   `json:"cluster"`
-	Namespace       string   `json:"namespace"`
-	ResourceName    string   `json:"resourceName"`
-	Kind            string   `json:"kind"`
-	ResourceID      string   `json:"resourceID"`
-	K8sResourceHash string   `json:"k8sResourceHash"`
-	RiskID          string   `json:"riskID"` // controlID/attackTrackID
-	RiskType        RiskType `json:"riskType,omitempty"`
+	ISecurityIssue   `json:",inline,omitempty"`
+	Cluster          string   `json:"cluster"`
+	ClusterShortName string   `json:"clusterShortName"`
+	Namespace        string   `json:"namespace"`
+	ResourceName     string   `json:"resourceName"`
+	Kind             string   `json:"kind"`
+	ResourceID       string   `json:"resourceID"`
+	K8sResourceHash  string   `json:"k8sResourceHash"`
+	RiskID           string   `json:"riskID"` // controlID/attackTrackID
+	RiskType         RiskType `json:"riskType,omitempty"`
 
 	SecurityRiskID string `json:"securityRiskID"`
 


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Introduced a new field `ClusterShortName` to the `SecurityIssue` struct in `securityrisks.go` to provide more granular identification of clusters in security risk assessments.
- This change allows for better differentiation and handling of security issues across clusters with potentially similar names or in large environments where clusters are numerous and diversely named.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>securityrisks.go</strong><dd><code>Add ClusterShortName to SecurityIssue Struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/securityrisks.go
<li>Added <code>ClusterShortName</code> field to <code>SecurityIssue</code> struct.<br> <li> No fields were removed, ensuring backward compatibility.<br> <li> Enhanced the data model to support more detailed cluster <br>identification.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/251/files#diff-981dc5ae17066e45bdc7512f27f6bdcb6632757826f636039b2b88aaf83e8166">+10/-9</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

