### PR TITLE
Update ExpirationTime field to ExpirationDate in BaseExceptionPolicy

### DIFF
--- a/armotypes/exceptionpolicy.go
+++ b/armotypes/exceptionpolicy.go
@@ -14,7 +14,7 @@ type BaseExceptionPolicy struct {
 	PolicyIDs      []string                       `json:"policyIDs,omitempty" bson:"policyIDs,omitempty"`
 	CreationTime   string                         `json:"creationTime,omitempty" bson:"creationTime,omitempty"`
 	Reason         string                         `json:"reason,omitempty" bson:"reason,omitempty"`
-	ExpirationTime *time.Time                     `json:"expirationTime,omitempty" bson:"expirationTime,omitempty"`
+	ExpirationDate *time.Time                     `json:"expirationDate,omitempty" bson:"expirationDate,omitempty"`
 	CreatedBy      string                         `json:"createdBy,omitempty" bson:"createdBy,omitempty"`
 	Resources      []identifiers.PortalDesignator `json:"resources" bson:"resources,omitempty"`
 }


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Renamed the field `ExpirationTime` to `ExpirationDate` in the `BaseExceptionPolicy` struct to better reflect the data type and usage.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>exceptionpolicy.go</strong><dd><code>Rename Field in BaseExceptionPolicy Struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/exceptionpolicy.go
<li>Renamed field <code>ExpirationTime</code> to <code>ExpirationDate</code> in <code>BaseExceptionPolicy</code> <br>struct.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/295/files#diff-caad82220352ce147efd4dd0a9c88fe53f490b95f422f245566071bcf50281e9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

