### PR TITLE
Added the field of Allocated CPU

### DIFF
--- a/armotypes/nodesProfile.go
+++ b/armotypes/nodesProfile.go
@@ -10,13 +10,16 @@ type NodeProfile struct {
 
 	RuntimeDetectionEnabled bool `json:"runtimeDetectionEnabled"`
 }
-
+type NodeSpec struct {
+	AllocatedCPU int `json:"allocatedCPU,omitempty"`
+}
 type NodeStatus struct {
 	CustomerGUID    string `json:"customerGUID"`
 	Cluster         string `json:"cluster"`
 	Name            string `json:"name"`
 	K8sResourceHash string `json:"k8sResourceHash"`
 	NodeProfile     `json:",inline"`
+	NodeSpec        `json:",inline"`
 }
 
 func (nc *NodeStatus) IsKDRMonitored() bool {


### PR DESCRIPTION
### **User description**
Added the field of Allocated CPU


___

### **PR Type**
enhancement


___

### **Description**
- Introduced a new `NodeSpec` type with an `AllocatedCPU` field to track CPU allocation.
- Updated the `NodeStatus` struct to include the `NodeSpec` type inline.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nodesProfile.go</strong><dd><code>Add `AllocatedCPU` field to NodeStatus via NodeSpec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/nodesProfile.go

<li>Added a new <code>NodeSpec</code> type with an <code>AllocatedCPU</code> field.<br> <li> Included <code>NodeSpec</code> inline in the <code>NodeStatus</code> struct.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/352/files#diff-beba0aa6ebca7425a6811afc113d4521df5501a386e58f15a7107f5af228d836">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

