### PR TITLE
Not equal AND separator 

### DIFF
--- a/armotypes/pagination_structs.go
+++ b/armotypes/pagination_structs.go
@@ -35,6 +35,7 @@ const (
 	V2ListSubQuerySeparator = "&"
 	V2ListSortTypeSeparator = ":"
 	V2ListEscapeChar        = "\\"
+	V2ListAndValueSeparator = ";" // for not equal operator ("field": "1;2|notequal" -> field != 1 AND field != 2)
 )
 
 type QueryScopeParams struct {


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Introduced a new constant `V2ListAndValueSeparator` with a value of `;` to facilitate the representation of AND conditions in not equal queries.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pagination_structs.go</strong><dd><code>Add Support for AND Condition in Not Equal Queries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/pagination_structs.go
<li>Added a new constant <code>V2ListAndValueSeparator</code> for handling not equal <br>conditions in queries.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/306/files#diff-66ee83f3f4141c588eac0a484a79f1eb421f6249193fdfeb4212edb2de7e5ea6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

