### PR TITLE
Changing the upper layer field to be ptr

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -60,7 +60,7 @@ type Process struct {
 	Hardlink   string    `json:"hardlink,omitempty" bson:"hardlink,omitempty"`
 	Uid        *uint32   `json:"uid,omitempty" bson:"uid,omitempty"`
 	Gid        *uint32   `json:"gid,omitempty" bson:"gid,omitempty"`
-	UpperLayer bool      `json:"upperLayer,omitempty" bson:"upperLayer,omitempty"`
+	UpperLayer *bool     `json:"upperLayer,omitempty" bson:"upperLayer,omitempty"`
 	Cwd        string    `json:"cwd,omitempty" bson:"cwd,omitempty"`
 	Path       string    `json:"path,omitempty" bson:"path,omitempty"`
 	Children   []Process `json:"children,omitempty" bson:"children,omitempty"`


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Changed the `UpperLayer` field type from `bool` to `*bool` in the `Process` struct to handle cases where the field might be unset.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Change `UpperLayer` field type to pointer in `Process` struct.</code></dd></summary>
<hr>

armotypes/runtimeincidents.go
- Changed the `UpperLayer` field type from `bool` to `*bool`.



</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/328/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

