### PR TITLE
add base image type

### DIFF
--- a/armotypes/vulnerabilitytypes.go
+++ b/armotypes/vulnerabilitytypes.go
@@ -86,6 +86,7 @@ type ImageSummary struct {
 	Architecture    string              `json:"architecture"`
 	OS              string              `json:"os"`
 	Size            uint64              `json:"size"`
+	BaseImage       string              `json:"baseImage"`
 	LastScanTime    time.Time           `json:"lastScanTime"`
 	Clusters        []string            `json:"clusters"`
 	Namespaces      []string            `json:"namespaces"`
@@ -102,6 +103,14 @@ type ImageSummary struct {
 	WorkloadsCount  int                 `json:"workloadsCount"`
 	ContainersCount int                 `json:"containersCount"`
 	Tickets         []Ticket            `json:"tickets,omitempty"`
+}
+
+type BaseImage struct {
+	DisplayName          string       `json:"displayName"`
+	Command              string       `json:"command"`
+	Size                 uint64       `json:"size"`
+	HighestSeverityFound string       `json:"highestSeverityFound,omitempty"`
+	Layers               []ImageLayer `json:"layers,omitempty"`
 }
 
 type ImageLayer struct {


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Enhanced `ImageSummary` struct by adding a new `BaseImage` field.
- Introduced a new `BaseImage` struct to encapsulate base image details, including `DisplayName`, `Command`, `Size`, `HighestSeverityFound`, and `Layers`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vulnerabilitytypes.go</strong><dd><code>Add `BaseImage` field and struct to `ImageSummary`.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/vulnerabilitytypes.go
<li>Added <code>BaseImage</code> field to <code>ImageSummary</code> struct.<br> <li> Introduced new <code>BaseImage</code> struct with fields <code>DisplayName</code>, <code>Command</code>, <br><code>Size</code>, <code>HighestSeverityFound</code>, and <code>Layers</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/340/files#diff-cac55976184cdb0c77ddde7ecbabd7411490f34df3e11868dd0e67e370c01830">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

