### PR TITLE
add image manifest getters/setters to ContainerScanSummaryResult inte…

### DIFF
--- a/containerscan/commonContainerScanSummaryResultMethods.go
+++ b/containerscan/commonContainerScanSummaryResultMethods.go
@@ -122,6 +122,10 @@ func (summary *CommonContainerScanSummaryResult) GetRelevantLabel() RelevantLabe
 	return summary.RelevantLabel
 }
 
+func (summary *CommonContainerScanSummaryResult) GetImageManifest() *ImageManifest {
+	return summary.ImageManifest
+}
+
 func (summary *CommonContainerScanSummaryResult) Validate() bool {
 	return summary.CustomerGUID != "" && summary.ContainerScanID != "" && (summary.ImageTag != "" || summary.ImageID != "") && summary.Timestamp > 0
 }
@@ -211,4 +215,8 @@ func (summary *CommonContainerScanSummaryResult) GetHasRelevancyData() bool {
 
 func (summary *CommonContainerScanSummaryResult) SetHasRelevancyData(hasRelevancy bool) {
 	summary.HasRelevancyData = hasRelevancy
+}
+
+func (summary *CommonContainerScanSummaryResult) SetImageManifest(imageManifest *ImageManifest) {
+	summary.ImageManifest = imageManifest
 }

--- a/containerscan/interfaces.go
+++ b/containerscan/interfaces.go
@@ -51,6 +51,7 @@ type ContainerScanSummaryResult interface {
 	GetRelevantLabel() RelevantLabel
 	Validate() bool
 	GetHasRelevancyData() bool
+	GetImageManifest() *ImageManifest
 
 	SetDesignators(identifiers.PortalDesignator)
 	SetContext([]identifiers.ArmoContext)
@@ -72,6 +73,7 @@ type ContainerScanSummaryResult interface {
 	SetTimestamp(int64)
 	SetRelevantLabel(RelevantLabel)
 	SetHasRelevancyData(bool)
+	SetImageManifest(*ImageManifest)
 }
 
 type ContainerScanVulnerabilityResult interface {


### PR DESCRIPTION
### **User description**
…rface


___

### **PR Type**
enhancement


___

### **Description**
- Added `GetImageManifest` method to `CommonContainerScanSummaryResult` struct.
- Added `SetImageManifest` method to `CommonContainerScanSummaryResult` struct.
- Extended `ContainerScanSummaryResult` interface with `GetImageManifest` and `SetImageManifest` methods.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>commonContainerScanSummaryResultMethods.go</strong><dd><code>Add image manifest getters and setters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

containerscan/commonContainerScanSummaryResultMethods.go
<li>Added <code>GetImageManifest</code> method.<br> <li> Added <code>SetImageManifest</code> method.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/332/files#diff-d01c6489709f8a7229b5d4ebb4f1c4f6a38d1f17995c590135065055cba5331e">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>interfaces.go</strong><dd><code>Extend ContainerScanSummaryResult interface with image manifest </code><br><code>methods</code></dd></summary>
<hr>

containerscan/interfaces.go
<li>Added <code>GetImageManifest</code> method to <code>ContainerScanSummaryResult</code> interface.<br> <li> Added <code>SetImageManifest</code> method to <code>ContainerScanSummaryResult</code> interface.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/332/files#diff-0ca5b8becbf43d0581cb605ec9fd742ec3b1e05ce065c96536aece2f2239080c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

