### PR TITLE
feat: Update ContainerStatus struct to include multiple architectures

### DIFF
--- a/armotypes/containers.go
+++ b/armotypes/containers.go
@@ -20,10 +20,10 @@ type ContainerStatus struct {
 	Name          string        `json:"name"`          // container name
 	ContainerType ContainerType `json:"containerType"` // initcontainer, container, ephemeralcontainer
 
-	Architecture string `json:"architecture"` // architecture of the container
-	WorkloadName string `json:"workloadName"` // name of the workload
-	Kind         string `json:"kind"`         // kind of the workload
-	Namespace    string `json:"namespace"`    // namespace of the workload
+	Architectures []string `json:"architectures"` // architectures of the container
+	WorkloadName  string   `json:"workloadName"`  // name of the workload
+	Kind          string   `json:"kind"`          // kind of the workload
+	Namespace     string   `json:"namespace"`     // namespace of the workload
 
 	// seccomp related fields (coming from ApplicationProfile)
 	// IsSeccompConfiguredWorkloadLevel  *bool    `json:"isSeccompConfiguredWorkloadLevel"` // if nil, seccomp is not configured


### PR DESCRIPTION
### **User description**
The `ContainerStatus` struct in `containers.go` has been modified to include a new field `Architectures` which represents the architectures of the container. This change allows for better management of container information.


___

### **PR Type**
Enhancement


___

### **Description**
- Updated `ContainerStatus` struct to support multiple architectures by replacing the `Architecture` field with an `Architectures` field.
- Changed the type of the architecture field from `string` to `[]string` to accommodate multiple architectures.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>containers.go</strong><dd><code>Support multiple architectures in `ContainerStatus` struct.</code></dd></summary>
<hr>

armotypes/containers.go
<li>Replaced <code>Architecture</code> field with <code>Architectures</code> field in <br><code>ContainerStatus</code> struct.<br> <li> Updated field type from <code>string</code> to <code>[]string</code> for multiple architectures <br>support.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/337/files#diff-dee5857ecda6c7addb6d37264cf81edf5dffcdc68f942a6c0c73a916a73944d5">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

