### PR TITLE
Adding trace + process fields

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -51,7 +51,7 @@ type StackFrame struct {
 	// User/Kernel space
 	UserSpace bool `json:"userSpace,omitempty" bson:"userSpace,omitempty"`
 	// Native/Source code
-	NativeCode bool `json:"nativeCode,omitempty" bson:"nativeCode,omitempty"`
+	NativeCode *bool `json:"nativeCode,omitempty" bson:"nativeCode,omitempty"`
 }
 
 type Trace struct {

--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -18,6 +18,9 @@ type Process struct {
 	Hardlink   string    `json:"hardlink,omitempty" bson:"hardlink,omitempty"`
 	Uid        *uint32   `json:"uid,omitempty" bson:"uid,omitempty"`
 	Gid        *uint32   `json:"gid,omitempty" bson:"gid,omitempty"`
+	UserName   string    `json:"userName,omitempty" bson:"userName,omitempty"`
+	GroupName  string    `json:"groupName,omitempty" bson:"groupName,omitempty"`
+	StartTime  time.Time `json:"startTime,omitempty" bson:"startTime,omitempty"`
 	UpperLayer *bool     `json:"upperLayer,omitempty" bson:"upperLayer,omitempty"`
 	Cwd        string    `json:"cwd,omitempty" bson:"cwd,omitempty"`
 	Path       string    `json:"path,omitempty" bson:"path,omitempty"`
@@ -31,6 +34,36 @@ const (
 	AlertTypeMalware
 	AlertTypeAdmission
 )
+
+type StackFrame struct {
+	// Frame ID
+	FrameID string `json:"frameId,omitempty" bson:"frameId,omitempty"`
+	// Function name
+	Function string `json:"function,omitempty" bson:"function,omitempty"`
+	// File name
+	File string `json:"file,omitempty" bson:"file,omitempty"`
+	// Line number
+	Line *int `json:"line,omitempty" bson:"line,omitempty"`
+	// Address
+	Address string `json:"address,omitempty" bson:"address,omitempty"`
+	// Arguments
+	Arguments []string `json:"arguments,omitempty" bson:"arguments,omitempty"`
+	// User/Kernel space
+	UserSpace bool `json:"userSpace,omitempty" bson:"userSpace,omitempty"`
+	// Native/Source code
+	NativeCode bool `json:"nativeCode,omitempty" bson:"nativeCode,omitempty"`
+}
+
+type Trace struct {
+	// Trace ID
+	TraceID string `json:"traceId,omitempty" bson:"traceId,omitempty"`
+	// Stack trace
+	Stack []StackFrame `json:"stack,omitempty" bson:"stack,omitempty"`
+	// Package name
+	Package string `json:"package,omitempty" bson:"package,omitempty"`
+	// Language
+	Language string `json:"language,omitempty" bson:"language,omitempty"`
+}
 
 type BaseRuntimeAlert struct {
 	// AlertName is either RuleName or MalwareName
@@ -57,6 +90,8 @@ type BaseRuntimeAlert struct {
 	Timestamp time.Time `json:"timestamp" bson:"timestamp"`
 	// Nanoseconds of the alert
 	Nanoseconds uint64 `json:"nanoseconds,omitempty" bson:"nanoseconds,omitempty"`
+	// Trace of the alert
+	Trace Trace `json:"trace,omitempty" bson:"trace,omitempty"`
 }
 
 type RuleAlert struct {

--- a/armotypes/runtimeincidents_test.go
+++ b/armotypes/runtimeincidents_test.go
@@ -18,11 +18,7 @@ func TestAdmissionAlert(t *testing.T) {
 		Resource:         schema.GroupVersionResource{},
 		Subresource:      "test-subresource",
 		Operation:        admission.Create,
-		Options:          nil,
 		DryRun:           false,
-		Object:           nil,
-		OldObject:        nil,
-		UserInfo:         nil,
 	}
 
 	assert.Equal(t, "test-namespace", alert.RequestNamespace)


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Enhanced the `Process` struct by adding `UserName`, `GroupName`, and `StartTime` fields to provide more detailed process information.
- Introduced new `StackFrame` and `Trace` structs to represent stack traces and trace information.
- Updated the `BaseRuntimeAlert` struct to include a `Trace` field, allowing for more comprehensive alert data.
- Refactored the `TestAdmissionAlert` by removing unused fields to streamline the test structure.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Enhance runtime incident structures with trace and process details</code></dd></summary>
<hr>

armotypes/runtimeincidents.go

<li>Added <code>UserName</code>, <code>GroupName</code>, and <code>StartTime</code> fields to <code>Process</code> struct.<br> <li> Introduced new <code>StackFrame</code> and <code>Trace</code> structs.<br> <li> Added <code>Trace</code> field to <code>BaseRuntimeAlert</code> struct.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/386/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+35/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents_test.go</strong><dd><code>Refactor admission alert test structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/runtimeincidents_test.go

<li>Removed unused fields <code>Options</code>, <code>Object</code>, <code>OldObject</code>, and <code>UserInfo</code> from <br><code>AdmissionAlert</code> test.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/386/files#diff-a55322bfd4651ff3ac5c63185f1a2824ff9f32bfb61e21619df17f533dbf0185">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information