### PR TITLE
change registry in progress status to upper case

### DIFF
--- a/armotypes/registrytypes.go
+++ b/armotypes/registrytypes.go
@@ -65,7 +65,7 @@ const (
 
 	// Scan statuses
 	Failed     RegistryScanStatus = "Failed"
-	InProgress RegistryScanStatus = "In progress"
+	InProgress RegistryScanStatus = "In Progress"
 	Completed  RegistryScanStatus = "Completed"
 )
 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the `InProgress` registry scan status to use upper case for "Progress" to ensure consistency in status string casing.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>registrytypes.go</strong><dd><code>Update registry status to consistent casing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/registrytypes.go

<li>Changed the <code>InProgress</code> status string to use upper case for "Progress".<br> <li> Ensures consistency in the casing of status strings.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/395/files#diff-48469d7277246ca60884cae3b5a818a6101c583069a4457d8189496e73d3b3bc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information