### PR TITLE
use map[string]interface for gar key

### DIFF
--- a/armotypes/registrymethods.go
+++ b/armotypes/registrymethods.go
@@ -59,7 +59,7 @@ func (aws *AWSImageRegistry) ExtractSecret() interface{} {
 }
 
 func (aws *AWSImageRegistry) FillSecret(value interface{}) error {
-	secretMap, err := decodeSecretMapFromInterface(value)
+	secretMap, err := decodeSecretFromInterface[map[string]string](value)
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func (azure *AzureImageRegistry) ExtractSecret() interface{} {
 }
 
 func (azure *AzureImageRegistry) FillSecret(value interface{}) error {
-	secretMap, err := decodeSecretMapFromInterface(value)
+	secretMap, err := decodeSecretFromInterface[map[string]string](value)
 	if err != nil {
 		return err
 	}
@@ -141,17 +141,19 @@ func (google *GoogleImageRegistry) MaskSecret() {
 }
 
 func (google *GoogleImageRegistry) ExtractSecret() interface{} {
-	return map[string]string{
+	return map[string]interface{}{
 		"registryURI": google.RegistryURI,
+		"key":         google.Key,
 	}
 }
 
 func (google *GoogleImageRegistry) FillSecret(value interface{}) error {
-	secretMap, err := decodeSecretMapFromInterface(value)
+	secretMap, err := decodeSecretFromInterface[map[string]interface{}](value)
 	if err != nil {
 		return err
 	}
-	google.RegistryURI = secretMap["registryURI"]
+	google.RegistryURI = secretMap["registryURI"].(string)
+	google.Key = secretMap["key"].(map[string]interface{})
 	return nil
 }
 
@@ -185,7 +187,7 @@ func (harbor *HarborImageRegistry) ExtractSecret() interface{} {
 }
 
 func (harbor *HarborImageRegistry) FillSecret(value interface{}) error {
-	secretMap, err := decodeSecretMapFromInterface(value)
+	secretMap, err := decodeSecretFromInterface[map[string]string](value)
 	if err != nil {
 		return err
 	}
@@ -234,7 +236,7 @@ func (quay *QuayImageRegistry) ExtractSecret() interface{} {
 }
 
 func (quay *QuayImageRegistry) FillSecret(value interface{}) error {
-	secretMap, err := decodeSecretMapFromInterface(value)
+	secretMap, err := decodeSecretFromInterface[map[string]string](value)
 	if err != nil {
 		return err
 	}
@@ -277,7 +279,7 @@ func (nexus *NexusImageRegistry) ExtractSecret() interface{} {
 }
 
 func (nexus *NexusImageRegistry) FillSecret(value interface{}) error {
-	secretMap, err := decodeSecretMapFromInterface(value)
+	secretMap, err := decodeSecretFromInterface[map[string]string](value)
 	if err != nil {
 		return err
 	}
@@ -307,8 +309,8 @@ func (nexus *NexusImageRegistry) GetDisplayName() string {
 	return nexus.RegistryURL
 }
 
-func decodeSecretMapFromInterface(value interface{}) (map[string]string, error) {
-	var res map[string]string
+func decodeSecretFromInterface[T any](value interface{}) (T, error) {
+	var res T
 	if value == nil {
 		return res, errors.New("got an empty value")
 	}


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Enhanced the `ExtractSecret` method for `GoogleImageRegistry` to return a `map[string]interface{}` to accommodate more complex data structures.
- Refactored `FillSecret` methods across various registry types to use a generic `decodeSecretFromInterface` function with type parameters, improving code flexibility and reusability.
- Updated the `decodeSecretFromInterface` function to be generic, allowing it to handle different map types.
- Adjusted the handling of the `google.Key` field in `GoogleImageRegistry` to support a `map[string]interface{}` structure.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>registrymethods.go</strong><dd><code>Enhance secret handling with generic decode function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/registrymethods.go

<li>Changed <code>ExtractSecret</code> method for <code>GoogleImageRegistry</code> to return <br><code>map[string]interface{}</code>.<br> <li> Updated <code>FillSecret</code> methods to use <code>decodeSecretFromInterface</code> with type <br>parameters.<br> <li> Modified <code>decodeSecretFromInterface</code> function to be generic.<br> <li> Updated handling of <code>google.Key</code> to use <code>map[string]interface{}</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/394/files#diff-fcffd7c1e64787463a48c94352d89c087444666bdfcbd85955f5ece0733bcfc7">+12/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information