### PR TITLE
add AppliedNetworkPolicyType to NetworkPoliciesWorkload

### DIFF
--- a/armotypes/networkpolicies.go
+++ b/armotypes/networkpolicies.go
@@ -28,6 +28,7 @@ type NetworkPoliciesWorkload struct {
 	Namespace                  string                   `json:"namespace"`
 	ClusterName                string                   `json:"cluster"`
 	ClusterShortName           string                   `json:"clusterShortName"`
+	AppliedNetworkPolicyType   string                   `json:"appliedNetworkPolicyType"`
 	NetworkPolicyStatus        NetworkPolicyStatus      `json:"networkPolicyStatus"`
 	NetworkPolicyStatusMessage string                   `json:"networkPolicyStatusMessage"`
 	MissingRuntimeInfoReason   MissingRuntimeInfoReason `json:"missingRuntimeInfoReason"`


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added a new field `AppliedNetworkPolicyType` to the `NetworkPoliciesWorkload` struct to store the type of applied network policy.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>networkpolicies.go</strong><dd><code>Add <code>AppliedNetworkPolicyType</code> field to <code>NetworkPoliciesWorkload</code> struct</code></dd></summary>
<hr>
      
armotypes/networkpolicies.go

<li>Added a new field <code>AppliedNetworkPolicyType</code> to the <br><code>NetworkPoliciesWorkload</code> struct.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/343/files#diff-edffc833afef72270a9815b6c2842d3d28e3eb3cefcae82601a76c0bd97bdbb4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

