### PR TITLE
registry types omitempty secret

### DIFF
--- a/armotypes/registrytypes.go
+++ b/armotypes/registrytypes.go
@@ -75,22 +75,22 @@ type BaseContainerImageRegistry struct {
 type QuayImageRegistry struct {
 	BaseContainerImageRegistry `json:",inline"`
 	ContainerRegistryName      string `json:"containerRegistryName"`
-	RobotAccountName           string `json:"RobotAccountName"`
-	RobotAccountToken          string `json:"RobotAccountToken"`
+	RobotAccountName           string `json:"robotAccountName"`
+	RobotAccountToken          string `json:"robotAccountToken,omitempty"`
 }
 
 type HarborImageRegistry struct {
 	BaseContainerImageRegistry `json:",inline"`
 	InstanceURL                string `json:"instanceURL"`
 	Username                   string `json:"username"`
-	Password                   string `json:"password"`
+	Password                   string `json:"password,omitempty"`
 }
 
 type AzureImageRegistry struct {
 	BaseContainerImageRegistry `json:",inline"`
 	LoginServer                string `json:"loginServer"`
 	Username                   string `json:"username"`
-	AccessToken                string `json:"accessToken"`
+	AccessToken                string `json:"accessToken,omitempty"`
 }
 
 type AWSImageRegistry struct {


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated JSON field names in `QuayImageRegistry`, `HarborImageRegistry`, and `AzureImageRegistry` to use camelCase for consistency.
- Added `omitempty` to `RobotAccountToken`, `Password`, and `AccessToken` fields to make them optional in JSON serialization.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>registrytypes.go</strong><dd><code>Update JSON field names and add omitempty in registry types</code></dd></summary>
<hr>

armotypes/registrytypes.go

<li>Changed JSON field names to camelCase for consistency.<br> <li> Added <code>omitempty</code> to several fields to allow them to be optional in JSON <br>serialization.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/379/files#diff-48469d7277246ca60884cae3b5a818a6101c583069a4457d8189496e73d3b3bc">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information