### PR TITLE
don't return error on missing provider

### DIFF
--- a/notifications/usernotificationreporttypes_test.go
+++ b/notifications/usernotificationreporttypes_test.go
@@ -637,7 +637,6 @@ func TestRemoveProviderConfig(t *testing.T) {
 		name             string
 		config           *NotificationsConfig
 		providerToRemove ChannelProvider
-		isError          bool
 	}{
 		{
 			name: "multiple providers",
@@ -720,19 +719,14 @@ func TestRemoveProviderConfig(t *testing.T) {
 				},
 			},
 			providerToRemove: CollaborationTypeTeams,
-			isError:          true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := test.config.RemoveProviderConfig(test.providerToRemove)
-			if test.isError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				assert.Empty(t, test.config.AlertChannels[test.providerToRemove])
-			}
+			test.config.RemoveProviderConfig(test.providerToRemove)
+			assert.Empty(t, test.config.AlertChannels[test.providerToRemove])
+
 		})
 	}
 }

--- a/notifications/usersnotificationsmethods.go
+++ b/notifications/usersnotificationsmethods.go
@@ -182,12 +182,10 @@ func (nc *NotificationsConfig) RemoveAlertChannel(collaborationId string) error 
 	return fmt.Errorf("alert channel with collaboration id %s not found", collaborationId)
 }
 
-func (nc *NotificationsConfig) RemoveProviderConfig(provider ChannelProvider) error {
+func (nc *NotificationsConfig) RemoveProviderConfig(provider ChannelProvider) {
 	if _, exists := nc.AlertChannels[provider]; exists {
 		nc.AlertChannels[provider] = make([]AlertChannel, 0)
-		return nil
 	}
-	return fmt.Errorf("provider with identifier %v not found", provider)
 }
 
 func (nci *NotificationConfigIdentifier) Validate() error {


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Removed error handling from `RemoveProviderConfig` method and associated tests.
- Tests now only assert that the alert channels are empty after attempting to remove a provider, instead of checking for errors.
- The `RemoveProviderConfig` method in `usersnotificationsmethods.go` no longer returns an error, simplifying the error handling in the calling code.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>usernotificationreporttypes_test.go</strong><dd><code>Simplify Test Logic for Provider Config Removal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

notifications/usernotificationreporttypes_test.go
<li>Removed error handling logic from <code>TestRemoveProviderConfig</code>.<br> <li> Simplified test assertions to only check for empty alert channels <br>after removal.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/300/files#diff-92da85d08813f4a45402cbec67a90e38c48dff5e60c62bae944e177adfe8bd41">+3/-9</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>usersnotificationsmethods.go</strong><dd><code>Refactor RemoveProviderConfig to Not Return Error</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

notifications/usersnotificationsmethods.go
<li>Removed error return from <code>RemoveProviderConfig</code>.<br> <li> Simplified the method to only clear the alert channels if they exist.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/300/files#diff-bd80e935c4d7aac4288a9af3ea42ff64e94e4be2fe1ab3e04acd7dea54941f42">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

