### PR TITLE
add AppliedNetworkPolicyType to SecurityIssueControl

### DIFF
--- a/armotypes/securityrisks.go
+++ b/armotypes/securityrisks.go
@@ -237,7 +237,8 @@ type SecurityIssueControl struct {
 	FrameworkName string `json:"frameworkName"`
 
 	// relevant for controls with network policy fix
-	NetworkPolicyStatus NetworkPolicyStatus `json:"networkPolicyStatus,omitempty"`
+	AppliedNetworkPolicyType string              `json:"appliedNetworkPolicyType,omitempty"`
+	NetworkPolicyStatus      NetworkPolicyStatus `json:"networkPolicyStatus,omitempty"`
 
 	MissingRuntimeInfoReason MissingRuntimeInfoReason `json:"missingRuntimeInfoReason,omitempty"`
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added a new field `AppliedNetworkPolicyType` to the `SecurityIssueControl` struct to enhance network policy reporting.
- Adjusted the order of fields in the `SecurityIssueControl` struct for better organization.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>securityrisks.go</strong><dd><code>Add `AppliedNetworkPolicyType` field to `SecurityIssueControl` struct</code></dd></summary>
<hr>
      
armotypes/securityrisks.go

<li>Added <code>AppliedNetworkPolicyType</code> field to <code>SecurityIssueControl</code> struct.<br> <li> Adjusted the order of fields in <code>SecurityIssueControl</code> struct.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/345/files#diff-981dc5ae17066e45bdc7512f27f6bdcb6632757826f636039b2b88aaf83e8166">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

