### PR TITLE
Update SecurityRisk struct with SmartRemediation field

### DIFF
--- a/armotypes/securityrisks.go
+++ b/armotypes/securityrisks.go
@@ -47,15 +47,16 @@ func (rt *RiskType) UnmarshalJSON(data []byte) error {
 
 // SecurityRisk represents the main object with various fields and an array of Risks
 type SecurityRisk struct {
-	ID             string           `json:"ID"`
-	Name           string           `json:"name"`
-	Description    string           `json:"description"`
-	WhatIs         string           `json:"whatIs"`
-	Severity       string           `json:"severity"`
-	Category       string           `json:"category"`
-	Remediation    string           `json:"remediation"`
-	Risks          []Risk           `json:"risks"`
-	SecurityIssues []ISecurityIssue `json:"securityIssues,omitempty"`
+	ID              string           `json:"ID"`
+	Name            string           `json:"name"`
+	Description     string           `json:"description"`
+	WhatIs          string           `json:"whatIs"`
+	Severity        string           `json:"severity"`
+	Category        string           `json:"category"`
+	Remediation     string           `json:"remediation"`
+	Risks           []Risk           `json:"risks"`
+	SecurityIssues  []ISecurityIssue `json:"securityIssues,omitempty"`
+	SmartRemedation bool             `json:"smartRemediation"`
 }
 
 func (sr *SecurityRisk) GetRisks() []Risk {
@@ -108,6 +109,9 @@ type SecurityIssuesSummary struct {
 
 	// resources that are resolved because of a kubernetes resource deletion
 	ResourcesDeletedLastChange []Resource `json:"resourcesDeletedLastChange"`
+
+	// if True, control supports smart remediation
+	SupportsSmartRemediation bool `json:"supportsSmartRemediation"`
 }
 
 type SecurityIssuesCategories struct {


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Introduced `SmartRemediation` boolean field in `SecurityRisk` struct to signify the availability of smart remediation for security risks.
- Added `SupportsSmartRemediation` boolean field in `SecurityIssuesSummary` struct, indicating if the control supports smart remediation.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>securityrisks.go</strong><dd><code>Add Smart Remediation Support Fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/securityrisks.go
<li>Added <code>SmartRemediation</code> field to <code>SecurityRisk</code> struct to indicate if <br>smart remediation is available.<br> <li> Introduced <code>SupportsSmartRemediation</code> field in <code>SecurityIssuesSummary</code> <br>struct to denote support for smart remediation.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/270/files#diff-981dc5ae17066e45bdc7512f27f6bdcb6632757826f636039b2b88aaf83e8166">+13/-9</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

