### PR TITLE
Add ProcessTree to RuntimeIncident struct

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -33,6 +33,7 @@ type RuntimeIncident struct {
 	MarkedAsFalsePositive bool       `json:"markedAsFalsePositive" bson:"markedAsFalsePositive"`
 	// for future use
 	RelatedResources []RuntimeIncidentResource `json:"relatedResources" bson:"relatedResources"`
+	ProcessTree      *ProcessTree              `json:"processTree,omitempty" bson:"processTree,omitempty"`
 }
 
 type RuntimeIncidentResource struct {


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added an optional `ProcessTree` field to the `RuntimeIncident` struct to enhance incident data structure, allowing for the storage of process tree information related to runtime incidents.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Add ProcessTree Field to RuntimeIncident Struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/runtimeincidents.go
<li>Added <code>ProcessTree</code> field to <code>RuntimeIncident</code> struct with JSON and BSON <br>annotations.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/294/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

