### PR TITLE
add paths to component summary type

### DIFF
--- a/armotypes/vulnerabilitytypes.go
+++ b/armotypes/vulnerabilitytypes.go
@@ -63,6 +63,7 @@ type ComponentSummary struct {
 	Name            string              `json:"name"`
 	Version         string              `json:"version"`
 	PackageType     string              `json:"packageType"`
+	Paths           []string            `json:"paths"`
 	FixVersions     []string            `json:"fixVersions"`
 	CriticalCount   int                 `json:"criticalCount"`
 	HighCount       int                 `json:"highCount"`


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added a new field `Paths` to the `ComponentSummary` struct in `armotypes/vulnerabilitytypes.go`.
- This field is a slice of strings that will store paths related to the component.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vulnerabilitytypes.go</strong><dd><code>Add `Paths` field to `ComponentSummary` struct.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/vulnerabilitytypes.go
- Added `Paths` field to `ComponentSummary` struct.



</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/327/files#diff-cac55976184cdb0c77ddde7ecbabd7411490f34df3e11868dd0e67e370c01830">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

