### PR TITLE
fix checktypes + add both check type

### DIFF
--- a/armotypes/cloudposturetypes.go
+++ b/armotypes/cloudposturetypes.go
@@ -37,7 +37,8 @@ const (
 	CloudCheckStatusSkipped = "SKIPPED"
 
 	CloudAutomatedCheckType = "AUTOMATED"
-	CloudManualCheckType    = CloudCheckStatusFail
+	CloudManualCheckType    = CloudCheckStatusManual
+	CloudManualAndAutomated = CloudAutomatedCheckType + "/" + CloudManualCheckType
 )
 
 var CloudCheckStatusToInt = map[string]int{


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the `CloudManualCheckType` constant to correctly use `CloudCheckStatusManual` instead of `CloudCheckStatusFail`.
- Introduced a new constant `CloudManualAndAutomated` to represent a combination of automated and manual check types.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cloudposturetypes.go</strong><dd><code>Update check type constants and add combined type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/cloudposturetypes.go

<li>Changed <code>CloudManualCheckType</code> to use <code>CloudCheckStatusManual</code>.<br> <li> Added new constant <code>CloudManualAndAutomated</code> to represent combined check <br>types.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/382/files#diff-b3664d35ac74c2a20b3065c3882c7a468863c6ef4e837a07ee17eabafce44fe2">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information