### PR TITLE
Remove unused Exception field in SecurityIssue struct

### DIFF
--- a/armotypes/securityrisks.go
+++ b/armotypes/securityrisks.go
@@ -193,8 +193,6 @@ type SecurityIssue struct {
 	LastTimeDetected string `json:"lastTimeDetected,omitempty"`
 	LastTimeResolved string `json:"lastTimeResolved,omitempty"`
 	ExceptionApplied bool   `json:"exceptionApplied"`
-
-	Exception BaseExceptionPolicy `json:"exception,omitempty"`
 }
 
 func (si *SecurityIssue) GetClusterName() string {


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Removed the `Exception` field from the `SecurityIssue` struct in `securityrisks.go` to clean up the code and improve maintainability.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>securityrisks.go</strong><dd><code>Remove Unused Field from SecurityIssue Struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/securityrisks.go
<li>Removed the unused <code>Exception</code> field from the <code>SecurityIssue</code> struct.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/299/files#diff-981dc5ae17066e45bdc7512f27f6bdcb6632757826f636039b2b88aaf83e8166">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

