### PR TITLE
change checkStatuses ints and order

### DIFF
--- a/armotypes/cloudposturetypes.go
+++ b/armotypes/cloudposturetypes.go
@@ -31,18 +31,18 @@ const (
 // cloud check statuses
 var CloudCheckStatusToInt = map[string]int{
 	"EMPTY":   -1,
-	"MANUAL":  0,
-	"FAIL":    1,
-	"PASS":    2,
-	"SKIPPED": 3,
+	"FAIL":    10,
+	"MANUAL":  20,
+	"PASS":    30,
+	"SKIPPED": 40,
 }
 
 var CloudIntToCheckStatus = map[int]string{
 	-1: "EMPTY",
-	0:  "MANUAL",
-	1:  "FAIL",
-	2:  "PASS",
-	3:  "SKIPPED",
+	10:  "FAIL",
+	20:  "MANUAL",
+	30:  "PASS",
+	40:  "SKIPPED",
 }
 
 // cloud posture scans statuses


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the integer values associated with cloud check statuses to new values: "FAIL" to 10, "MANUAL" to 20, "PASS" to 30, and "SKIPPED" to 40.
- Adjusted the order of statuses in the `CloudCheckStatusToInt` map to reflect the new integer values.
- Updated the `CloudIntToCheckStatus` map to ensure consistency with the new integer values.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cloudposturetypes.go</strong><dd><code>Update cloud check statuses integer values and order</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/cloudposturetypes.go

<li>Updated integer values for cloud check statuses.<br> <li> Changed the order of statuses in <code>CloudCheckStatusToInt</code>.<br> <li> Updated corresponding integer-to-status mappings in <br><code>CloudIntToCheckStatus</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/371/files#diff-b3664d35ac74c2a20b3065c3882c7a468863c6ef4e837a07ee17eabafce44fe2">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information