### PR TITLE
SUB-2558 | remove workload hash

### DIFF
--- a/armotypes/vulnerabilitytypes.go
+++ b/armotypes/vulnerabilitytypes.go
@@ -84,7 +84,6 @@ type ImageSummary struct {
 	Clusters        []string            `json:"clusters"`
 	Namespaces      []string            `json:"namespaces"`
 	Workloads       []string            `json:"workloads"`
-	WorkloadsHash   []string            `json:"workloadsHash"`
 	Kinds           []string            `json:"kinds"`
 	Containers      []string            `json:"containers"`
 	SeverityStats   map[string][]string `json:"severityStats"`


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Removed the `WorkloadsHash` field from the `ImageSummary` struct in `armotypes/vulnerabilitytypes.go` to simplify data structures and potentially improve performance.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vulnerabilitytypes.go</strong><dd><code>Remove WorkloadsHash Field from ImageSummary Struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/vulnerabilitytypes.go
- Removed `WorkloadsHash` field from `ImageSummary` struct.



</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/261/files#diff-cac55976184cdb0c77ddde7ecbabd7411490f34df3e11868dd0e67e370c01830">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

