### PR TITLE
SUB-4975 | add image layer type

### DIFF
--- a/armotypes/vulnerabilitytypes.go
+++ b/armotypes/vulnerabilitytypes.go
@@ -106,10 +106,10 @@ type ImageSummary struct {
 
 type ImageLayer struct {
 	Order                int    `json:"order"`
-	Hash                 string `json:"hash"`
+	Hash                 string `json:"hash,omitempty"`
 	Command              string `json:"command"`
 	Size                 uint64 `json:"size"`
-	HighestSeverityFound string `json:"highestSeverityFound"`
+	HighestSeverityFound string `json:"highestSeverityFound,omitempty"`
 }
 
 type VulnerabilitiesComponent struct {

--- a/armotypes/vulnerabilitytypes.go
+++ b/armotypes/vulnerabilitytypes.go
@@ -104,6 +104,14 @@ type ImageSummary struct {
 	Tickets         []Ticket            `json:"tickets,omitempty"`
 }
 
+type ImageLayer struct {
+	Order                int    `json:"order"`
+	Hash                 string `json:"hash"`
+	Command              string `json:"command"`
+	Size                 uint64 `json:"size"`
+	HighestSeverityFound string `json:"highestSeverityFound"`
+}
+
 type VulnerabilitiesComponent struct {
 	CustomerGUID string `json:"customerGUID"`
 	Name         string `json:"name"`


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added a new `ImageLayer` type to the `armotypes/vulnerabilitytypes.go` file.
- Defined fields for `ImageLayer`: `Order`, `Hash`, `Command`, `Size`, and `HighestSeverityFound`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vulnerabilitytypes.go</strong><dd><code>Introduce new `ImageLayer` type with relevant fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/vulnerabilitytypes.go
<li>Added a new <code>ImageLayer</code> type.<br> <li> Defined fields: <code>Order</code>, <code>Hash</code>, <code>Command</code>, <code>Size</code>, and <code>HighestSeverityFound</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/336/files#diff-cac55976184cdb0c77ddde7ecbabd7411490f34df3e11868dd0e67e370c01830">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

