### PR TITLE
add registry types

### DIFF
--- a/armotypes/registrytypes.go
+++ b/armotypes/registrytypes.go
@@ -1,5 +1,7 @@
 package armotypes
 
+import "time"
+
 type RegistryJobParams struct {
 	Name            string `json:"name,omitempty"`
 	ID              string `json:"id,omitempty"`
@@ -31,4 +33,36 @@ type AuthMethod struct {
 
 type Repository struct {
 	RepositoryName string `json:"repositoryName"`
+}
+
+type RegistryProvider int
+
+const (
+	Quay RegistryProvider = iota
+	Harbor
+)
+
+type BaseContainerImageRegistry struct {
+	PortalBase    `json:",inline" bson:"inline"`
+	Provider      RegistryProvider `json:"provider" bson:"provider"`
+	ClusterName   string           `json:"clusterName" bson:"clusterName"`
+	Repositories  []string         `json:"repositories" bson:"repositories"`
+	LastScan      *time.Time       `json:"lastScan,omitempty" bson:"lastScan,omitempty"`
+	ScanFrequency string           `json:"scanFrequency,omitempty" bson:"scanFrequency,omitempty"`
+	ResourceHash  string           `json:"resourceHash,omitempty" bson:"resourceHash,omitempty"`
+	AuthID        string           `json:"authID,omitempty" bson:"authID"`
+}
+
+type QuayImageRegistry struct {
+	BaseContainerImageRegistry `json:",inline"`
+	ContainerRegistryName      string `json:"containerRegistryName"`
+	RobotAccountName           string `json:"RobotAccountName"`
+	RobotAccountToken          string `json:"RobotAccountToken"`
+}
+
+type HarborImageRegistry struct {
+	BaseContainerImageRegistry `json:",inline"`
+	InstanceURL                string `json:"instanceURL"`
+	Username                   string `json:"username"`
+	Password                   string `json:"password"`
 }


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Introduced new registry types and structures to support container image registries.
- Added `RegistryProvider` type with constants for `Quay` and `Harbor`.
- Implemented `BaseContainerImageRegistry` struct with fields for provider, cluster name, repositories, last scan, scan frequency, resource hash, and authentication ID.
- Created specific structs `QuayImageRegistry` and `HarborImageRegistry` extending `BaseContainerImageRegistry` with additional fields for registry-specific details.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>registrytypes.go</strong><dd><code>Add registry types and structures for container image registries</code></dd></summary>
<hr>

armotypes/registrytypes.go

<li>Added import for <code>time</code> package.<br> <li> Introduced <code>RegistryProvider</code> type and constants for <code>Quay</code> and <code>Harbor</code>.<br> <li> Added <code>BaseContainerImageRegistry</code> struct with fields for registry <br>details.<br> <li> Created <code>QuayImageRegistry</code> and <code>HarborImageRegistry</code> structs extending <br><code>BaseContainerImageRegistry</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/367/files#diff-48469d7277246ca60884cae3b5a818a6101c583069a4457d8189496e73d3b3bc">+34/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

