### PR TITLE
Adding pod labels to k8s details

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -83,19 +83,20 @@ type AdmissionAlert struct {
 }
 
 type RuntimeAlertK8sDetails struct {
-	ClusterName       string `json:"clusterName" bson:"clusterName"`
-	ContainerName     string `json:"containerName,omitempty" bson:"containerName,omitempty"`
-	HostNetwork       *bool  `json:"hostNetwork,omitempty" bson:"hostNetwork,omitempty"`
-	Image             string `json:"image,omitempty" bson:"image,omitempty"`
-	ImageDigest       string `json:"imageDigest,omitempty" bson:"imageDigest,omitempty"`
-	Namespace         string `json:"namespace,omitempty" bson:"namespace,omitempty"`
-	NodeName          string `json:"nodeName,omitempty" bson:"nodeName,omitempty"`
-	ContainerID       string `json:"containerID,omitempty" bson:"containerID,omitempty"`
-	PodName           string `json:"podName,omitempty" bson:"podName,omitempty"`
-	PodNamespace      string `json:"podNamespace,omitempty" bson:"podNamespace,omitempty"`
-	WorkloadName      string `json:"workloadName" bson:"workloadName"`
-	WorkloadNamespace string `json:"workloadNamespace,omitempty" bson:"workloadNamespace,omitempty"`
-	WorkloadKind      string `json:"workloadKind" bson:"workloadKind"`
+	ClusterName       string            `json:"clusterName" bson:"clusterName"`
+	ContainerName     string            `json:"containerName,omitempty" bson:"containerName,omitempty"`
+	HostNetwork       *bool             `json:"hostNetwork,omitempty" bson:"hostNetwork,omitempty"`
+	Image             string            `json:"image,omitempty" bson:"image,omitempty"`
+	ImageDigest       string            `json:"imageDigest,omitempty" bson:"imageDigest,omitempty"`
+	Namespace         string            `json:"namespace,omitempty" bson:"namespace,omitempty"`
+	NodeName          string            `json:"nodeName,omitempty" bson:"nodeName,omitempty"`
+	ContainerID       string            `json:"containerID,omitempty" bson:"containerID,omitempty"`
+	PodName           string            `json:"podName,omitempty" bson:"podName,omitempty"`
+	PodNamespace      string            `json:"podNamespace,omitempty" bson:"podNamespace,omitempty"`
+	PodLabels         map[string]string `json:"podLabels,omitempty" bson:"podLabels,omitempty"`
+	WorkloadName      string            `json:"workloadName" bson:"workloadName"`
+	WorkloadNamespace string            `json:"workloadNamespace,omitempty" bson:"workloadNamespace,omitempty"`
+	WorkloadKind      string            `json:"workloadKind" bson:"workloadKind"`
 }
 
 type RuntimeAlert struct {


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Introduced a new `PodLabels` field to the `RuntimeAlertK8sDetails` struct to store Kubernetes pod labels.
- The `PodLabels` field is a map of string key-value pairs and is optional.
- This enhancement allows for more detailed Kubernetes runtime alert information by including pod labels.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Add `PodLabels` field to `RuntimeAlertK8sDetails` struct</code>&nbsp; </dd></summary>
<hr>

armotypes/runtimeincidents.go

<li>Added a new field <code>PodLabels</code> to the <code>RuntimeAlertK8sDetails</code> struct.<br> <li> The <code>PodLabels</code> field is a map of string key-value pairs.<br> <li> This field is optional and serialized with JSON and BSON.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/356/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+14/-13</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

