### PR TITLE
add opposite maps to intToValue

### DIFF
--- a/armotypes/cloudposturetypes.go
+++ b/armotypes/cloudposturetypes.go
@@ -7,10 +7,11 @@ var CloudSeverityToInt = map[string]int{
 	"medium":   300,
 	"low":      200,
 	"info":     100,
+	"unknown":  1,
 }
 
 var CloudIntToSeverity = map[int]string{
-	UnknownScore:  "Unknown",
+	UnknownScore:  "unknown",
 	InfoScore:     "info",
 	LowScore:      "low",
 	MediumScore:   "medium",

--- a/armotypes/cloudposturetypes.go
+++ b/armotypes/cloudposturetypes.go
@@ -1,5 +1,6 @@
 package armotypes
 
+// cloud severities
 var CloudSeverityToInt = map[string]int{
 	"critical": 500,
 	"high":     400,
@@ -8,6 +9,25 @@ var CloudSeverityToInt = map[string]int{
 	"info":     100,
 }
 
+var CloudIntToSeverity = map[int]string{
+	UnknownScore:  "Unknown",
+	InfoScore:     "info",
+	LowScore:      "low",
+	MediumScore:   "medium",
+	HighScore:     "high",
+	CriticalScore: "critical",
+}
+
+const (
+	UnknownScore  = 1
+	InfoScore     = 100
+	LowScore      = 200
+	MediumScore   = 300
+	HighScore     = 400
+	CriticalScore = 500
+)
+
+// cloud check statuses
 var CloudCheckStatusToInt = map[string]int{
 	"EMPTY":   -1,
 	"MANUAL":  0,
@@ -16,14 +36,35 @@ var CloudCheckStatusToInt = map[string]int{
 	"SKIPPED": 3,
 }
 
+var CloudIntToCheckStatus = map[int]string{
+	-1: "EMPTY",
+	0:  "MANUAL",
+	1:  "FAIL",
+	2:  "PASS",
+	3:  "SKIPPED",
+}
+
+// cloud posture scans statuses
 var CloudPostureScanStatusToInt = map[string]int{
 	ScanFailed:     1,
 	ScanInProgress: 2,
 	ScanSuccess:    3,
 }
 
+var CloudPostureScanIntToStatus = map[int]string{
+	ScanFailedScore:     ScanFailed,
+	ScanInProgressScore: ScanInProgress,
+	ScanSuccessScore:    ScanSuccess,
+}
+
 const (
 	ScanFailed     = "FAILED"
 	ScanInProgress = "INPROGRESS"
 	ScanSuccess    = "SUCCESS"
+)
+
+const (
+	ScanFailedScore     = 1
+	ScanInProgressScore = 2
+	ScanSuccessScore    = 3
 )


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added reverse mappings from integer values to severity strings in `CloudIntToSeverity`.
- Introduced constants for severity scores such as `UnknownScore`, `InfoScore`, etc.
- Added reverse mappings from integer values to check status strings in `CloudIntToCheckStatus`.
- Introduced constants for scan status scores such as `ScanFailedScore`, `ScanInProgressScore`, etc.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cloudposturetypes.go</strong><dd><code>Add reverse mappings and constants for cloud severities and statuses</code></dd></summary>
<hr>

armotypes/cloudposturetypes.go

<li>Added reverse mappings from integers to severity strings.<br> <li> Introduced constants for severity scores.<br> <li> Added reverse mappings from integers to check status strings.<br> <li> Introduced constants for scan status scores.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/366/files#diff-b3664d35ac74c2a20b3065c3882c7a468863c6ef4e837a07ee17eabafce44fe2">+41/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

