### PR TITLE
Update RiskType values in securityrisks.go

### DIFF
--- a/armotypes/securityrisks.go
+++ b/armotypes/securityrisks.go
@@ -14,8 +14,9 @@ const (
 	SecurityIssueStatusDetected SecurityIssueStatus = "Detected"
 	SecurityIssueStatusResolved SecurityIssueStatus = "Resolved"
 
-	RiskTypeControl    RiskType = "Control"
-	RiskTypeAttackPath RiskType = "AttackPath"
+	RiskTypeControl                  RiskType = "Control"
+	RiskTypeControlWithNetworkPolicy RiskType = "ControlWithNetworkPolicy"
+	RiskTypeAttackPath               RiskType = "AttackPath"
 
 	SecurityIssueSeverityCritical SecurityIssueSeverity = "Critical"
 	SecurityIssueSeverityHigh     SecurityIssueSeverity = "High"
@@ -33,6 +34,9 @@ const (
 type Risk struct {
 	ID   string   `json:"ID"`
 	Type RiskType `json:"type"`
+
+	// field to be enriched by the backend, relevant only to type Control
+	FixByNetworkPolicy bool `json:"fixByNetworkPolicy,omitempty"`
 }
 
 // UnmarshalJSON is a custom unmarshaler for RiskType that validates its value
@@ -217,6 +221,9 @@ type SecurityIssueControl struct {
 	ControlID     string `json:"controlID"`
 	ReportGUID    string `json:"reportGUID"`
 	FrameworkName string `json:"frameworkName"`
+
+	// relevant for controls with network policy fix
+	NetworkPolicyStatus NetworkPolicyStatus `json:"networkPolicyStatus,omitempty"`
 }
 
 type SecurityIssueAttackPath struct {

--- a/armotypes/securityrisks.go
+++ b/armotypes/securityrisks.go
@@ -36,7 +36,7 @@ type Risk struct {
 	Type RiskType `json:"type"`
 
 	// field to be enriched by the backend, relevant only to type Control
-	FixByNetworkPolicy bool `json:"fixByNetworkPolicy,omitempty"`
+	FixByNetworkPolicy bool `json:"fixByNetworkPolicy"`
 }
 
 // UnmarshalJSON is a custom unmarshaler for RiskType that validates its value


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Introduced a new risk type `RiskTypeControlWithNetworkPolicy` to differentiate controls that can be addressed with network policies.
- Added `FixByNetworkPolicy` boolean field in `Risk` struct to specify if the risk can be mitigated by network policy, enhancing backend data handling.
- Included `NetworkPolicyStatus` in `SecurityIssueControl` struct to manage and track network policy implementations for controls.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>securityrisks.go</strong><dd><code>Enhance RiskType Definitions and Related Structs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/securityrisks.go
<li>Added new <code>RiskType</code> value <code>RiskTypeControlWithNetworkPolicy</code>.<br> <li> Introduced <code>FixByNetworkPolicy</code> field in <code>Risk</code> struct to indicate if the <br>risk can be fixed by a network policy.<br> <li> Added <code>NetworkPolicyStatus</code> field in <code>SecurityIssueControl</code> struct to <br>track the status of network policy fixes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/303/files#diff-981dc5ae17066e45bdc7512f27f6bdcb6632757826f636039b2b88aaf83e8166">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

