### PR TITLE
Making some fields pointers and removing ptr from fields

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -49,10 +49,11 @@ type Process struct {
 	PPID       uint32    `json:"ppid,omitempty" bson:"ppid,omitempty"`
 	Pcomm      string    `json:"pcomm,omitempty" bson:"pcomm,omitempty"`
 	Hardlink   string    `json:"hardlink,omitempty" bson:"hardlink,omitempty"`
-	Uid        uint32    `json:"uid,omitempty" bson:"uid,omitempty"`
-	Gid        uint32    `json:"gid,omitempty" bson:"gid,omitempty"`
+	Uid        *uint32   `json:"uid,omitempty" bson:"uid,omitempty"`
+	Gid        *uint32   `json:"gid,omitempty" bson:"gid,omitempty"`
 	UpperLayer bool      `json:"upperLayer,omitempty" bson:"upperLayer,omitempty"`
 	Cwd        string    `json:"cwd,omitempty" bson:"cwd,omitempty"`
+	Path       string    `json:"path,omitempty" bson:"path,omitempty"`
 	Children   []Process `json:"children,omitempty" bson:"children,omitempty"`
 }
 
@@ -83,7 +84,7 @@ type BaseRuntimeAlert struct {
 	// Severity of the alert
 	Severity int `json:"severity,omitempty" bson:"severity,omitempty"`
 	// Size of the file that was infected
-	Size *string `json:"size,omitempty" bson:"size,omitempty"`
+	Size string `json:"size,omitempty" bson:"size,omitempty"`
 	// Command line
 	Timestamp time.Time `json:"timestamp" bson:"timestamp"`
 }


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Changed the `Uid` and `Gid` fields in the `Process` struct to pointers (`*uint32`). This allows handling of null values, which can be useful in cases where these fields might not be applicable or available.
- Modified the `Size` field in the `BaseRuntimeAlert` struct from a pointer type (`*string`) to a non-pointer type (`string`). This change simplifies the handling of this field when it is always expected to have a value.
- Added a new `Path` field to the `Process` struct to potentially capture the file path related to the process, enhancing the detail available in runtime incident reports.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Update Field Types and Add New Field in Structs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/runtimeincidents.go
<li>Changed the <code>Uid</code> and <code>Gid</code> fields from <code>uint32</code> to <code>*uint32</code> (pointers) to <br>handle null values more effectively.<br> <li> Removed the pointer from the <code>Size</code> field in <code>BaseRuntimeAlert</code>, changing <br>it from <code>*string</code> to <code>string</code>.<br> <li> Added a new field <code>Path</code> to the <code>Process</code> struct.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/298/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

