### PR TITLE
minor fix - allow field to be omitempty

### DIFF
--- a/armotypes/attackchainstypes.go
+++ b/armotypes/attackchainstypes.go
@@ -56,7 +56,7 @@ type RelatedResource struct {
 	identifiers.PortalDesignator `json:",inline" bson:",inline"`
 	Clickable                    bool              `json:"clickable,omitempty" bson:"clickable,omitempty"`
 	EdgeText                     []string          `json:"edgeText,omitempty" bson:"edgeText,omitempty"`
-	RelatedResources             []RelatedResource `json:"relatedResources" bson:"relatedResources,omitempty"`
+	RelatedResources             []RelatedResource `json:"relatedResources,omitempty" bson:"relatedResources,omitempty"`
 }
 
 type Vulnerabilities struct {


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Updated `RelatedResources` field in `RelatedResource` struct to include `omitempty` tag for JSON serialization, enhancing data handling and storage efficiency.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>attackchainstypes.go</strong><dd><code>Improve Serialization of RelatedResources Field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/attackchainstypes.go
- Made `RelatedResources` field omitempty for JSON serialization.



</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/259/files#diff-5595620c8c60f0885933079675b1c26cb5ae01121f9cabaac12b8587340bd334">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

