### PR TITLE
feat: Add mandatory seccomp syscalls

### DIFF
--- a/armotypes/seccomp.go
+++ b/armotypes/seccomp.go
@@ -11,6 +11,8 @@ const (
 	SeccompStatusMisconfigured      SeccompStatus = 5
 )
 
+var MandatorySeccompSyscalls = []string{"epoll_wait", "tgkill", "sched_yield"}
+
 type SeccompWorkload struct {
 	Name                     string                   `json:"name"`
 	Kind                     string                   `json:"kind"`


### PR DESCRIPTION
### **User description**
This commit adds the `MandatorySeccompSyscalls` variable to the `seccomp.go` file. The variable contains a list of mandatory syscalls that must be allowed by the seccomp filter. The added syscalls are "epoll_wait" and "tgkill".


___

### **PR Type**
enhancement


___

### **Description**
- Introduced a new variable `MandatorySeccompSyscalls` in `seccomp.go` to define a list of mandatory syscalls.
- Added syscalls "epoll_wait", "tgkill", and "sched_yield" to the mandatory list.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>seccomp.go</strong><dd><code>Add Mandatory Seccomp Syscalls Variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/seccomp.go

<li>Added <code>MandatorySeccompSyscalls</code> variable.<br> <li> Included syscalls "epoll_wait", "tgkill", and "sched_yield".<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/354/files#diff-20f3c56683af6cde59a85ed31eacf890a4e43829b61984b27f95b945229d8b8a">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

