### PR TITLE
add set base func

### DIFF
--- a/armotypes/registrymethods.go
+++ b/armotypes/registrymethods.go
@@ -70,6 +70,10 @@ func (aws *AWSImageRegistry) GetBase() *BaseContainerImageRegistry {
 	return &aws.BaseContainerImageRegistry
 }
 
+func (aws *AWSImageRegistry) SetBase(base *BaseContainerImageRegistry) {
+	aws.BaseContainerImageRegistry = *base
+}
+
 func (aws *AWSImageRegistry) Validate() error {
 	if err := aws.GetBase().ValidateBase(); err != nil {
 		return err
@@ -114,6 +118,10 @@ func (azure *AzureImageRegistry) GetBase() *BaseContainerImageRegistry {
 	return &azure.BaseContainerImageRegistry
 }
 
+func (azure *AzureImageRegistry) SetBase(base *BaseContainerImageRegistry) {
+	azure.BaseContainerImageRegistry = *base
+}
+
 func (azure *AzureImageRegistry) Validate() error {
 	if err := azure.GetBase().ValidateBase(); err != nil {
 		return err
@@ -154,6 +162,10 @@ func (google *GoogleImageRegistry) GetBase() *BaseContainerImageRegistry {
 	return &google.BaseContainerImageRegistry
 }
 
+func (google *GoogleImageRegistry) SetBase(base *BaseContainerImageRegistry) {
+	google.BaseContainerImageRegistry = *base
+}
+
 func (google *GoogleImageRegistry) Validate() error {
 	if err := google.GetBase().ValidateBase(); err != nil {
 		return err
@@ -189,6 +201,10 @@ func (harbor *HarborImageRegistry) FillSecret(value interface{}) error {
 
 func (harbor *HarborImageRegistry) GetBase() *BaseContainerImageRegistry {
 	return &harbor.BaseContainerImageRegistry
+}
+
+func (harbor *HarborImageRegistry) SetBase(base *BaseContainerImageRegistry) {
+	harbor.BaseContainerImageRegistry = *base
 }
 
 func (harbor *HarborImageRegistry) Validate() error {
@@ -232,6 +248,10 @@ func (quay *QuayImageRegistry) FillSecret(value interface{}) error {
 
 func (quay *QuayImageRegistry) GetBase() *BaseContainerImageRegistry {
 	return &quay.BaseContainerImageRegistry
+}
+
+func (quay *QuayImageRegistry) SetBase(base *BaseContainerImageRegistry) {
+	quay.BaseContainerImageRegistry = *base
 }
 
 func (quay *QuayImageRegistry) Validate() error {

--- a/armotypes/registrytypes.go
+++ b/armotypes/registrytypes.go
@@ -58,6 +58,7 @@ type ContainerImageRegistry interface {
 	ExtractSecret() interface{}
 	FillSecret(interface{}) error
 	GetBase() *BaseContainerImageRegistry
+	SetBase(*BaseContainerImageRegistry)
 	Validate() error
 }
 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Introduced a new `SetBase` method to the `ContainerImageRegistry` interface and implemented it in various registry structs (`AWSImageRegistry`, `AzureImageRegistry`, `GoogleImageRegistry`, `HarborImageRegistry`, `QuayImageRegistry`).
- The `SetBase` method allows setting a `BaseContainerImageRegistry` for each registry type, enhancing the configurability of the registries.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>registrymethods.go</strong><dd><code>Add SetBase method to image registry structs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/registrymethods.go

<li>Added <code>SetBase</code> method to <code>AWSImageRegistry</code>, <code>AzureImageRegistry</code>, <br><code>GoogleImageRegistry</code>, <code>HarborImageRegistry</code>, and <code>QuayImageRegistry</code>.<br> <li> The <code>SetBase</code> method assigns a <code>BaseContainerImageRegistry</code> to the <br>respective registry.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/378/files#diff-fcffd7c1e64787463a48c94352d89c087444666bdfcbd85955f5ece0733bcfc7">+20/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>registrytypes.go</strong><dd><code>Extend ContainerImageRegistry interface with SetBase method</code></dd></summary>
<hr>

armotypes/registrytypes.go

- Added `SetBase` method to `ContainerImageRegistry` interface.



</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/378/files#diff-48469d7277246ca60884cae3b5a818a6101c583069a4457d8189496e73d3b3bc">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information