### PR TITLE
feat: Update exception policy types and add security risk constants

### DIFF
--- a/armotypes/exceptionpolicy.go
+++ b/armotypes/exceptionpolicy.go
@@ -6,9 +6,17 @@ import (
 	"github.com/armosec/armoapi-go/identifiers"
 )
 
+const (
+	// SecurityRiskPolicy - policy for security risks
+	SecurityRiskExceptionPolicyType PolicyType = "securityRiskExceptionPolicy"
+
+	// RuntimeIncidentPolicy - policy for runtime incidents
+	RuntimeIncidentExceptionPolicy PolicyType = "runtimeIncidentExceptionPolicy"
+)
+
 type BaseExceptionPolicy struct {
 	PortalBase `json:",inline" bson:"inline"`
-	PolicyType string `json:"policyType,omitempty" bson:"policyType,omitempty"`
+	PolicyType PolicyType `json:"policyType,omitempty" bson:"policyType,omitempty"`
 
 	// IDs of the policies (SecurityRiskID, ControlID, etc.)
 	PolicyIDs      []string                       `json:"policyIDs,omitempty" bson:"policyIDs,omitempty"`

--- a/armotypes/securityrisks.go
+++ b/armotypes/securityrisks.go
@@ -24,8 +24,6 @@ const (
 	SecurityIssueSeverityMedium   SecurityIssueSeverity = "Medium"
 	SecurityIssueSeverityLow      SecurityIssueSeverity = "Low"
 
-	SecurityRiskExceptionPolicyType PolicyType = "securityRiskExceptionPolicy"
-
 	ResolvedReasonResourceDeleted ResolvedReason = "ResourceDeleted"
 	ResolvedReasonClusterDeleted  ResolvedReason = "ClusterDeleted"
 	ResolvedReasonRiskResolved    ResolvedReason = "RiskResolved"


### PR DESCRIPTION
### **User description**
This commit updates the `BaseExceptionPolicy` struct in `exceptionpolicy.go` to use the `PolicyType` enum for the `PolicyType` field. It also adds two new constants, `SecurityRiskExceptionPolicyType` and `RuntimeIncidentExceptionPolicy`, to the `armotypes/securityrisks.go` file. These constants represent the policy types for security risks and runtime incidents respectively.


___

### **PR Type**
enhancement


___

### **Description**
- Added new constants `SecurityRiskExceptionPolicyType` and `RuntimeIncidentExceptionPolicy` to `exceptionpolicy.go` for defining policy types.
- Updated `BaseExceptionPolicy` struct to use the `PolicyType` enum for the `PolicyType` field.
- Removed duplicate `SecurityRiskExceptionPolicyType` constant from `securityrisks.go`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>exceptionpolicy.go</strong><dd><code>Update BaseExceptionPolicy and add policy constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/exceptionpolicy.go

<li>Added constants for security risk and runtime incident policies.<br> <li> Updated <code>PolicyType</code> field in <code>BaseExceptionPolicy</code> to use <code>PolicyType</code> <br>enum.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/357/files#diff-caad82220352ce147efd4dd0a9c88fe53f490b95f422f245566071bcf50281e9">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>securityrisks.go</strong><dd><code>Remove duplicate security risk policy constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/securityrisks.go

- Removed duplicate constant `SecurityRiskExceptionPolicyType`.



</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/357/files#diff-981dc5ae17066e45bdc7512f27f6bdcb6632757826f636039b2b88aaf83e8166">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

