### PR TITLE
refactor: Update SecurityRiskID field to SecurityRiskIDs slice

### DIFF
--- a/notifications/usernotificationreporttypes.go
+++ b/notifications/usernotificationreporttypes.go
@@ -90,7 +90,7 @@ type NotificationParams struct {
 	Fixable        *bool   `json:"fixable,omitempty" bson:"fixable,omitempty"`               // Fixable (CISA FX)
 
 	// security risks params
-	SecurityRiskID string `json:"securityRiskID,omitempty" bson:"securityRiskID,omitempty"` // Security Risk ID
+	SecurityRiskIDs []string `json:"securityRiskIDs,omitempty" bson:"securityRiskIDs,omitempty"` // Security Risk ID
 
 }
 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Refactored the `NotificationParams` struct in `usernotificationreporttypes.go` to replace the `SecurityRiskID` field with a `SecurityRiskIDs` slice.
- Updated JSON and BSON annotations to align with the new field name and type.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>usernotificationreporttypes.go</strong><dd><code>Refactor SecurityRiskID to SecurityRiskIDs slice in NotificationParams</code></dd></summary>
<hr>

notifications/usernotificationreporttypes.go

<li>Changed <code>SecurityRiskID</code> field from a single string to a slice of <br>strings <code>SecurityRiskIDs</code>.<br> <li> Updated JSON and BSON annotations to reflect the new field name and <br>type.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/363/files#diff-3c7e18817dc4b7f569df2e93256fc6f6f4da980004aa57447583deca6cd9ea06">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

