### PR TITLE
Add "type" to entity map

### DIFF
--- a/notifications/integrationref.go
+++ b/notifications/integrationref.go
@@ -168,7 +168,9 @@ func (e *EntityIdentifiers) Validate() error {
 
 func (e *EntityIdentifiers) ToMap() map[string]string {
 	entityMap := make(map[string]string)
-	entityMap[identifiers.AttributeType] = string(e.Type)
+	if e.Type != "" {
+		entityMap[identifiers.AttributeType] = string(e.Type)
+	}
 	if e.Cluster != "" {
 		entityMap[identifiers.AttributeCluster] = e.Cluster
 	}

--- a/notifications/integrationref.go
+++ b/notifications/integrationref.go
@@ -167,8 +167,8 @@ func (e *EntityIdentifiers) Validate() error {
 }
 
 func (e *EntityIdentifiers) ToMap() map[string]string {
-	//avoid empty values
 	entityMap := make(map[string]string)
+	entityMap[identifiers.AttributeType] = string(e.Type)
 	if e.Cluster != "" {
 		entityMap[identifiers.AttributeCluster] = e.Cluster
 	}


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added `Type` to the entity map in `EntityIdentifiers.ToMap` method to include the type of the entity in the map.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>integrationref.go</strong><dd><code>Add Type to Entity Map</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

notifications/integrationref.go
<li>Added <code>Type</code> to the entity map with key <code>identifiers.AttributeType</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/293/files#diff-c2b85aafaedffc508a0331728f554442605db085a97714482e6925f7c683c0ab">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

