### PR TITLE
Remove ns validation from tickets resources owners

### DIFF
--- a/notifications/integration_test.go
+++ b/notifications/integration_test.go
@@ -50,6 +50,18 @@ func TestEntity_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Valid posture resource entity (no namespace)",
+			entity: EntityIdentifiers{
+				Type:         EntityTypePostureResource,
+				Cluster:      validBaseEntity.Cluster,				
+				Name:         validBaseEntity.Name,
+				Kind:         validBaseEntity.Kind,
+				ResourceHash: validBaseEntity.ResourceHash,
+				ResourceID:   validBaseEntity.ResourceID,
+			},
+			wantErr: false,
+		},
+		{
 			name: "Invalid posture resource entity",
 			entity: EntityIdentifiers{
 				Type: EntityTypePostureResource,
@@ -63,6 +75,18 @@ func TestEntity_Validate(t *testing.T) {
 				RepoHash:   validBaseEntity.RepoHash,
 				FilePath:   validBaseEntity.FilePath,
 				Namespace:  validBaseEntity.Namespace,
+				Name:       validBaseEntity.Name,
+				Kind:       validBaseEntity.Kind,
+				ResourceID: validBaseEntity.ResourceID,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Valid repository resource entity (no namespace)",
+			entity: EntityIdentifiers{
+				Type:       EntityTypeRepositoryResource,
+				RepoHash:   validBaseEntity.RepoHash,
+				FilePath:   validBaseEntity.FilePath,		
 				Name:       validBaseEntity.Name,
 				Kind:       validBaseEntity.Kind,
 				ResourceID: validBaseEntity.ResourceID,

--- a/notifications/integrationref.go
+++ b/notifications/integrationref.go
@@ -133,7 +133,7 @@ func (e *EntityIdentifiers) Validate() error {
 	}
 	switch e.Type {
 	case EntityTypePostureResource:
-		if e.Cluster == "" || e.Namespace == "" || e.Name == "" || e.Kind == "" || e.ResourceHash == "" || e.ResourceID == "" {
+		if e.Cluster == "" || e.Name == "" || e.Kind == "" || e.ResourceHash == "" || e.ResourceID == "" {
 			return fmt.Errorf("namespace, name, kind, resource hash, cluster and resource id are required for %s", e.Type)
 		}
 	case EntityTypeContainerScanWorkload:
@@ -141,7 +141,7 @@ func (e *EntityIdentifiers) Validate() error {
 			return fmt.Errorf("namespace, name, kind, resource hash and cluster are required for %s", e.Type)
 		}
 	case EntityTypeRepositoryResource:
-		if e.RepoHash == "" || e.FilePath == "" || e.Namespace == "" || e.Name == "" || e.Kind == "" || e.ResourceID == "" {
+		if e.RepoHash == "" || e.FilePath == "" || e.Name == "" || e.Kind == "" || e.ResourceID == "" {
 			return fmt.Errorf("namespace, name, kind, resource hash, repo hash, file path and resource id are required for %s", e.Type)
 		}
 	case EntityTypeImage:


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added new test cases in `integration_test.go` to ensure that entities of types `EntityTypePostureResource` and `EntityTypeRepositoryResource` can be validated without a namespace.
- Updated the `Validate` method in `integrationref.go` to remove the namespace requirement for `EntityTypePostureResource` and `EntityTypeRepositoryResource`.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>integration_test.go</strong><dd><code>Add test cases for entity validation without namespace</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

notifications/integration_test.go
<li>Added test cases for <code>EntityIdentifiers</code> validation without namespace <br>for <code>EntityTypePostureResource</code> and <code>EntityTypeRepositoryResource</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/296/files#diff-e9a6e39662006c9aade7217d2aa1e9210bbc11c5793744e9c21644330f5b15bc">+24/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>integrationref.go</strong><dd><code>Modify entity validation to support no namespace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

notifications/integrationref.go
<li>Modified validation logic in <code>EntityIdentifiers.Validate()</code> to allow <br><code>EntityTypePostureResource</code> and <code>EntityTypeRepositoryResource</code> without a <br>namespace.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/296/files#diff-c2b85aafaedffc508a0331728f554442605db085a97714482e6925f7c683c0ab">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

