### PR TITLE
Fixing types we don't have for sure

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -92,7 +92,7 @@ type RuntimeAlertProcessDetails struct {
 	// Process Name
 	Comm string `json:"comm,omitempty" bson:"comm,omitempty"`
 	// GID of the process
-	GID uint32 `json:"gid,omitempty" bson:"gid,omitempty"`
+	GID *uint32 `json:"gid,omitempty" bson:"gid,omitempty"`
 	// Group name of the process
 	GroupName *string `json:"groupName,omitempty" bson:"groupName,omitempty"`
 	// Path to the file that was infected
@@ -100,25 +100,25 @@ type RuntimeAlertProcessDetails struct {
 	// Process ID
 	PID uint32 `json:"pid,omitempty" bson:"pid,omitempty"`
 	// UID of the process
-	UID uint32 `json:"uid,omitempty" bson:"uid,omitempty"`
+	UID *uint32 `json:"uid,omitempty" bson:"uid,omitempty"`
 	// User name of the process
 	UserName *string `json:"userName,omitempty" bson:"userName,omitempty"`
 }
 
 type RuntimeAlertK8sDetails struct {
-	ClusterName       *string `json:"clusterName" bson:"clusterName"`
-	ContainerName     string  `json:"containerName,omitempty" bson:"containerName,omitempty"`
-	HostNetwork       *bool   `json:"hostNetwork,omitempty" bson:"hostNetwork,omitempty"`
-	Image             string  `json:"image,omitempty" bson:"image,omitempty"`
-	ImageDigest       string  `json:"imageDigest,omitempty" bson:"imageDigest,omitempty"`
-	Namespace         string  `json:"namespace,omitempty" bson:"namespace,omitempty"`
-	NodeName          string  `json:"nodeName,omitempty" bson:"nodeName,omitempty"`
-	ContainerID       string  `json:"containerID,omitempty" bson:"containerID,omitempty"`
-	PodName           string  `json:"podName,omitempty" bson:"podName,omitempty"`
-	PodNamespace      string  `json:"podNamespace,omitempty" bson:"podNamespace,omitempty"`
-	WorkloadName      string  `json:"workloadName" bson:"workloadName"`
-	WorkloadNamespace string  `json:"workloadNamespace,omitempty" bson:"workloadNamespace,omitempty"`
-	WorkloadKind      string  `json:"workloadKind" bson:"workloadKind"`
+	ClusterName       string `json:"clusterName" bson:"clusterName"`
+	ContainerName     string `json:"containerName,omitempty" bson:"containerName,omitempty"`
+	HostNetwork       *bool  `json:"hostNetwork,omitempty" bson:"hostNetwork,omitempty"`
+	Image             string `json:"image,omitempty" bson:"image,omitempty"`
+	ImageDigest       string `json:"imageDigest,omitempty" bson:"imageDigest,omitempty"`
+	Namespace         string `json:"namespace,omitempty" bson:"namespace,omitempty"`
+	NodeName          string `json:"nodeName,omitempty" bson:"nodeName,omitempty"`
+	ContainerID       string `json:"containerID,omitempty" bson:"containerID,omitempty"`
+	PodName           string `json:"podName,omitempty" bson:"podName,omitempty"`
+	PodNamespace      string `json:"podNamespace,omitempty" bson:"podNamespace,omitempty"`
+	WorkloadName      string `json:"workloadName" bson:"workloadName"`
+	WorkloadNamespace string `json:"workloadNamespace,omitempty" bson:"workloadNamespace,omitempty"`
+	WorkloadKind      string `json:"workloadKind" bson:"workloadKind"`
 }
 
 type RuntimeAlert struct {


### PR DESCRIPTION
## **Type**
bug_fix, enhancement


___

## **Description**
This PR introduces changes aimed at improving the way nullable fields are handled within the `RuntimeAlertProcessDetails` and `RuntimeAlertK8sDetails` structs, alongside ensuring type consistency:
- For `RuntimeAlertProcessDetails`, fields `GID` and `UID` have been updated to pointers (`*uint32`) to better represent optional values.
- In `RuntimeAlertK8sDetails`, the `ClusterName` field has been changed from a pointer (`*string`) to a plain `string`, aligning with other similar fields.
- These changes enhance the code's ability to accurately represent optional and nullable values in runtime incident data structures.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Nullable Fields Handling and Type Consistency in Runtime Incident </code><br><code>Types</code></dd></summary>
<hr>

armotypes/runtimeincidents.go
<li>Changed <code>GID</code> and <code>UID</code> fields from <code>uint32</code> to <code>*uint32</code> to handle nullable <br>values.<br> <li> Changed <code>ClusterName</code> field from <code>*string</code> to <code>string</code>.<br> <li> Ensured consistency in handling optional fields across <br><code>RuntimeAlertProcessDetails</code> and <code>RuntimeAlertK8sDetails</code> structs.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/286/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+15/-15</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

