### PR TITLE
add FixByNetworkPolicy indicator

### DIFF
--- a/armotypes/posturetypes.go
+++ b/armotypes/posturetypes.go
@@ -207,6 +207,7 @@ type PostureControlSummary struct {
 	HighlightPathsCount            int64                        `json:"highlightPathsCount"`
 	ClusterShortName               string                       `json:"clusterShortName"`
 	SupportsSmartRemediation       bool                         `json:"supportsSmartRemediation"`
+	FixByNetworkPolicy             bool                         `json:"fixByNetworkPolicy"`
 }
 
 //---------/api/v1/posture/resources


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added a new boolean field `FixByNetworkPolicy` to the `PostureControlSummary` struct in `posturetypes.go`. This field indicates whether a posture control can be fixed by applying a network policy.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>posturetypes.go</strong><dd><code>Add FixByNetworkPolicy Field to PostureControlSummary</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/posturetypes.go
<li>Added <code>FixByNetworkPolicy</code> boolean field to <code>PostureControlSummary</code> <br>struct.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/264/files#diff-35bbbb735be368155d69386277b5f780dde467befe3715c97e402b5883bdeeff">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

