### PR TITLE
feat: Add K8sResourceHash field to SeccompWorkload

### DIFF
--- a/armotypes/seccomp.go
+++ b/armotypes/seccomp.go
@@ -14,6 +14,7 @@ type SeccompWorkload struct {
 	Kind                     string                   `json:"kind"`
 	Namespace                string                   `json:"namespace"`
 	ClusterName              string                   `json:"clusterName"`
+	K8sResourceHash          string                   `json:"k8sResourceHash"`
 	ProfileStatus            SeccompStatus            `json:"profileStatus"`
 	SyscallsUsedCount        int                      `json:"syscallsUsedCount"`
 	SyscallsUnusedCount      int                      `json:"syscallsUnusedCount"`


### PR DESCRIPTION
### **User description**
The `SeccompWorkload` struct in `seccomp.go` has been modified to include a new field `K8sResourceHash` which represents the hash of the Kubernetes resource. This change enhances the Seccomp profile management by associating it with the specific Kubernetes resource.


___

### **PR Type**
Enhancement


___

### **Description**
- Added `K8sResourceHash` field to `SeccompWorkload` struct in `seccomp.go`.
- The new field represents the hash of the Kubernetes resource.
- Enhances Seccomp profile management by associating it with the specific Kubernetes resource.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>seccomp.go</strong><dd><code>Add `K8sResourceHash` field to `SeccompWorkload` struct</code>&nbsp; &nbsp; </dd></summary>
<hr>

armotypes/seccomp.go
<li>Added <code>K8sResourceHash</code> field to <code>SeccompWorkload</code> struct.<br> <li> The new field represents the hash of the Kubernetes resource.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/339/files#diff-20f3c56683af6cde59a85ed31eacf890a4e43829b61984b27f95b945229d8b8a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

