### PR TITLE
Refactor notification-related test and method

### DIFF
--- a/notifications/usernotificationreporttypes_test.go
+++ b/notifications/usernotificationreporttypes_test.go
@@ -3,11 +3,12 @@ package notifications
 import (
 	"encoding/json"
 	"fmt"
-	"k8s.io/utils/ptr"
 	"reflect"
 	"sort"
 	"testing"
 	"time"
+
+	"k8s.io/utils/ptr"
 
 	_ "embed"
 
@@ -740,4 +741,51 @@ func sortAlertChannelsByType(channels []AlertChannel) {
 	sort.Slice(channels, func(i, j int) bool {
 		return channels[i].ChannelType < channels[j].ChannelType
 	})
+}
+
+func TestIsEqualOrGreaterThanMinSeverity(t *testing.T) {
+	tests := []struct {
+		name     string
+		severity int
+		min      int
+		expected bool
+	}{
+		{
+			name:     "equal",
+			severity: 3,
+			min:      3,
+			expected: true,
+		},
+		{
+			name:     "greater",
+			severity: 4,
+			min:      3,
+			expected: true,
+		},
+		{
+			name:     "less",
+			severity: 2,
+			min:      3,
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			min := test.min
+			params := AlertChannel{
+				Alerts: []AlertConfig{
+					{
+						NotificationConfigIdentifier: NotificationConfigIdentifier{
+							NotificationType: NotificationTypePush,
+						},
+						Parameters: NotificationParams{
+							MinSeverity: &min,
+						},
+					},
+				},
+			}
+			assert.Equal(t, test.expected, params.IsEqualOrGreaterThanMinSeverity(test.severity, NotificationTypePush))
+		})
+	}
 }

--- a/notifications/usersnotificationsmethods.go
+++ b/notifications/usersnotificationsmethods.go
@@ -23,6 +23,25 @@ func (ac *AlertChannel) GetAlertConfig(notificationType NotificationType) *Alert
 	return nil
 }
 
+func (ac *AlertChannel) IsEqualOrGreaterThanMinSeverity(severity int, notificationType NotificationType) bool {
+	if ac.Alerts == nil {
+		return true
+	}
+
+	for _, alert := range ac.Alerts {
+		if alert.IsEnabled() && alert.NotificationType == notificationType {
+			if alert.Parameters.MinSeverity != nil {
+				if *alert.Parameters.MinSeverity > severity {
+					return false
+				}
+			}
+		}
+
+	}
+
+	return true
+}
+
 func (ac *AlertChannel) AddAlertConfig(config AlertConfig) error {
 	if config.NotificationType == "" {
 		return fmt.Errorf("notification type is required")


### PR DESCRIPTION
## **Type**
enhancement, tests


___

## **Description**
- Implemented a new method `IsEqualOrGreaterThanMinSeverity` in `AlertChannel` to support filtering alerts based on severity levels.
- Added comprehensive tests for the new severity level handling functionality in alert configurations.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>usernotificationreporttypes_test.go</strong><dd><code>Add Test for Severity Level Handling in Alert Configurations</code></dd></summary>
<hr>

notifications/usernotificationreporttypes_test.go
<li>Added a new test function <code>TestIsEqualOrGreaterThanMinSeverity</code> to <br>validate severity level handling in alert configurations.<br> <li> Imported <code>k8s.io/utils/ptr</code> for pointer utilities.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/268/files#diff-92da85d08813f4a45402cbec67a90e38c48dff5e60c62bae944e177adfe8bd41">+49/-1</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>usersnotificationsmethods.go</strong><dd><code>Implement Severity Level Check in AlertChannel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

notifications/usersnotificationsmethods.go
<li>Implemented <code>IsEqualOrGreaterThanMinSeverity</code> method in <code>AlertChannel</code> to <br>check if an alert's severity is equal or greater than a minimum <br>threshold.<br> <li> This method is used to filter alerts based on their severity level.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/268/files#diff-bd80e935c4d7aac4288a9af3ea42ff64e94e4be2fe1ab3e04acd7dea54941f42">+19/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

