### PR TITLE
Changed the int to be pointer int

### DIFF
--- a/armotypes/nodesProfile.go
+++ b/armotypes/nodesProfile.go
@@ -11,7 +11,7 @@ type NodeProfile struct {
 	RuntimeDetectionEnabled bool `json:"runtimeDetectionEnabled"`
 }
 type NodeSpec struct {
-	AllocatedCPU int `json:"allocatedCPU,omitempty"`
+	AllocatedCPU *int `json:"allocatedCPU,omitempty"`
 }
 type NodeStatus struct {
 	CustomerGUID    string `json:"customerGUID"`


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Changed the `AllocatedCPU` field in the `NodeSpec` struct from an `int` to a pointer to an `int` (`*int`).



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nodesProfile.go</strong><dd><code>Change `AllocatedCPU` field to pointer in `NodeSpec` struct</code></dd></summary>
<hr>

armotypes/nodesProfile.go

<li>Changed <code>AllocatedCPU</code> field from <code>int</code> to <code>*int</code> in <code>NodeSpec</code> struct.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/353/files#diff-beba0aa6ebca7425a6811afc113d4521df5501a386e58f15a7107f5af228d836">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

