### PR TITLE
Add methods to get and set cluster names in SecurityIssue struct

### DIFF
--- a/armotypes/securityrisks.go
+++ b/armotypes/securityrisks.go
@@ -147,6 +147,10 @@ func NewSecurityIssuesSeverities() SecurityIssuesSeverities {
 }
 
 type ISecurityIssue interface {
+	GetClusterName() string
+	GetShortClusterName() string
+	SetClusterName(string)
+	SetShortClusterName(string)
 }
 
 type SecurityIssue struct {
@@ -171,6 +175,22 @@ type SecurityIssue struct {
 	LastTimeResolved string `json:"lastTimeResolved,omitempty"`
 
 	ExceptionApplied bool `json:"exceptionApplied"`
+}
+
+func (si *SecurityIssue) GetClusterName() string {
+	return si.Cluster
+}
+
+func (si *SecurityIssue) GetShortClusterName() string {
+	return si.ClusterShortName
+}
+
+func (si *SecurityIssue) SetClusterName(clusterName string) {
+	si.Cluster = clusterName
+}
+
+func (si *SecurityIssue) SetShortClusterName(clusterShortName string) {
+	si.ClusterShortName = clusterShortName
 }
 
 type SecurityIssueControl struct {


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Introduced methods to get (`GetClusterName()`, `GetShortClusterName()`) and set (`SetClusterName(string)`, `SetShortClusterName(string)`) cluster names in the `SecurityIssue` struct.
- Enhanced the `ISecurityIssue` interface to include the newly added methods.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>securityrisks.go</strong><dd><code>Extend SecurityIssue with Cluster Name Accessors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/securityrisks.go
<li>Added <code>GetClusterName()</code> and <code>GetShortClusterName()</code> methods to <br><code>SecurityIssue</code> struct.<br> <li> Added <code>SetClusterName(string)</code> and <code>SetShortClusterName(string)</code> methods <br>to <code>SecurityIssue</code> struct.<br> <li> Extended <code>ISecurityIssue</code> interface with new methods for getting and <br>setting cluster names.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/255/files#diff-981dc5ae17066e45bdc7512f27f6bdcb6632757826f636039b2b88aaf83e8166">+20/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

