### PR TITLE
Add runtime incident resolved status fields

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -29,10 +29,13 @@ type RuntimeIncident struct {
 	// alerts / events that are part of this incident
 	RelatedAlerts []RuntimeAlert `json:"relatedAlerts,omitempty" bson:"relatedAlerts,omitempty"`
 	// user gestures
-	SeenAt                *time.Time `json:"seenAt,omitempty" bson:"seenAt,omitempty"`
-	SeenBy                string     `json:"seenBy,omitempty" bson:"seenBy,omitempty"`
+	SeenAt *time.Time `json:"seenAt,omitempty" bson:"seenAt,omitempty"`
+	SeenBy string     `json:"seenBy,omitempty" bson:"seenBy,omitempty"`
+	// Resolve status
 	IsDismissed           bool       `json:"isDismissed" bson:"isDismissed"`
 	MarkedAsFalsePositive bool       `json:"markedAsFalsePositive" bson:"markedAsFalsePositive"`
+	ResolvedAt            *time.Time `json:"resolvedAt,omitempty" bson:"resolvedAt,omitempty"`
+	ResolvedBy            *string    `json:"resolvedBy,omitempty" bson:"resolvedBy,omitempty"`
 	// for future use
 	RelatedResources []RuntimeIncidentResource `json:"relatedResources,omitempty" bson:"relatedResources,omitempty"`
 	ProcessTree      *ProcessTree              `json:"processTree,omitempty" bson:"processTree,omitempty"`


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added new fields `ResolvedAt` and `ResolvedBy` to the `RuntimeIncident` struct to enhance tracking of incident resolution.
- Adjusted formatting of `SeenAt` and `SeenBy` fields for consistency.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Add Resolution Tracking to RuntimeIncident Struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/runtimeincidents.go
<li>Added <code>ResolvedAt</code> field to track the resolution time of an incident.<br> <li> Added <code>ResolvedBy</code> field to identify who resolved the incident.<br> <li> Existing fields <code>SeenAt</code> and <code>SeenBy</code> formatting adjusted without changing <br>functionality.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/316/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

