### PR TITLE
add WorkloadStatus

### DIFF
--- a/armotypes/workloadstatus.go
+++ b/armotypes/workloadstatus.go
@@ -1,0 +1,7 @@
+package armotypes
+
+type WorkloadStatus struct {
+	ResourceHash     string `json:"resourceHash,omitempty"`
+	CustomerGUID     string `json:"customerGUID,omitempty"`
+	IsInternetFacing *bool  `json:"isInternetFacing,omitempty"`
+}

--- a/armotypes/workloadstatus.go
+++ b/armotypes/workloadstatus.go
@@ -1,7 +1,7 @@
 package armotypes
 
 type WorkloadStatus struct {
-	ResourceHash     string `json:"resourceHash,omitempty"`
-	CustomerGUID     string `json:"customerGUID,omitempty"`
-	IsInternetFacing *bool  `json:"isInternetFacing,omitempty"`
+	ResourceHash     string `json:"resourceHash"`
+	CustomerGUID     string `json:"customerGUID"`
+	IsInternetFacing *bool  `json:"isInternetFacing"`
 }

--- a/armotypes/workloadstatus.go
+++ b/armotypes/workloadstatus.go
@@ -1,16 +1,8 @@
 package armotypes
 
 type WorkloadStatus struct {
-	WorkloadName        string   `json:"workloadName"`
-	Namespace           string   `json:"namespace"`
-	Kind                string   `json:"kind"`
-	ClusterName         string   `json:"clusterName"`
-	CustomerGUID        string   `json:"customerGUID"`
-	ResourceHash        string   `json:"resourceHash"`
-	ResourceHashNumeric float64  `json:"resourceHashNumeric"`
-	workloadLabelsCount int      `json:"workloadLabelsCount"`
-	riskFactorsCount    int      `json:"riskFactorsCount"`
-	WorkloadLabels      []string `json:"workloadLabels"`
-	RiskFactors         []string `json:"riskFactors"`
-	IsInternetFacing    *bool    `json:"isInternetFacing"`
+	ResourceHash     string `json:"resourceHash"`
+	CustomerGUID     string `json:"customerGUID"`
+	ClusterName      string `json:"clusterName"`
+	IsInternetFacing *bool  `json:"isInternetFacing"`
 }

--- a/armotypes/workloadstatus.go
+++ b/armotypes/workloadstatus.go
@@ -8,6 +8,8 @@ type WorkloadStatus struct {
 	CustomerGUID        string   `json:"customerGUID"`
 	ResourceHash        string   `json:"resourceHash"`
 	ResourceHashNumeric float64  `json:"resourceHashNumeric"`
+	workloadLabelsCount int      `json:"workloadLabelsCount"`
+	riskFactorsCount    int      `json:"riskFactorsCount"`
 	WorkloadLabels      []string `json:"workloadLabels"`
 	RiskFactors         []string `json:"riskFactors"`
 	IsInternetFacing    *bool    `json:"isInternetFacing"`

--- a/armotypes/workloadstatus.go
+++ b/armotypes/workloadstatus.go
@@ -1,8 +1,14 @@
 package armotypes
 
 type WorkloadStatus struct {
-	ResourceHash     string `json:"resourceHash"`
-	CustomerGUID     string `json:"customerGUID"`
-	ClusterName      string `json:"clusterName"`
-	IsInternetFacing *bool  `json:"isInternetFacing"`
+	WorkloadName        string   `json:"workloadName"`
+	Namespace           string   `json:"namespace"`
+	Kind                string   `json:"kind"`
+	ClusterName         string   `json:"clusterName"`
+	CustomerGUID        string   `json:"customerGUID"`
+	ResourceHash        string   `json:"resourceHash"`
+	ResourceHashNumeric float64  `json:"resourceHashNumeric"`
+	WorkloadLabels      []string `json:"workloadLabels"`
+	RiskFactors         []string `json:"riskFactors"`
+	IsInternetFacing    *bool    `json:"isInternetFacing"`
 }

--- a/armotypes/workloadstatus.go
+++ b/armotypes/workloadstatus.go
@@ -3,5 +3,6 @@ package armotypes
 type WorkloadStatus struct {
 	ResourceHash     string `json:"resourceHash"`
 	CustomerGUID     string `json:"customerGUID"`
+	ClusterName      string `json:"clusterName"`
 	IsInternetFacing *bool  `json:"isInternetFacing"`
 }


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added a new `WorkloadStatus` struct to the `armotypes` package.
- The struct includes the following fields:
  - `ResourceHash`: A string representing the resource hash.
  - `CustomerGUID`: A string representing the customer GUID.
  - `IsInternetFacing`: A boolean pointer indicating if the workload is internet-facing.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workloadstatus.go</strong><dd><code>Introduce `WorkloadStatus` struct with relevant fields.</code>&nbsp; &nbsp; </dd></summary>
<hr>

armotypes/workloadstatus.go
<li>Added a new <code>WorkloadStatus</code> struct.<br> <li> Included fields: <code>ResourceHash</code>, <code>CustomerGUID</code>, and <code>IsInternetFacing</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/334/files#diff-ad851c88b813ee35e12b7a3eda9029d6830fc028e5c4bded68755232bb0632d6">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

