### PR TITLE
Removing provider type

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -27,18 +27,9 @@ type Process struct {
 	Children   []Process `json:"children,omitempty" bson:"children,omitempty"`
 }
 
-type Provider string
-
-// Cloud providers (The Provider suffix is added to avoid conflicts with other Provider types :( ).
-const (
-	AWSProvider          Provider = "aws"
-	GCPProvider          Provider = "gcp"
-	AzureProvider        Provider = "azure"
-	DigitalOceanProvider Provider = "digitalocean"
-)
-
 type CloudMetadata struct {
-	Provider     Provider `json:"provider,omitempty" bson:"provider,omitempty"`
+	// Provider is the cloud provider name (e.g. aws, gcp, azure).
+	Provider     string `json:"provider,omitempty" bson:"provider,omitempty"`
 	InstanceID   string   `json:"instance_id,omitempty" bson:"instance_id,omitempty"`
 	InstanceType string   `json:"instance_type,omitempty" bson:"instance_type,omitempty"`
 	Region       string   `json:"region,omitempty" bson:"region,omitempty"`


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Removed the custom `Provider` type and its constants, simplifying the code.
- Changed the `Provider` field in `CloudMetadata` to a `string`, allowing for more flexible provider naming.
- Updated comments to clarify the usage of the `Provider` field.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Simplify cloud provider representation in CloudMetadata</code>&nbsp; &nbsp; </dd></summary>
<hr>

armotypes/runtimeincidents.go

<li>Removed the <code>Provider</code> type definition and its associated constants.<br> <li> Changed the <code>Provider</code> field in <code>CloudMetadata</code> from a custom type to a <br><code>string</code>.<br> <li> Updated comments to reflect the change in the <code>Provider</code> field.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/388/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+2/-11</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information