### PR TITLE
SUB-4455 | add images field to workload summary

### DIFF
--- a/armotypes/vulnerabilitytypes.go
+++ b/armotypes/vulnerabilitytypes.go
@@ -41,6 +41,7 @@ type VulnerabilityWorkload struct {
 	RiskFactors      []RiskFactor        `json:"riskFactors"`
 	Labels           []string            `json:"labels"`
 	HasRelevancyData bool                `json:"hasRelevancyData"`
+	Images           []string            `json:"images"`
 }
 
 type ContainerPathInfo struct {


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added a new `Images` field to the `VulnerabilityWorkload` struct to store image information related to vulnerabilities. This enhancement allows for a more detailed summary of workloads by including image data.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vulnerabilitytypes.go</strong><dd><code>Add Images Field to VulnerabilityWorkload Struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/vulnerabilitytypes.go
<li>Added <code>Images</code> field to <code>VulnerabilityWorkload</code> struct to include image <br>information.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/274/files#diff-cac55976184cdb0c77ddde7ecbabd7411490f34df3e11868dd0e67e370c01830">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

