### PR TITLE
Add ResourcesDeletedLastChange field to SecurityIssuesSummary struct

### DIFF
--- a/armotypes/securityrisks.go
+++ b/armotypes/securityrisks.go
@@ -105,6 +105,9 @@ type SecurityIssuesSummary struct {
 	AffectedResourcesChange          int        `json:"affectedResourcesChange"`
 	ResourcesDetectedLastChange      []Resource `json:"resourcesDetectedLastChange"`
 	ResourcesResolvedLastChange      []Resource `json:"resourcesResolvedLastChange"`
+
+	// resources that are resolved because of a kubernetes resource deletion
+	ResourcesDeletedLastChange []Resource `json:"resourcesDeletedLastChange"`
 }
 
 type SecurityIssuesCategories struct {
@@ -203,6 +206,7 @@ type SecurityIssueControl struct {
 type SecurityIssueAttackPath struct {
 	SecurityIssue `json:",inline"`
 	AttackChainID string `json:"attackChainID"`
+	FirstSeen     string `json:"firstSeen"`
 }
 
 type SecurityRiskExceptionPolicy struct {


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Introduced a new field `ResourcesDeletedLastChange` in the `SecurityIssuesSummary` struct. This field is designed to keep track of resources that have been resolved as a result of their deletion in Kubernetes, enhancing the visibility into the lifecycle of security issues.
- Added a `FirstSeen` field to the `SecurityIssueAttackPath` struct, allowing for the tracking of when an attack path was first detected. This addition aims to provide more detailed insights into the timeline of security threats.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>securityrisks.go</strong><dd><code>Add Tracking for Deleted Resources and Attack Path First Seen</code></dd></summary>
<hr>

armotypes/securityrisks.go
<li>Added <code>ResourcesDeletedLastChange</code> field to <code>SecurityIssuesSummary</code> struct <br>to track resources resolved due to deletion.<br> <li> Added <code>FirstSeen</code> field to <code>SecurityIssueAttackPath</code> struct to track the <br>first detection time of an attack path.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/262/files#diff-981dc5ae17066e45bdc7512f27f6bdcb6632757826f636039b2b88aaf83e8166">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

