### PR TITLE
Adding admission type

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -117,8 +117,6 @@ type MalwareAlert struct {
 type AdmissionAlert struct {
 	// Admission Request
 	AdmissionRequest *admissionv1.AdmissionRequest `json:"admissionRequest,omitempty" bson:"admissionRequest,omitempty"`
-	// Admission ID
-	AdmissionID string `json:"admissionID,omitempty" bson:"admissionID,omitempty"`
 }
 
 type RuntimeAlertK8sDetails struct {

--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -104,8 +104,6 @@ type BaseRuntimeAlert struct {
 }
 
 type RuleAlert struct {
-	// Rule ID
-	RuleID string `json:"ruleID,omitempty" bson:"ruleID,omitempty"`
 	// Rule Description
 	RuleDescription string `json:"ruleDescription,omitempty" bson:"ruleDescription,omitempty"`
 }
@@ -142,6 +140,8 @@ type RuntimeAlert struct {
 	AdmissionAlert         `json:",inline" bson:"inline"`
 	RuntimeAlertK8sDetails `json:",inline" bson:"inline"`
 	AlertType              AlertType `json:"alertType" bson:"alertType"`
+	// Rule ID
+	RuleID string `json:"ruleID,omitempty" bson:"ruleID,omitempty"`
 	// Hostname is the name of the node agent pod
 	HostName string `json:"hostName" bson:"hostName"`
 	Message  string `json:"message" bson:"message"`

--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -96,8 +96,10 @@ type BaseRuntimeAlert struct {
 	Severity int `json:"severity,omitempty" bson:"severity,omitempty"`
 	// Size of the file that was infected
 	Size string `json:"size,omitempty" bson:"size,omitempty"`
-	// Command line
+	// Timestamp of the alert
 	Timestamp time.Time `json:"timestamp" bson:"timestamp"`
+	// Nanoseconds of the alert
+	Nanoseconds uint64 `json:"nanoseconds" bson:"nanoseconds"`
 }
 
 type RuleAlert struct {

--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -10,8 +10,9 @@ type IncidentCategory string
 type RuntimeIncidentResolveReason string
 
 const (
-	RuntimeIncidentCategoryMalware IncidentCategory = "Malware"
-	RuntimeIncidentCategoryAnomaly IncidentCategory = "Anomaly"
+	RuntimeIncidentCategoryMalware   IncidentCategory = "Malware"
+	RuntimeIncidentCategoryAnomaly   IncidentCategory = "Anomaly"
+	RuntimeIncidentCategorySignature IncidentCategory = "Signature"
 
 	RuntimeResolveReasonFalsePositive RuntimeIncidentResolveReason = "FalsePositive"
 	RuntimeResolveReasonSuspicious    RuntimeIncidentResolveReason = "Suspicious"
@@ -71,6 +72,7 @@ type AlertType int
 const (
 	AlertTypeRule AlertType = iota
 	AlertTypeMalware
+	AlertTypeAdmission
 )
 
 type BaseRuntimeAlert struct {
@@ -109,6 +111,27 @@ type MalwareAlert struct {
 	MalwareDescription string `json:"malwareDescription,omitempty" bson:"malwareDescription,omitempty"`
 }
 
+type AdmissionAlert struct {
+	// The user who sent the request
+	User string `json:"user,omitempty"`
+	// The user groups
+	Groups []string `json:"groups,omitempty"`
+	// The user UID
+	UID string `json:"uid,omitempty"`
+	// The name of the request
+	Name string `json:"name,omitempty"`
+	// The operation of the request
+	Operation string `json:"operation,omitempty"`
+	// The kind of the request
+	Kind string `json:"kind,omitempty"`
+	// The request resource
+	Resource string `json:"resource,omitempty"`
+	// The request subresource
+	Subresource string `json:"subresource,omitempty"`
+	// Admission ID
+	AdmissionID string `json:"admissionID,omitempty"`
+}
+
 type RuntimeAlertK8sDetails struct {
 	ClusterName       string `json:"clusterName" bson:"clusterName"`
 	ContainerName     string `json:"containerName,omitempty" bson:"containerName,omitempty"`
@@ -129,6 +152,7 @@ type RuntimeAlert struct {
 	BaseRuntimeAlert       `json:",inline" bson:"inline"`
 	RuleAlert              `json:",inline" bson:"inline"`
 	MalwareAlert           `json:",inline" bson:"inline"`
+	AdmissionAlert         `json:",inline" bson:"inline"`
 	RuntimeAlertK8sDetails `json:",inline" bson:"inline"`
 	AlertType              AlertType `json:"alertType" bson:"alertType"`
 	// Hostname is the name of the node agent pod

--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/armosec/armoapi-go/identifiers"
+	admissionv1 "k8s.io/api/admission/v1"
 )
 
 type IncidentCategory string
@@ -99,7 +100,7 @@ type BaseRuntimeAlert struct {
 	// Timestamp of the alert
 	Timestamp time.Time `json:"timestamp" bson:"timestamp"`
 	// Nanoseconds of the alert
-	Nanoseconds uint64 `json:"nanoseconds" bson:"nanoseconds"`
+	Nanoseconds uint64 `json:"nanoseconds,omitempty" bson:"nanoseconds,omitempty"`
 }
 
 type RuleAlert struct {
@@ -114,24 +115,10 @@ type MalwareAlert struct {
 }
 
 type AdmissionAlert struct {
-	// The user who sent the request
-	User string `json:"user,omitempty"`
-	// The user groups
-	Groups []string `json:"groups,omitempty"`
-	// The user UID
-	UID string `json:"uid,omitempty"`
-	// The name of the request
-	Name string `json:"name,omitempty"`
-	// The operation of the request
-	Operation string `json:"operation,omitempty"`
-	// The kind of the request
-	Kind string `json:"kind,omitempty"`
-	// The request resource
-	Resource string `json:"resource,omitempty"`
-	// The request subresource
-	Subresource string `json:"subresource,omitempty"`
+	// Admission Request
+	AdmissionRequest *admissionv1.AdmissionRequest `json:"admissionRequest,omitempty" bson:"admissionRequest,omitempty"`
 	// Admission ID
-	AdmissionID string `json:"admissionID,omitempty"`
+	AdmissionID string `json:"admissionID,omitempty" bson:"admissionID,omitempty"`
 }
 
 type RuntimeAlertK8sDetails struct {


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added a new `RuntimeIncidentCategorySignature` to the `IncidentCategory` constants.
- Introduced a new `AlertTypeAdmission` to the `AlertType` constants.
- Created a new struct `AdmissionAlert` with fields such as `User`, `Groups`, `UID`, `Name`, `Operation`, `Kind`, `Resource`, `Subresource`, and `AdmissionID`.
- Updated the `RuntimeAlert` struct to include the new `AdmissionAlert` struct.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Add new admission alert type and related structures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/runtimeincidents.go
<li>Added <code>RuntimeIncidentCategorySignature</code> to <code>IncidentCategory</code>.<br> <li> Introduced <code>AlertTypeAdmission</code> to <code>AlertType</code>.<br> <li> Added new struct <code>AdmissionAlert</code> with various fields.<br> <li> Included <code>AdmissionAlert</code> in <code>RuntimeAlert</code> struct.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/338/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+26/-2</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

