### PR TITLE
update node profiles structures

### DIFF
--- a/armotypes/crds_test.go
+++ b/armotypes/crds_test.go
@@ -10,9 +10,7 @@ import (
 func TestGenericCRDWithNodeProfile(t *testing.T) {
 	// Setting up a sample NodeProfile
 	nodeProfile := NodeProfile{
-		CustomerGUID:            "1234-5678-9101",
-		Cluster:                 "ClusterA",
-		Name:                    "Node1",
+
 		PodStatuses:             []PodStatus{{Name: "Pod1", HasFinalApplicationProfile: true}},
 		NodeAgentRunning:        true,
 		RuntimeDetectionEnabled: true,

--- a/armotypes/nodesProfile_test.go
+++ b/armotypes/nodesProfile_test.go
@@ -20,9 +20,10 @@ func TestIsKDRMonitored(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			np := NodeProfile{
-				NodeAgentRunning:        test.nodeAgent,
-				RuntimeDetectionEnabled: test.runtime,
+			np := NodeStatus{
+				NodeProfile: NodeProfile{
+					NodeAgentRunning:        test.nodeAgent,
+					RuntimeDetectionEnabled: test.runtime},
 			}
 			if result := np.IsKDRMonitored(); result != test.expected {
 				t.Errorf("Expected %v, got %v", test.expected, result)
@@ -32,7 +33,7 @@ func TestIsKDRMonitored(t *testing.T) {
 }
 
 func TestGetMonitoredNamespaces(t *testing.T) {
-	np := NodeProfile{
+	np := NodeStatus{NodeProfile: NodeProfile{
 		NodeAgentRunning:        true,
 		RuntimeDetectionEnabled: true,
 		PodStatuses: []PodStatus{
@@ -41,6 +42,7 @@ func TestGetMonitoredNamespaces(t *testing.T) {
 			{Namespace: "default", IsKDRMonitored: true}, // Duplicate
 			{Namespace: "test", IsKDRMonitored: false},
 		},
+	},
 	}
 
 	expected := []string{"default"}
@@ -51,13 +53,14 @@ func TestGetMonitoredNamespaces(t *testing.T) {
 }
 
 func TestGetMonitoredPods(t *testing.T) {
-	np := NodeProfile{
+	np := NodeStatus{NodeProfile: NodeProfile{
 		NodeAgentRunning:        true,
 		RuntimeDetectionEnabled: true,
 		PodStatuses: []PodStatus{
 			{Name: "pod1", IsKDRMonitored: true, Phase: "Running"},
 			{Name: "pod2", IsKDRMonitored: false, Phase: "Running"},
 		},
+	},
 	}
 
 	expected := []PodStatus{{Name: "pod1", IsKDRMonitored: true, Phase: "Running"}}
@@ -68,7 +71,7 @@ func TestGetMonitoredPods(t *testing.T) {
 }
 
 func TestCountMonitoredNamespaces(t *testing.T) {
-	np := NodeProfile{
+	np := NodeStatus{NodeProfile: NodeProfile{
 		NodeAgentRunning:        true,
 		RuntimeDetectionEnabled: true,
 		PodStatuses: []PodStatus{
@@ -77,6 +80,7 @@ func TestCountMonitoredNamespaces(t *testing.T) {
 			{Namespace: "default", IsKDRMonitored: true, Phase: "Running"},
 			{Namespace: "test", IsKDRMonitored: false, Phase: "Pending"},
 		},
+	},
 	}
 
 	expectedCount := 2
@@ -87,7 +91,7 @@ func TestCountMonitoredNamespaces(t *testing.T) {
 }
 
 func TestCountMonitoredPods(t *testing.T) {
-	np := NodeProfile{
+	np := NodeStatus{NodeProfile: NodeProfile{
 		NodeAgentRunning:        true,
 		RuntimeDetectionEnabled: true,
 		PodStatuses: []PodStatus{
@@ -95,6 +99,7 @@ func TestCountMonitoredPods(t *testing.T) {
 			{IsKDRMonitored: true, Phase: "Pending"},
 			{IsKDRMonitored: false, Phase: "Running"},
 		},
+	},
 	}
 
 	expectedCount := 1
@@ -105,7 +110,7 @@ func TestCountMonitoredPods(t *testing.T) {
 }
 
 func TestCountMonitoredContainers(t *testing.T) {
-	np := NodeProfile{
+	np := NodeStatus{NodeProfile: NodeProfile{
 		NodeAgentRunning:        true,
 		RuntimeDetectionEnabled: true,
 		PodStatuses: []PodStatus{
@@ -138,6 +143,7 @@ func TestCountMonitoredContainers(t *testing.T) {
 				Containers:     []PodContainer{}, // Monitored pod but no containers
 			},
 		},
+	},
 	}
 
 	expectedCount := 1


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Introduced a new `NodeStatus` struct which embeds the existing `NodeProfile` struct.
- Refactored methods and tests to utilize the new `NodeStatus` struct, enhancing the structure and clarity of the code.
- Simplified test setups by removing redundant fields in `NodeProfile` instantiation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>crds_test.go</strong><dd><code>Simplify NodeProfile Test Setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/crds_test.go
<li>Simplified the <code>NodeProfile</code> instantiation by removing unnecessary <br>fields in the test setup.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/318/files#diff-013dd450521f423c998381f709706024ad95d71a6fe2d03345b42244b55c6889">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>nodesProfile.go</strong><dd><code>Introduce NodeStatus Struct and Refactor Methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/nodesProfile.go
<li>Introduced a new <code>NodeStatus</code> struct embedding <code>NodeProfile</code>.<br> <li> Refactored methods from <code>NodeProfile</code> to <code>NodeStatus</code> to use the new <br>structure.<br> <li> Adjusted method implementations to reflect the structural changes.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/318/files#diff-beba0aa6ebca7425a6811afc113d4521df5501a386e58f15a7107f5af228d836">+19/-15</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nodesProfile_test.go</strong><dd><code>Update Tests to Use NodeStatus Struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/nodesProfile_test.go
<li>Updated tests to use the new <code>NodeStatus</code> struct instead of <code>NodeProfile</code>.<br> <li> Adjusted test setups to reflect the new data structure changes.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/318/files#diff-6e341d5c4e779ab90a1805703eb87c38558d8f4ccb780f36d1c827623a77092a">+14/-8</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

