### PR TITLE
add checkType map

### DIFF
--- a/armotypes/cloudposturetypes.go
+++ b/armotypes/cloudposturetypes.go
@@ -35,10 +35,6 @@ const (
 	CloudCheckStatusManual  = "MANUAL"
 	CloudCheckStatusPass    = "PASS"
 	CloudCheckStatusSkipped = "SKIPPED"
-
-	CloudAutomatedCheckType = "AUTOMATED"
-	CloudManualCheckType    = CloudCheckStatusManual
-	CloudManualAndAutomated = CloudAutomatedCheckType + "/" + CloudManualCheckType
 )
 
 var CloudCheckStatusToInt = map[string]int{
@@ -55,6 +51,25 @@ var CloudIntToCheckStatus = map[int]string{
 	20: CloudCheckStatusManual,
 	30: CloudCheckStatusPass,
 	40: CloudCheckStatusSkipped,
+}
+
+// cloud check types
+const (
+	CloudAutomatedCheckType = "AUTOMATED"
+	CloudManualCheckType    = CloudCheckStatusManual
+	CloudManualAndAutomated = CloudAutomatedCheckType + "/" + CloudManualCheckType
+)
+
+var CloudCheckTypeToInt = map[string]int{
+	CloudAutomatedCheckType: 10,
+	CloudManualCheckType:    20,
+	CloudManualAndAutomated: 30,
+}
+
+var CloudIntToCheckType = map[int]string{
+	10: CloudAutomatedCheckType,
+	20: CloudManualCheckType,
+	30: CloudManualAndAutomated,
 }
 
 // cloud posture scans statuses

--- a/armotypes/cloudposturetypes.go
+++ b/armotypes/cloudposturetypes.go
@@ -55,18 +55,21 @@ var CloudIntToCheckStatus = map[int]string{
 
 // cloud check types
 const (
+	CloudEmptyCheckType     = "EMPTY"
 	CloudAutomatedCheckType = "AUTOMATED"
 	CloudManualCheckType    = CloudCheckStatusManual
 	CloudManualAndAutomated = CloudAutomatedCheckType + "/" + CloudManualCheckType
 )
 
 var CloudCheckTypeToInt = map[string]int{
+	CloudEmptyCheckType:     -1,
 	CloudAutomatedCheckType: 10,
 	CloudManualCheckType:    20,
 	CloudManualAndAutomated: 30,
 }
 
 var CloudIntToCheckType = map[int]string{
+	-1: CloudEmptyCheckType,
 	10: CloudAutomatedCheckType,
 	20: CloudManualCheckType,
 	30: CloudManualAndAutomated,


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Introduced new mappings `CloudCheckTypeToInt` and `CloudIntToCheckType` to convert between cloud check types and integers.
- Reorganized constants related to cloud check types for better clarity and separation from cloud check statuses.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cloudposturetypes.go</strong><dd><code>Add mappings for cloud check types to integers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/cloudposturetypes.go

<li>Added a new mapping <code>CloudCheckTypeToInt</code> for cloud check types to <br>integers.<br> <li> Added a new mapping <code>CloudIntToCheckType</code> for integers to cloud check <br>types.<br> <li> Moved constants related to cloud check types to a new section.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/390/files#diff-b3664d35ac74c2a20b3065c3882c7a468863c6ef4e837a07ee17eabafce44fe2">+19/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information