### PR TITLE
* remove idle status * add gar key field

### DIFF
--- a/armotypes/registrymethods.go
+++ b/armotypes/registrymethods.go
@@ -137,7 +137,7 @@ func (azure *AzureImageRegistry) GetDisplayName() string {
 }
 
 func (google *GoogleImageRegistry) MaskSecret() {
-
+	google.Key = nil
 }
 
 func (google *GoogleImageRegistry) ExtractSecret() interface{} {
@@ -161,6 +161,9 @@ func (google *GoogleImageRegistry) Validate() error {
 	}
 	if google.RegistryURI == "" {
 		return errors.New("registryURI is empty")
+	}
+	if len(google.Key) == 0 {
+		return errors.New("json key is empty")
 	}
 	return nil
 }

--- a/armotypes/registrytypes.go
+++ b/armotypes/registrytypes.go
@@ -64,7 +64,6 @@ const (
 	Error   RegistryManageStatus = "Error"
 
 	// Scan statuses
-	Idle       RegistryScanStatus = "Idle"
 	Failed     RegistryScanStatus = "Failed"
 	InProgress RegistryScanStatus = "In progress"
 	Completed  RegistryScanStatus = "Completed"
@@ -128,7 +127,8 @@ type AWSImageRegistry struct {
 
 type GoogleImageRegistry struct {
 	BaseContainerImageRegistry `json:",inline"`
-	RegistryURI                string `json:"registryURI"`
+	RegistryURI                string                 `json:"registryURI"`
+	Key                        map[string]interface{} `json:"key,omitempty"`
 }
 
 type NexusImageRegistry struct {


### PR DESCRIPTION
### **PR Type**
enhancement, bug fix


___

### **Description**
- Enhanced `GoogleImageRegistry` by adding a `Key` field and ensuring it is validated for emptiness.
- Improved security by setting the `Key` to nil in the `MaskSecret` method.
- Removed the `Idle` status from `RegistryScanStatus`, streamlining status management.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>registrymethods.go</strong><dd><code>Enhance GoogleImageRegistry with key validation and masking</code></dd></summary>
<hr>

armotypes/registrymethods.go

<li>Added a check for empty <code>Key</code> in <code>Validate</code> method.<br> <li> Set <code>Key</code> to nil in <code>MaskSecret</code> method.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/393/files#diff-fcffd7c1e64787463a48c94352d89c087444666bdfcbd85955f5ece0733bcfc7">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>registrytypes.go</strong><dd><code>Update registry types with new key field and status removal</code></dd></summary>
<hr>

armotypes/registrytypes.go

<li>Removed <code>Idle</code> status from <code>RegistryScanStatus</code>.<br> <li> Added <code>Key</code> field to <code>GoogleImageRegistry</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/393/files#diff-48469d7277246ca60884cae3b5a818a6101c583069a4457d8189496e73d3b3bc">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information