### PR TITLE
rename registry scan status kind

### DIFF
--- a/armotypes/registrytypes.go
+++ b/armotypes/registrytypes.go
@@ -95,8 +95,8 @@ type BaseContainerImageRegistry struct {
 	ScanStatusMessage   string               `json:"scanStatusMessage,omitempty" bson:"scanStatusMessage"`
 }
 
-const RegistryScanStatusPath = "registrystatuses"
-const RegistryScanStatusKind = "RegistryStatus"
+const RegistryScanStatusesKindPath = "registrystatuses"
+const RegistryScanStatusesKind = "RegistryStatuses"
 
 type ContainerImageRegistryScanStatusUpdate struct {
 	GUID              string             `json:"guid"`


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Renamed the constant `RegistryScanStatusKind` from "RegistryStatus" to "RegistryStatuses" to better reflect its purpose or usage.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>registrytypes.go</strong><dd><code>Rename constant for registry scan status kind</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/registrytypes.go

<li>Renamed the constant <code>RegistryScanStatusKind</code> from "RegistryStatus" to <br>"RegistryStatuses".<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/403/files#diff-48469d7277246ca60884cae3b5a818a6101c583069a4457d8189496e73d3b3bc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information