### PR TITLE
Removing ptr from interface type

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -116,17 +116,17 @@ type MalwareAlert struct {
 }
 
 type AdmissionAlert struct {
-	Kind              schema.GroupVersionKind     `json:"kind,omitempty" bson:"kind,omitempty"`
-	ResourceNamespace string                      `json:"resourceNamespace,omitempty" bson:"resourceNamespace,omitempty"`
-	ResourceName      string                      `json:"resourceName,omitempty" bson:"resourceName,omitempty"`
-	Resource          schema.GroupVersionResource `json:"resource,omitempty" bson:"resource,omitempty"`
-	Subresource       string                      `json:"subresource,omitempty" bson:"subresource,omitempty"`
-	Operation         admission.Operation         `json:"operation,omitempty" bson:"operation,omitempty"`
-	Options           *unstructured.Unstructured  `json:"options,omitempty" bson:"options,omitempty"`
-	DryRun            bool                        `json:"dryRun,omitempty" bson:"dryRun,omitempty"`
-	Object            *unstructured.Unstructured  `json:"object,omitempty" bson:"object,omitempty"`
-	OldObject         *unstructured.Unstructured  `json:"oldObject,omitempty" bson:"oldObject,omitempty"`
-	UserInfo          *user.DefaultInfo           `json:"userInfo,omitempty" bson:"userInfo,omitempty"`
+	Kind             schema.GroupVersionKind     `json:"kind,omitempty" bson:"kind,omitempty"`
+	RequestNamespace string                      `json:"requestNamespace,omitempty" bson:"requestNamespace,omitempty"`
+	ObjectName       string                      `json:"objectName,omitempty" bson:"objectName,omitempty"`
+	Resource         schema.GroupVersionResource `json:"resource,omitempty" bson:"resource,omitempty"`
+	Subresource      string                      `json:"subresource,omitempty" bson:"subresource,omitempty"`
+	Operation        admission.Operation         `json:"operation,omitempty" bson:"operation,omitempty"`
+	Options          *unstructured.Unstructured  `json:"options,omitempty" bson:"options,omitempty"`
+	DryRun           bool                        `json:"dryRun,omitempty" bson:"dryRun,omitempty"`
+	Object           *unstructured.Unstructured  `json:"object,omitempty" bson:"object,omitempty"`
+	OldObject        *unstructured.Unstructured  `json:"oldObject,omitempty" bson:"oldObject,omitempty"`
+	UserInfo         *user.DefaultInfo           `json:"userInfo,omitempty" bson:"userInfo,omitempty"`
 }
 
 type RuntimeAlertK8sDetails struct {

--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -4,7 +4,10 @@ import (
 	"time"
 
 	"github.com/armosec/armoapi-go/identifiers"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
 )
 
 type IncidentCategory string
@@ -113,8 +116,17 @@ type MalwareAlert struct {
 }
 
 type AdmissionAlert struct {
-	// Admission Attrs
-	AdmissionAttrs admission.Attributes `json:"admissionAttrs,omitempty" bson:"admissionAttrs,omitempty"`
+	Kind              schema.GroupVersionKind
+	ResourceNamespace string
+	ResourceName      string
+	Resource          schema.GroupVersionResource
+	Subresource       string
+	Operation         admission.Operation
+	Options           *unstructured.Unstructured
+	DryRun            bool
+	Object            *unstructured.Unstructured
+	OldObject         *unstructured.Unstructured
+	UserInfo          *user.DefaultInfo
 }
 
 type RuntimeAlertK8sDetails struct {

--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -116,17 +116,17 @@ type MalwareAlert struct {
 }
 
 type AdmissionAlert struct {
-	Kind              schema.GroupVersionKind
-	ResourceNamespace string
-	ResourceName      string
-	Resource          schema.GroupVersionResource
-	Subresource       string
-	Operation         admission.Operation
-	Options           *unstructured.Unstructured
-	DryRun            bool
-	Object            *unstructured.Unstructured
-	OldObject         *unstructured.Unstructured
-	UserInfo          *user.DefaultInfo
+	Kind              schema.GroupVersionKind     `json:"kind,omitempty" bson:"kind,omitempty"`
+	ResourceNamespace string                      `json:"resourceNamespace,omitempty" bson:"resourceNamespace,omitempty"`
+	ResourceName      string                      `json:"resourceName,omitempty" bson:"resourceName,omitempty"`
+	Resource          schema.GroupVersionResource `json:"resource,omitempty" bson:"resource,omitempty"`
+	Subresource       string                      `json:"subresource,omitempty" bson:"subresource,omitempty"`
+	Operation         admission.Operation         `json:"operation,omitempty" bson:"operation,omitempty"`
+	Options           *unstructured.Unstructured  `json:"options,omitempty" bson:"options,omitempty"`
+	DryRun            bool                        `json:"dryRun,omitempty" bson:"dryRun,omitempty"`
+	Object            *unstructured.Unstructured  `json:"object,omitempty" bson:"object,omitempty"`
+	OldObject         *unstructured.Unstructured  `json:"oldObject,omitempty" bson:"oldObject,omitempty"`
+	UserInfo          *user.DefaultInfo           `json:"userInfo,omitempty" bson:"userInfo,omitempty"`
 }
 
 type RuntimeAlertK8sDetails struct {

--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -114,7 +114,7 @@ type MalwareAlert struct {
 
 type AdmissionAlert struct {
 	// Admission Attrs
-	AdmissionAttrs *admission.Attributes `json:"admissionAttrs,omitempty" bson:"admissionAttrs,omitempty"`
+	AdmissionAttrs admission.Attributes `json:"admissionAttrs,omitempty" bson:"admissionAttrs,omitempty"`
 }
 
 type RuntimeAlertK8sDetails struct {

--- a/armotypes/runtimeincidents_test.go
+++ b/armotypes/runtimeincidents_test.go
@@ -1,0 +1,59 @@
+package armotypes
+
+import (
+	"testing"
+
+	"encoding/json"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+func TestAdmissionAlert(t *testing.T) {
+	alert := AdmissionAlert{
+		Kind:             schema.GroupVersionKind{},
+		RequestNamespace: "test-namespace",
+		ObjectName:       "test-object",
+		Resource:         schema.GroupVersionResource{},
+		Subresource:      "test-subresource",
+		Operation:        admission.Create,
+		Options:          nil,
+		DryRun:           false,
+		Object:           nil,
+		OldObject:        nil,
+		UserInfo:         nil,
+	}
+
+	assert.Equal(t, "test-namespace", alert.RequestNamespace)
+	assert.Equal(t, "test-object", alert.ObjectName)
+	assert.Equal(t, "test-subresource", alert.Subresource)
+	assert.Equal(t, admission.Create, alert.Operation)
+	assert.False(t, alert.DryRun)
+}
+
+// Test json marshalling and unmarshalling of AdmissionAlert
+func TestAdmissionAlertJSON(t *testing.T) {
+	alert := AdmissionAlert{
+		Kind:             schema.GroupVersionKind{},
+		RequestNamespace: "test-namespace",
+		ObjectName:       "test-object",
+		Resource:         schema.GroupVersionResource{},
+		Subresource:      "test-subresource",
+		Operation:        admission.Create,
+		Options:          nil,
+		DryRun:           false,
+		Object:           nil,
+		OldObject:        nil,
+		UserInfo:         nil,
+	}
+
+	jsonData, err := json.Marshal(alert)
+	assert.Nil(t, err)
+
+	var alert2 AdmissionAlert
+	err = json.Unmarshal(jsonData, &alert2)
+	assert.Nil(t, err)
+
+	assert.Equal(t, alert, alert2)
+}


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Changed `AdmissionAttrs` type from pointer to non-pointer in `AdmissionAlert` struct to fix potential issues with nil pointer dereference.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Remove pointer from `AdmissionAttrs` in `AdmissionAlert` struct</code></dd></summary>
<hr>
      
armotypes/runtimeincidents.go

<li>Changed <code>AdmissionAttrs</code> type from pointer to non-pointer in <br><code>AdmissionAlert</code> struct.<br>


</details>
    

  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/346/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

