### PR TITLE
Add Not equal operator

### DIFF
--- a/armotypes/pagination_structs.go
+++ b/armotypes/pagination_structs.go
@@ -14,6 +14,7 @@ type RespTotal struct {
 const (
 	V2ListExistsOperator       string = "exists"
 	V2ListEqualOperator        string = "equal"
+	V2ListNotEqualOperator     string = "notequal"
 	V2ListMissingOperator      string = "missing"
 	V2ListEmptyOperator        string = "empty"
 	V2ListMatchOperator        string = "match"


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Introduced a new operator `V2ListNotEqualOperator` with the value "notequal" to enhance query capabilities.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pagination_structs.go</strong><dd><code>Add Not Equal Operator to Pagination Structs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/pagination_structs.go
- Added `V2ListNotEqualOperator` constant with the value "notequal".



</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/288/files#diff-66ee83f3f4141c588eac0a484a79f1eb421f6249193fdfeb4212edb2de7e5ea6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

