### PR TITLE
Added old image field

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -30,14 +30,14 @@ type Process struct {
 type CloudMetadata struct {
 	// Provider is the cloud provider name (e.g. aws, gcp, azure).
 	Provider     string `json:"provider,omitempty" bson:"provider,omitempty"`
-	InstanceID   string   `json:"instance_id,omitempty" bson:"instance_id,omitempty"`
-	InstanceType string   `json:"instance_type,omitempty" bson:"instance_type,omitempty"`
-	Region       string   `json:"region,omitempty" bson:"region,omitempty"`
-	Zone         string   `json:"zone,omitempty" bson:"zone,omitempty"`
-	PrivateIP    string   `json:"private_ip,omitempty" bson:"private_ip,omitempty"`
-	PublicIP     string   `json:"public_ip,omitempty" bson:"public_ip,omitempty"`
-	Hostname     string   `json:"hostname,omitempty" bson:"hostname,omitempty"`
-	AccountID    string   `json:"account_id,omitempty" bson:"account_id,omitempty"`
+	InstanceID   string `json:"instance_id,omitempty" bson:"instance_id,omitempty"`
+	InstanceType string `json:"instance_type,omitempty" bson:"instance_type,omitempty"`
+	Region       string `json:"region,omitempty" bson:"region,omitempty"`
+	Zone         string `json:"zone,omitempty" bson:"zone,omitempty"`
+	PrivateIP    string `json:"private_ip,omitempty" bson:"private_ip,omitempty"`
+	PublicIP     string `json:"public_ip,omitempty" bson:"public_ip,omitempty"`
+	Hostname     string `json:"hostname,omitempty" bson:"hostname,omitempty"`
+	AccountID    string `json:"account_id,omitempty" bson:"account_id,omitempty"`
 }
 
 type AlertType int
@@ -134,6 +134,7 @@ type RuntimeAlertK8sDetails struct {
 	ClusterName       string            `json:"clusterName" bson:"clusterName"`
 	ContainerName     string            `json:"containerName,omitempty" bson:"containerName,omitempty"`
 	HostNetwork       *bool             `json:"hostNetwork,omitempty" bson:"hostNetwork,omitempty"`
+	OldImage          string            `json:"oldImage,omitempty" bson:"oldImage,omitempty"`
 	Image             string            `json:"image,omitempty" bson:"image,omitempty"`
 	ImageDigest       string            `json:"imageDigest,omitempty" bson:"imageDigest,omitempty"`
 	Namespace         string            `json:"namespace,omitempty" bson:"namespace,omitempty"`


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added a new field `OldImage` to the `RuntimeAlertK8sDetails` struct to store information about the previous image used.
- Reformatted the `CloudMetadata` struct for consistent spacing and alignment of fields.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Add `OldImage` field and adjust struct formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/runtimeincidents.go

<li>Added <code>OldImage</code> field to <code>RuntimeAlertK8sDetails</code> struct.<br> <li> Adjusted formatting for fields in <code>CloudMetadata</code> struct.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/399/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information