### PR TITLE
```text

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -152,10 +152,9 @@ func (ra *RuntimeAlert) GetTimestampFieldName() string {
 }
 
 type KDRMonitoredEntitiesCounters struct {
-	ClustersCount         int `json:"clustersCount"`
-	NodesCount            int `json:"nodesCount"`
-	NamespacesCount       int `json:"namespacesCount"`
-	PodsCount             int `json:"podsCount"`
-	ContainersCount       int `json:"containersCount"`
-	ContainersImagesCount int `json:"containersImagesCount"`
+	ClustersCount   int `json:"clustersCount"`
+	NodesCount      int `json:"nodesCount"`
+	NamespacesCount int `json:"namespacesCount"`
+	PodsCount       int `json:"podsCount"`
+	ContainersCount int `json:"containersCount"`
 }

--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -111,6 +111,7 @@ type MalwareAlert struct {
 
 type RuntimeAlertK8sDetails struct {
 	ClusterName       string `json:"clusterName" bson:"clusterName"`
+	ClusterShortName  string `json:"clusterShortName" bson:"clusterShortName"`
 	ContainerName     string `json:"containerName,omitempty" bson:"containerName,omitempty"`
 	HostNetwork       *bool  `json:"hostNetwork,omitempty" bson:"hostNetwork,omitempty"`
 	Image             string `json:"image,omitempty" bson:"image,omitempty"`

--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -111,7 +111,6 @@ type MalwareAlert struct {
 
 type RuntimeAlertK8sDetails struct {
 	ClusterName       string `json:"clusterName" bson:"clusterName"`
-	ClusterShortName  string `json:"clusterShortName" bson:"clusterShortName"`
 	ContainerName     string `json:"containerName,omitempty" bson:"containerName,omitempty"`
 	HostNetwork       *bool  `json:"hostNetwork,omitempty" bson:"hostNetwork,omitempty"`
 	Image             string `json:"image,omitempty" bson:"image,omitempty"`


### PR DESCRIPTION
### **User description**
refactor: Add ClusterShortName field to RuntimeAlertK8sDetails struct

Add the ClusterShortName field to the RuntimeAlertK8sDetails struct in the runtimeincidents.go file. This change allows for storing the short name of the cluster along with other details for runtime alerts in Kubernetes.


___

### **PR Type**
enhancement


___

### **Description**
- Added a new field `ClusterShortName` to the `RuntimeAlertK8sDetails` struct in `runtimeincidents.go`. This field is intended to store the short name of the cluster, enhancing the details available for runtime alerts in Kubernetes environments.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Add ClusterShortName Field to RuntimeAlertK8sDetails</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/runtimeincidents.go
- Added `ClusterShortName` field to `RuntimeAlertK8sDetails` struct.


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/319/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

