### PR TITLE
Adding correct full types for KDR

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/armosec/armoapi-go/identifiers"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type IncidentCategory string
@@ -12,6 +11,13 @@ type IncidentCategory string
 const (
 	RuntimeIncidentCategoryMalware IncidentCategory = "Malware"
 	RuntimeIncidentCategoryAnomaly IncidentCategory = "Anomaly"
+)
+
+type AlertType int
+
+const (
+	AlertTypeRule AlertType = iota
+	AlertTypeMalware
 )
 
 type RuntimeIncident struct {
@@ -43,43 +49,76 @@ type RuntimeIncidentResource struct {
 }
 
 type RuleAlert struct {
-	Severity       int    `json:"severity,omitempty" bson:"severity,omitempty"`       // PriorityToStatus(failedRule.Priority()),
-	ProcessName    string `json:"processName,omitempty" bson:"processName,omitempty"` // failedRule.Event().Comm,
+	// Rule Name
+	RuleName string `json:"ruleName,omitempty" bson:"ruleName,omitempty"`
+	// Rule ID
+	RuleID string `json:"ruleID,omitempty" bson:"ruleID,omitempty"`
+	// Severity of the alert
+	Severity int `json:"severity,omitempty" bson:"severity,omitempty"`
+	// Process name
+	ProcessName string `json:"processName,omitempty" bson:"processName,omitempty"`
+	// Command line
+	CommandLine string `json:"commandLine,omitempty" bson:"commandLine,omitempty"`
+	// Fix suggestions
 	FixSuggestions string `json:"fixSuggestions,omitempty" bson:"fixSuggestions,omitempty"`
-	PID            uint32 `json:"pid,omitempty" bson:"pid,omitempty"`   // Process ID
-	PPID           uint32 `json:"ppid,omitempty" bson:"ppid,omitempty"` //  Parent Process ID
-	UID            uint32 `json:"uid,omitempty" bson:"uid,omitempty"`   // User ID of the process
-	GID            uint32 `json:"gid,omitempty" bson:"gid,omitempty"`   // Group ID of the process
+	// Parent Process ID
+	PPID uint32 `json:"ppid,omitempty" bson:"ppid,omitempty"`
+	// PPIDComm - Parent Process Name
+	PPIDComm string `json:"ppidComm,omitempty" bson:"ppidComm,omitempty"`
+	// Is part of the image
+	IsPartOfImage bool `json:"isPartOfImage,omitempty" bson:"isPartOfImage,omitempty"`
+	// MD5 hash of the file that was infected
+	MD5Hash string `json:"md5Hash,omitempty" bson:"md5Hash,omitempty"`
+	// SHA1 hash of the file that was infected
+	SHA1Hash string `json:"sha1Hash,omitempty" bson:"sha1Hash,omitempty"`
+	// SHA256 hash of the file that was infected
+	SHA256Hash string `json:"sha256Hash,omitempty" bson:"sha256Hash,omitempty"`
 }
 
 type MalwareAlert struct {
-	MalwareName        string `json:"malwareName,omitempty" bson:"malwareName,omitempty"`
+	// Name of the malware
+	MalwareName string `json:"malwareName,omitempty" bson:"malwareName,omitempty"`
+	// Description of the malware
 	MalwareDescription string `json:"malwareDescription,omitempty" bson:"malwareDescription,omitempty"`
 	// Path to the file that was infected
 	Path string `json:"path,omitempty" bson:"path,omitempty"`
-	// Hash of the file that was infected
-	Hash string `json:"hash,omitempty" bson:"hash,omitempty"`
+	// MD5 hash of the file that was infected
+	MD5Hash string `json:"md5Hash,omitempty" bson:"md5Hash,omitempty"`
+	// SHA1 hash of the file that was infected
+	SHA1Hash string `json:"sha1Hash,omitempty" bson:"sha1Hash,omitempty"`
+	// SHA256 hash of the file that was infected
+	SHA256Hash string `json:"sha256Hash,omitempty" bson:"sha256Hash,omitempty"`
 	// Size of the file that was infected
 	Size string `json:"size,omitempty" bson:"size,omitempty"`
 	// Is part of the image
 	IsPartOfImage bool `json:"isPartOfImage,omitempty" bson:"isPartOfImage,omitempty"`
-	// K8s resource that was infected
-	Resource schema.GroupVersionResource `json:"resource,omitempty" bson:"resource,omitempty"`
-	// K8s container image that was infected
-	ContainerImage string `json:"containerImage,omitempty" bson:"containerImage,omitempty"`
+	// Severity of the malware
+	Severity int `json:"severity,omitempty" bson:"severity,omitempty"`
+	// Parent Process ID of the process that was infected
+	PPID uint32 `json:"ppid,omitempty" bson:"ppid,omitempty"`
+	// Parent Process Name of the process that was infected
+	PPIDComm string `json:"ppidComm,omitempty" bson:"ppidComm,omitempty"`
+	// Command Line of the process that was infected
+	CommandLine string `json:"commandLine,omitempty" bson:"commandLine,omitempty"`
+	// Fix suggestions
+	FixSuggestions string `json:"fixSuggestions,omitempty" bson:"fixSuggestions,omitempty"`
 }
 
 type RuntimeAlert struct {
 	RuleAlert     `json:",inline"`
 	MalwareAlert  `json:",inline"`
-	RuleName      string    `json:"ruleName" bson:"ruleName"`
-	RuleID        string    `json:"ruleID" bson:"ruleID"`
+	AlertType     AlertType `json:"alertType" bson:"alertType"`
 	Message       string    `json:"message" bson:"message"`
 	ContainerID   string    `json:"containerID,omitempty" bson:"containerID,omitempty"`
 	ContainerName string    `json:"containerName,omitempty" bson:"containerName,omitempty"`
-	PodNamespace  string    `json:"podNamespace,omitempty" bson:"podNamespace,omitempty"`
+	Namespace     string    `json:"namespace,omitempty" bson:"namespace,omitempty"`
 	PodName       string    `json:"podName,omitempty" bson:"podName,omitempty"`
+	HostNetwork   bool      `json:"hostNetwork,omitempty" bson:"hostNetwork,omitempty"`
+	Image         string    `json:"image,omitempty" bson:"image,omitempty"`
+	ImageDigest   string    `json:"imageDigest,omitempty" bson:"imageDigest,omitempty"`
 	HostName      string    `json:"hostName" bson:"hostName"`
 	NodeName      string    `json:"nodeName" bson:"nodeName"`
+	WorkloadName  string    `json:"workloadName" bson:"workloadName"`
+	WorkloadKind  string    `json:"workloadKind" bson:"workloadKind"`
 	Timestamp     time.Time `json:"timestamp" bson:"timestamp"`
 }

--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -120,5 +120,6 @@ type RuntimeAlert struct {
 	NodeName      string    `json:"nodeName" bson:"nodeName"`
 	WorkloadName  string    `json:"workloadName" bson:"workloadName"`
 	WorkloadKind  string    `json:"workloadKind" bson:"workloadKind"`
+	ClusterName   string    `json:"clusterName" bson:"clusterName"`
 	Timestamp     time.Time `json:"timestamp" bson:"timestamp"`
 }


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Introduced a new `AlertType` enum to differentiate between rule-based alerts and malware alerts.
- Expanded the `RuleAlert` and `MalwareAlert` structs to include comprehensive details about the alerts, such as command line, hash values, and fix suggestions.
- Cleaned up unused imports and fields, streamlining the data structure.
- Updated the `RuntimeAlert` struct to include alert type, additional metadata about the alert context, and detailed information about the affected resources.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Enhancements to Runtime Incident Alert Types and Details</code>&nbsp; </dd></summary>
<hr>

armotypes/runtimeincidents.go
<li>Introduced <code>AlertType</code> enum with <code>AlertTypeRule</code> and <code>AlertTypeMalware</code> <br>values.<br> <li> Enhanced <code>RuleAlert</code> and <code>MalwareAlert</code> structs with additional fields <br>such as <code>RuleName</code>, <code>RuleID</code>, <code>CommandLine</code>, <code>MD5Hash</code>, <code>SHA1Hash</code>, <code>SHA256Hash</code>, <br>and more.<br> <li> Removed unused imports and fields like <code>schema.GroupVersionResource</code>.<br> <li> Added new fields to <code>RuntimeAlert</code> struct to support differentiating <br>between rule and malware alerts, and to provide more detailed <br>information about the alert context.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/280/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+56/-17</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

