### PR TITLE
Add MissingRuntimeInfoReason field to SecurityIssueControl struct in …

### DIFF
--- a/armotypes/securityrisks.go
+++ b/armotypes/securityrisks.go
@@ -224,6 +224,8 @@ type SecurityIssueControl struct {
 
 	// relevant for controls with network policy fix
 	NetworkPolicyStatus NetworkPolicyStatus `json:"networkPolicyStatus,omitempty"`
+
+	MissingRuntimeInfoReason MissingRuntimeInfoReason `json:"missingRuntimeInfoReason,omitempty"`
 }
 
 type SecurityIssueAttackPath struct {


### PR DESCRIPTION
## **User description**
…securityrisks.go


___

## **Type**
enhancement


___

## **Description**
- Added a new optional field `MissingRuntimeInfoReason` to the `SecurityIssueControl` struct in `securityrisks.go` to enhance the tracking of missing runtime information in security controls.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>securityrisks.go</strong><dd><code>Add Missing Runtime Info Reason Field to SecurityIssueControl</code></dd></summary>
<hr>

armotypes/securityrisks.go
<li>Added <code>MissingRuntimeInfoReason</code> field to <code>SecurityIssueControl</code> struct.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/304/files#diff-981dc5ae17066e45bdc7512f27f6bdcb6632757826f636039b2b88aaf83e8166">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

