### PR TITLE
Refactor SecurityIssue methods to use pointer receiver

### DIFF
--- a/armotypes/securityrisks.go
+++ b/armotypes/securityrisks.go
@@ -177,19 +177,19 @@ type SecurityIssue struct {
 	ExceptionApplied bool `json:"exceptionApplied"`
 }
 
-func (si SecurityIssue) GetClusterName() string {
+func (si *SecurityIssue) GetClusterName() string {
 	return si.Cluster
 }
 
-func (si SecurityIssue) GetShortClusterName() string {
+func (si *SecurityIssue) GetShortClusterName() string {
 	return si.ClusterShortName
 }
 
-func (si SecurityIssue) SetClusterName(clusterName string) {
+func (si *SecurityIssue) SetClusterName(clusterName string) {
 	si.Cluster = clusterName
 }
 
-func (si SecurityIssue) SetShortClusterName(clusterShortName string) {
+func (si *SecurityIssue) SetShortClusterName(clusterShortName string) {
 	si.ClusterShortName = clusterShortName
 }
 

--- a/armotypes/securityrisks_test.go
+++ b/armotypes/securityrisks_test.go
@@ -1,0 +1,78 @@
+package armotypes
+
+import (
+	"testing"
+)
+
+var securityIssueControl = SecurityIssueControl{
+	SecurityIssue: SecurityIssue{
+		Cluster:          "cluster1",
+		ClusterShortName: "clusterShortName1",
+	},
+}
+
+var securityIssueAttackPath = SecurityIssueAttackPath{
+	SecurityIssue: SecurityIssue{
+		Cluster:          "cluster1",
+		ClusterShortName: "clusterShortName1",
+	},
+}
+
+func checkISecurityIssueControlGetClusterName(test ISecurityIssue) string {
+	return test.GetClusterName()
+
+}
+
+func TestSecurityIssueControl(t *testing.T) {
+	// Test for the SecurityIssueControl struct
+	if securityIssueControl.Cluster != "cluster1" {
+		t.Errorf("Expected %s, got %s", "cluster1", securityIssueControl.Cluster)
+	}
+	if securityIssueControl.ClusterShortName != "clusterShortName1" {
+		t.Errorf("Expected %s, got %s", "clusterShortName1", securityIssueControl.ClusterShortName)
+	}
+
+	securityIssueControl.SetClusterName("cluster2")
+
+	if securityIssueControl.GetClusterName() != "cluster2" {
+		t.Errorf("Expected %s, got %s", "cluster2", securityIssueControl.Cluster)
+	}
+
+	securityIssueControl.SetShortClusterName("clusterShortName2")
+
+	if securityIssueControl.GetShortClusterName() != "clusterShortName2" {
+		t.Errorf("Expected %s, got %s", "clusterShortName2", securityIssueControl.ClusterShortName)
+	}
+
+	// Test for the ISecurityIssue interface
+	if checkISecurityIssueControlGetClusterName(&securityIssueControl) != "cluster2" {
+		t.Errorf("Expected %s, got %s", "cluster2", securityIssueControl.Cluster)
+	}
+
+	// Test for the SecurityIssueAttackPath struct
+	if securityIssueAttackPath.Cluster != "cluster1" {
+		t.Errorf("Expected %s, got %s", "cluster1", securityIssueAttackPath.Cluster)
+	}
+
+	if securityIssueAttackPath.ClusterShortName != "clusterShortName1" {
+		t.Errorf("Expected %s, got %s", "clusterShortName1", securityIssueAttackPath.ClusterShortName)
+	}
+
+	securityIssueAttackPath.SetClusterName("cluster2")
+
+	if securityIssueAttackPath.GetClusterName() != "cluster2" {
+		t.Errorf("Expected %s, got %s", "cluster2", securityIssueAttackPath.Cluster)
+	}
+
+	securityIssueAttackPath.SetShortClusterName("clusterShortName2")
+
+	if securityIssueAttackPath.GetShortClusterName() != "clusterShortName2" {
+		t.Errorf("Expected %s, got %s", "clusterShortName2", securityIssueAttackPath.ClusterShortName)
+	}
+
+	// Test for the ISecurityIssue interface
+	if checkISecurityIssueControlGetClusterName(&securityIssueAttackPath) != "cluster2" {
+		t.Errorf("Expected %s, got %s", "cluster2", securityIssueAttackPath.Cluster)
+	}
+
+}


### PR DESCRIPTION
## **Type**
enhancement, tests


___

## **Description**
- Refactored `SecurityIssue` methods in `securityrisks.go` to use pointer receivers for improved efficiency and consistency.
- Introduced comprehensive tests in `securityrisks_test.go` to validate the functionality of the `SecurityIssue` and `SecurityIssueControl` structs, including their methods `GetClusterName`, `GetShortClusterName`, `SetClusterName`, and `SetShortClusterName`.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>securityrisks.go</strong><dd><code>Refactor SecurityIssue Methods to Use Pointer Receivers</code>&nbsp; &nbsp; </dd></summary>
<hr>

armotypes/securityrisks.go
- Refactored `SecurityIssue` methods to use pointer receivers.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/257/files#diff-981dc5ae17066e45bdc7512f27f6bdcb6632757826f636039b2b88aaf83e8166">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>securityrisks_test.go</strong><dd><code>Add Tests for SecurityIssue Struct and Methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/securityrisks_test.go
<li>Added tests for <code>SecurityIssue</code> and <code>SecurityIssueControl</code> structs.<br> <li> Tested <code>GetClusterName</code>, <code>GetShortClusterName</code>, <code>SetClusterName</code>, and <br><code>SetShortClusterName</code> methods.<br> <li> Validated the functionality of pointer receivers in <code>SecurityIssue</code> <br>methods.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/257/files#diff-3201d36dfe93d7fd762e137b2b3933d2ee6a304a764a0ec7073e843941c9449c">+78/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

