### PR TITLE
Fix resource field in BaseExceptionPolicy and add Exception field in SecurityIssue

### DIFF
--- a/armotypes/exceptionpolicy.go
+++ b/armotypes/exceptionpolicy.go
@@ -16,5 +16,5 @@ type BaseExceptionPolicy struct {
 	Reason         string                         `json:"reason,omitempty" bson:"reason,omitempty"`
 	ExpirationDate *time.Time                     `json:"expirationDate,omitempty" bson:"expirationDate,omitempty"`
 	CreatedBy      string                         `json:"createdBy,omitempty" bson:"createdBy,omitempty"`
-	Resources      []identifiers.PortalDesignator `json:"resources" bson:"resources,omitempty"`
+	Resources      []identifiers.PortalDesignator `json:"resources,omitempty" bson:"resources,omitempty"`
 }

--- a/armotypes/securityrisks.go
+++ b/armotypes/securityrisks.go
@@ -192,8 +192,9 @@ type SecurityIssue struct {
 
 	LastTimeDetected string `json:"lastTimeDetected,omitempty"`
 	LastTimeResolved string `json:"lastTimeResolved,omitempty"`
+	ExceptionApplied bool   `json:"exceptionApplied"`
 
-	ExceptionApplied bool `json:"exceptionApplied"`
+	Exception BaseExceptionPolicy `json:"exception,omitempty"`
 }
 
 func (si *SecurityIssue) GetClusterName() string {
@@ -230,6 +231,8 @@ type SecurityRiskExceptionPolicy struct {
 	Name                string `json:"name"`
 	Category            string `json:"category"`
 	Severity            string `json:"severity"`
+	SecurityRiskID      string `json:"securityRiskID"`
+	Risks               []Risk `json:"risks"`
 }
 
 type SecurityIssuesTrends struct {


### PR DESCRIPTION
## **Type**
bug_fix, enhancement


___

## **Description**
- Updated the `Resources` field in `BaseExceptionPolicy` to be optional in both JSON and BSON serialization, enhancing flexibility in data handling.
- Enhanced the `SecurityIssue` structure by adding `ExceptionApplied` and `Exception` fields to improve tracking and management of security exceptions.
- Expanded `SecurityRiskExceptionPolicy` with new fields `SecurityRiskID` and `Risks` to provide better identification and management of security risks.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>exceptionpolicy.go</strong><dd><code>Update serialization option for Resources in BaseExceptionPolicy</code></dd></summary>
<hr>

armotypes/exceptionpolicy.go
<li>Made the <code>Resources</code> field in <code>BaseExceptionPolicy</code> optional in JSON and <br>BSON serialization.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/297/files#diff-caad82220352ce147efd4dd0a9c88fe53f490b95f422f245566071bcf50281e9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>securityrisks.go</strong><dd><code>Enhance SecurityIssue and SecurityRiskExceptionPolicy with new fields</code></dd></summary>
<hr>

armotypes/securityrisks.go
<li>Added <code>ExceptionApplied</code> field to <code>SecurityIssue</code> to track if an exception <br>is applied.<br> <li> Introduced <code>Exception</code> field in <code>SecurityIssue</code> to store exception policy <br>details.<br> <li> Added <code>SecurityRiskID</code> and <code>Risks</code> fields to <code>SecurityRiskExceptionPolicy</code> <br>for better risk identification and management.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/297/files#diff-981dc5ae17066e45bdc7512f27f6bdcb6632757826f636039b2b88aaf83e8166">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

