### PR TITLE
use bool ptr for FixAvailable

### DIFF
--- a/armotypes/vulnerabilitytypes.go
+++ b/armotypes/vulnerabilitytypes.go
@@ -200,7 +200,7 @@ type VulnerabilityUniqueFinding struct {
 	VulnerabilityID  string    `json:"vulnerabilityID"`
 	Component        string    `json:"component"`
 	ComponentVersion string    `json:"componentVersion"`
-	FixAvailable     bool      `json:"fixAvailable"`
+	FixAvailable     *bool     `json:"fixAvailable"`
 	ResourceHash     string    `json:"resourceHash"`
 	IsRelevant       bool      `json:"isRelevant"`
 	ScanDate         time.Time `json:"scanDate"`


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Changed the `FixAvailable` field in the `VulnerabilityUniqueFinding` struct from `bool` to `*bool` to allow for nullable values.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vulnerabilitytypes.go</strong><dd><code>Change `FixAvailable` field to a nullable boolean pointer</code></dd></summary>
<hr>

armotypes/vulnerabilitytypes.go
- Changed `FixAvailable` field type from `bool` to `*bool`.



</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/322/files#diff-cac55976184cdb0c77ddde7ecbabd7411490f34df3e11868dd0e67e370c01830">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

