### PR TITLE
add scan statuses consts

### DIFF
--- a/armotypes/cloudposturetypes.go
+++ b/armotypes/cloudposturetypes.go
@@ -1,6 +1,6 @@
 package armotypes
 
-var SeverityToInt = map[string]int{
+var CloudSeverityToInt = map[string]int{
 	"critical": 500,
 	"high":     400,
 	"medium":   300,
@@ -8,7 +8,7 @@ var SeverityToInt = map[string]int{
 	"info":     100,
 }
 
-var CheckStatusToInt = map[string]int{
+var CloudCheckStatusToInt = map[string]int{
 	"EMPTY":   -1,
 	"MANUAL":  0,
 	"FAIL":    1,
@@ -16,7 +16,7 @@ var CheckStatusToInt = map[string]int{
 	"SKIPPED": 3,
 }
 
-var ScanStatusToInt = map[string]int{
+var CloudPostureScanStatusToInt = map[string]int{
 	ScanFailed:     1,
 	ScanInProgress: 2,
 	ScanSuccess:    3,

--- a/armotypes/cloudposturetypes.go
+++ b/armotypes/cloudposturetypes.go
@@ -17,7 +17,13 @@ var CheckStatusToInt = map[string]int{
 }
 
 var ScanStatusToInt = map[string]int{
-	"FAILED":     1,
-	"INPROGRESS": 2,
-	"SUCCESS":    3,
+	ScanFailed:     1,
+	ScanInProgress: 2,
+	ScanSuccess:    3,
 }
+
+const (
+	ScanFailed     = "FAILED"
+	ScanInProgress = "INPROGRESS"
+	ScanSuccess    = "SUCCESS"
+)

--- a/identifiers/designators.go
+++ b/identifiers/designators.go
@@ -151,12 +151,12 @@ const (
 
 // CSPM related attributes
 const (
-	AttributeAccountID   = "accountID"
-	AttributeAccountName = "accountName"
+	AttributeCloudAccountID   = "accountID"
+	AttributeCloudAccountName = "accountName"
 	AttributeFramework   = "framework"
-	AttributeScanID      = "scanID"
-	AttributeTaskID      = "taskID"
-	AttributeFindingType = "findingType"
+	AttributeCloudScanID      = "scanID"
+	AttributeCloudTaskID      = "taskID"
+	AttributeCloudFindingType = "findingType"
 )
 
 type mapString2String map[string]string


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added constants `ScanFailed`, `ScanInProgress`, and `ScanSuccess` to improve code readability and maintainability.
- Updated the `ScanStatusToInt` map to utilize the newly defined constants, replacing hardcoded string values.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cloudposturetypes.go</strong><dd><code>Add constants for scan statuses and update map</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/cloudposturetypes.go

<li>Introduced constants for scan statuses: <code>ScanFailed</code>, <code>ScanInProgress</code>, <br>and <code>ScanSuccess</code>.<br> <li> Updated <code>ScanStatusToInt</code> map to use the new constants.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/365/files#diff-b3664d35ac74c2a20b3065c3882c7a468863c6ef4e837a07ee17eabafce44fe2">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

