### PR TITLE
SUB-3670 | swagger ignore first seen and supportSmartRemediation fields

### DIFF
--- a/armotypes/posturetypes.go
+++ b/armotypes/posturetypes.go
@@ -206,9 +206,10 @@ type PostureControlSummary struct {
 	IsLastScan                     int                          `json:"isLastScan"`
 	HighlightPathsCount            int64                        `json:"highlightPathsCount"`
 	ClusterShortName               string                       `json:"clusterShortName"`
-	SupportsSmartRemediation       bool                         `json:"supportsSmartRemediation"` // DEPRECATED
-	SmartRemediation               bool                         `json:"smartRemediation"`
-	FixByNetworkPolicy             bool                         `json:"fixByNetworkPolicy"`
+	// swagger:ignore
+	SupportsSmartRemediation bool `json:"supportsSmartRemediation"` // DEPRECATED
+	SmartRemediation         bool `json:"smartRemediation"`
+	FixByNetworkPolicy       bool `json:"fixByNetworkPolicy"`
 }
 
 //---------/api/v1/posture/resources
@@ -297,6 +298,7 @@ type PostureResourceSummary struct {
 	ClusterShortName         string `json:"clusterShortName"`
 
 	// if True, at least one failed control supports smart remediation
+	// swagger:ignore
 	SupportsSmartRemediation bool `json:"supportsSmartRemediation"` // DEPRECATED
 	SmartRemediation         bool `json:"smartRemediation"`
 }
@@ -380,6 +382,7 @@ type ControlInfo struct {
 	FailedResources int `json:"failedResources"`
 
 	// if True, this control supports smart remediation
+	// swagger:ignore
 	SupportsSmartRemediation bool `json:"supportsSmartRemediation"` // DEPRECATED
 
 	SmartRemediation bool `json:"smartRemediation"`

--- a/armotypes/securityrisks.go
+++ b/armotypes/securityrisks.go
@@ -111,6 +111,7 @@ type SecurityIssuesSummary struct {
 	ResourcesDeletedLastChange []Resource `json:"resourcesDeletedLastChange"`
 
 	// if True, control supports smart remediation
+	// swagger:ignore
 	SupportsSmartRemediation bool `json:"supportsSmartRemediation"` // DEPRECATED
 	SmartRemediation         bool `json:"smartRemediation"`
 }

--- a/armotypes/vulnerabilitytypes.go
+++ b/armotypes/vulnerabilitytypes.go
@@ -100,13 +100,14 @@ type ImageSummary struct {
 }
 
 type VulnerabilitiesComponent struct {
-	CustomerGUID string              `json:"customerGUID"`
-	Name         string              `json:"name"`
-	Version      string              `json:"version"`
-	PackageType  string              `json:"packageType"`
-	FirstSeen    time.Time           `json:"firstSeen"` //first found in the user account (not in the world)
-	FixVersions  []string            `json:"fixVersions"`
-	PathsInfo    []ComponentPathInfo `json:"pathsInfo"`
+	CustomerGUID string `json:"customerGUID"`
+	Name         string `json:"name"`
+	Version      string `json:"version"`
+	PackageType  string `json:"packageType"`
+	// swagger:ignore
+	FirstSeen   time.Time           `json:"firstSeen"` //first found in the user account (not in the world)
+	FixVersions []string            `json:"fixVersions"`
+	PathsInfo   []ComponentPathInfo `json:"pathsInfo"`
 }
 
 type ComponentPathInfo struct {


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added `swagger:ignore` annotations to various fields across multiple structs (`PostureControlSummary`, `PostureResourceSummary`, `ControlInfo`, `SecurityIssuesSummary`, and `VulnerabilitiesComponent`) to exclude them from Swagger documentation.
- Specifically, deprecated fields related to smart remediation and the `FirstSeen` field in vulnerabilities are now ignored by Swagger, indicating a move to deprecate or change how these fields are used or exposed.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>posturetypes.go</strong><dd><code>Exclude Deprecated Fields from Swagger Documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/posturetypes.go
<li>Added <code>swagger:ignore</code> annotations to <code>SupportsSmartRemediation</code> fields in <br><code>PostureControlSummary</code>, <code>PostureResourceSummary</code>, and <code>ControlInfo</code> structs <br>to exclude them from Swagger documentation.<br> <li> These fields are marked as DEPRECATED.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/282/files#diff-35bbbb735be368155d69386277b5f780dde467befe3715c97e402b5883bdeeff">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>securityrisks.go</strong><dd><code>Exclude Deprecated Security Issues Field from Swagger</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/securityrisks.go
<li>Added <code>swagger:ignore</code> annotation to <code>SupportsSmartRemediation</code> field in <br><code>SecurityIssuesSummary</code> struct to exclude it from Swagger documentation.<br> <li> The <code>SupportsSmartRemediation</code> field is marked as DEPRECATED.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/282/files#diff-981dc5ae17066e45bdc7512f27f6bdcb6632757826f636039b2b88aaf83e8166">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>vulnerabilitytypes.go</strong><dd><code>Exclude Vulnerability First Seen Field from Swagger</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/vulnerabilitytypes.go
<li>Added <code>swagger:ignore</code> annotation to <code>FirstSeen</code> field in <br><code>VulnerabilitiesComponent</code> struct to exclude it from Swagger <br>documentation.<br> <li> This change aims to ignore the <code>FirstSeen</code> field which indicates when a <br>vulnerability was first found in the user account.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/282/files#diff-cac55976184cdb0c77ddde7ecbabd7411490f34df3e11868dd0e67e370c01830">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

