### PR TITLE
feat: Add SeccompWorkload type and constants

### DIFF
--- a/armotypes/seccomp.go
+++ b/armotypes/seccomp.go
@@ -1,0 +1,22 @@
+package armotypes
+
+type SeccompStatus int
+
+const (
+	SeccompStatusMissingRuntimeInfo SeccompStatus = 1
+	SeccompStatusMissing            SeccompStatus = 2
+	SeccompStatusOverlyPermissive   SeccompStatus = 3
+	SeccompStatusOptimized          SeccompStatus = 4
+)
+
+type SeccompWorkload struct {
+	Name                string        `json:"name"`
+	Kind                string        `json:"kind"`
+	Namespace           string        `json:"namespace"`
+	ClusterName         string        `json:"clusterName"`
+	ProfileStatus       SeccompStatus `json:"profileStatus"`
+	SyscallsUsedCount   int           `json:"syscallsUsedCount"`
+	SyscallsUnusedCount int           `json:"syscallsUnusedCount"`
+	SyscallsUsed        []string      `json:"syscallsUsed"`
+	SyscallUnused       []string      `json:"syscallsUnused"`
+}


### PR DESCRIPTION
### **User description**
The code changes introduce a new file `seccomp.go` which defines the `SeccompWorkload` type and constants for `SeccompStatus`. This addition allows for better handling and tracking of seccomp-related information in the codebase.


___

### **PR Type**
Enhancement


___

### **Description**
- Introduced a new file `seccomp.go` in the `armotypes` package.
- Defined the `SeccompStatus` type and constants for various seccomp statuses.
- Added the `SeccompWorkload` struct to encapsulate seccomp-related information such as name, kind, namespace, cluster name, profile status, and syscall counts.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>seccomp.go</strong><dd><code>Define `SeccompWorkload` type and `SeccompStatus` constants.</code></dd></summary>
<hr>

armotypes/seccomp.go
<li>Introduced <code>SeccompStatus</code> type and constants.<br> <li> Added <code>SeccompWorkload</code> struct with fields for seccomp-related <br>information.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/333/files#diff-20f3c56683af6cde59a85ed31eacf890a4e43829b61984b27f95b945229d8b8a">+22/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

