### PR TITLE
Missing runtime info reason

### DIFF
--- a/armotypes/networkpolicies.go
+++ b/armotypes/networkpolicies.go
@@ -2,21 +2,33 @@ package armotypes
 
 type NetworkPolicyStatus int
 
+type MissingRuntimeInfoReason int
+
 const (
 	MissingRuntimeInfo    NetworkPolicyStatus = 1
 	NetworkPolicyRequired NetworkPolicyStatus = 2
 	NetworkPolicyApplied  NetworkPolicyStatus = 3
 )
 
+// MissingRuntimeInfoReason is used to store the reason why the runtime information is missing
+const (
+	UnknownReason            MissingRuntimeInfoReason = 0
+	RestartRequired          MissingRuntimeInfoReason = 1
+	UnscheduledNodeAgentPods MissingRuntimeInfoReason = 2
+	IncompatibleKernel       MissingRuntimeInfoReason = 3
+	RuncNotFound             MissingRuntimeInfoReason = 4
+)
+
 // NetworkPoliciesWorkload is used store information about workloads
 // in the customer's clusters related to the NetworkPolicies feature
 type NetworkPoliciesWorkload struct {
-	Name                       string              `json:"name"`
-	Kind                       string              `json:"kind"`
-	CustomerGUID               string              `json:"customerGUID"`
-	Namespace                  string              `json:"namespace"`
-	ClusterName                string              `json:"cluster"`
-	ClusterShortName           string              `json:"clusterShortName"`
-	NetworkPolicyStatus        NetworkPolicyStatus `json:"networkPolicyStatus"`
-	NetworkPolicyStatusMessage string              `json:"networkPolicyStatusMessage"`
+	Name                       string                   `json:"name"`
+	Kind                       string                   `json:"kind"`
+	CustomerGUID               string                   `json:"customerGUID"`
+	Namespace                  string                   `json:"namespace"`
+	ClusterName                string                   `json:"cluster"`
+	ClusterShortName           string                   `json:"clusterShortName"`
+	NetworkPolicyStatus        NetworkPolicyStatus      `json:"networkPolicyStatus"`
+	NetworkPolicyStatusMessage string                   `json:"networkPolicyStatusMessage"`
+	MissingRuntimeInfoReason   MissingRuntimeInfoReason `json:"missingRuntimeInfoReason"`
 }


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Introduced a new type `MissingRuntimeInfoReason` to categorize reasons for missing runtime information in network policies.
- Defined constants for `MissingRuntimeInfoReason` including `UnknownReason`, `RestartRequired`, `UnscheduledNodeAgentPods`, `IncompatibleKernel`, and `RuncNotFound`.
- Enhanced `NetworkPoliciesWorkload` struct with a new field `MissingRuntimeInfoReason` to store the specific reason for missing runtime information.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>networkpolicies.go</strong><dd><code>Add Missing Runtime Info Reason to Network Policies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/networkpolicies.go
<li>Introduced a new type <code>MissingRuntimeInfoReason</code> with constants to <br>describe reasons for missing runtime information.<br> <li> Added a new field <code>MissingRuntimeInfoReason</code> to <code>NetworkPoliciesWorkload</code> <br>struct to store the reason for missing runtime information.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/267/files#diff-edffc833afef72270a9815b6c2842d3d28e3eb3cefcae82601a76c0bd97bdbb4">+20/-8</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

