### PR TITLE
interface to map

### DIFF
--- a/notifications/integrationref.go
+++ b/notifications/integrationref.go
@@ -22,7 +22,7 @@ const (
 type IntegrationReference struct {
 	armotypes.PortalBase `json:",inline" bson:"inline"`
 	Provider             ChannelProvider     `json:"provider,omitempty" bson:"provider,omitempty"`             //integration provider (e.g jira, slack, teams)
-	ProviderData         interface{}         `json:"providerData,omitempty" bson:"providerData,omitempty"`     //integration provider data (e.g jira ticket data)
+	ProviderData         map[string]string   `json:"providerData,omitempty" bson:"providerData,omitempty"`     //integration provider data (e.g jira ticket data)
 	Type                 ReferenceType       `json:"type,omitempty" bson:"type,omitempty"`                     //type of the reference (e.g cve-ticket, slack-message etc)
 	Owner                *EntityIdentifiers  `json:"owner,omitempty" bson:"owner,omitempty"`                   //owner identifiers of this reference (e.g resourceHash, wlid)
 	RelatedObjects       EntitiesIdentifiers `json:"relatedObjects,omitempty" bson:"relatedObjects,omitempty"` //related entities identifiers of this reference (e.g cves, controls)


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Changed the type of `ProviderData` field in `IntegrationReference` struct from `interface{}` to `map[string]string` to enforce a more structured format for integration provider data.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>integrationref.go</strong><dd><code>Change ProviderData Field Type in IntegrationReference</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

notifications/integrationref.go
<li>Changed <code>ProviderData</code> field type from <code>interface{}</code> to <code>map[string]string</code> <br>in <code>IntegrationReference</code> struct.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/291/files#diff-c2b85aafaedffc508a0331728f554442605db085a97714482e6925f7c683c0ab">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

