### PR TITLE
Update bson tags in RuntimeAlert struct

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -117,10 +117,10 @@ type RuntimeAlertK8sDetails struct {
 }
 
 type RuntimeAlert struct {
-	BaseRuntimeAlert       `json:",inline"`
-	RuleAlert              `json:",inline"`
-	MalwareAlert           `json:",inline"`
-	RuntimeAlertK8sDetails `json:",inline"`
+	BaseRuntimeAlert       `json:",inline" bson:"inline"`
+	RuleAlert              `json:",inline" bson:"inline"`
+	MalwareAlert           `json:",inline" bson:"inline"`
+	RuntimeAlertK8sDetails `json:",inline" bson:"inline"`
 	AlertType              AlertType `json:"alertType" bson:"alertType"`
 	// Hostname is the name of the node agent pod
 	HostName string `json:"hostName" bson:"hostName"`


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added BSON tags to all embedded structs within the `RuntimeAlert` struct to ensure proper serialization and deserialization with MongoDB.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Enhance MongoDB Integration with BSON Tags in RuntimeAlert</code></dd></summary>
<hr>

armotypes/runtimeincidents.go
<li>Added BSON tags to embedded structs in <code>RuntimeAlert</code> for better MongoDB <br>integration.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/305/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

