### PR TITLE
fix: add missing bson tags for CVSS fields in AggregatedVulnerability…

### DIFF
--- a/notifications/vulnerability.go
+++ b/notifications/vulnerability.go
@@ -26,8 +26,8 @@ type AggregatedVulnerability struct {
 	UpdatedTime      string                `json:"updatedTime,omitempty" bson:"updatedTime,omitempty"`
 	Exploitable      string                `json:"exploitable,omitempty" bson:"exploitable,omitempty"`
 	IsRelevant       string                `json:"isRelevant,omitempty" bson:"isRelevant,omitempty"`
-	CVSSBaseScore    float64               `json:"cvssBaseScore"`
-	CVSSScoreVersion string                `json:"cvssScoreVersion"`
+	CVSSBaseScore    float64               `json:"cvssBaseScore" bson:"cvssBaseScore"`
+	CVSSScoreVersion string                `json:"cvssScoreVersion" bson:"cvssScoreVersion"`
 	CvssInfo         armotypes.CvssInfo    `json:"cvssInfo,omitempty" bson:"cvssInfo,omitempty"`
 	EpssInfo         armotypes.EpssInfo    `json:"epssInfo,omitempty" bson:"epssInfo,omitempty"`
 	CisaKevInfo      armotypes.CisaKevInfo `json:"cisaKevInfo,omitempty" bson:"cisaKevInfo,omitempty"`


### PR DESCRIPTION
### **User description**
… struct


___

### **PR Type**
Bug fix


___

### **Description**
- Added missing BSON tags to the `CVSSBaseScore` and `CVSSScoreVersion` fields in the `AggregatedVulnerability` struct to ensure proper serialization and deserialization.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vulnerability.go</strong><dd><code>Add missing BSON tags to CVSS fields in struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

notifications/vulnerability.go

<li>Added missing BSON tags for <code>CVSSBaseScore</code> and <code>CVSSScoreVersion</code> fields.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/402/files#diff-8fa30a8cf686a914c5546af1bde262eccf1dce7babed3065c29615d10c507e49">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information