### PR TITLE
refactor: Update `PodStatus` struct fields for omitempty tags

### DIFF
--- a/armotypes/podstatus.go
+++ b/armotypes/podstatus.go
@@ -23,13 +23,13 @@ type PodStatus struct {
 	Containers          []PodContainer `json:"containers,omitempty"`
 	InitContainers      []PodContainer `json:"initContainers,omitempty"`
 
-	HasFinalApplicationProfile bool `json:"hasFinalApplicationProfile"`
+	HasFinalApplicationProfile bool `json:"hasFinalApplicationProfile,omitempty"`
 
-	HasApplicableRuleBindings bool `json:"hasApplicableRuleBindings"`
+	HasApplicableRuleBindings bool `json:"hasApplicableRuleBindings,omitempty"`
 
-	HasRelevancyCalculating bool `json:"hasRelevancyCalculating"`
+	HasRelevancyCalculating bool `json:"hasRelevancyCalculating,omitempty"`
 
-	IsKDRMonitored bool `json:"isKDRMonitored"`
+	IsKDRMonitored bool `json:"isKDRMonitored,omitempty"`
 }
 
 type PodContainer struct {


### PR DESCRIPTION
Update the `PodStatus` struct fields `HasFinalApplicationProfile`, `HasApplicableRuleBindings`, `HasRelevancyCalculating`, and `IsKDRMonitored` to include the `omitempty` tag. This change ensures that these fields are omitted from the JSON output if they are empty, improving the clarity and conciseness of the code.