### PR TITLE
Adding services to cloudmetadata

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -29,15 +29,16 @@ type Process struct {
 
 type CloudMetadata struct {
 	// Provider is the cloud provider name (e.g. aws, gcp, azure).
-	Provider     string `json:"provider,omitempty" bson:"provider,omitempty"`
-	InstanceID   string `json:"instance_id,omitempty" bson:"instance_id,omitempty"`
-	InstanceType string `json:"instance_type,omitempty" bson:"instance_type,omitempty"`
-	Region       string `json:"region,omitempty" bson:"region,omitempty"`
-	Zone         string `json:"zone,omitempty" bson:"zone,omitempty"`
-	PrivateIP    string `json:"private_ip,omitempty" bson:"private_ip,omitempty"`
-	PublicIP     string `json:"public_ip,omitempty" bson:"public_ip,omitempty"`
-	Hostname     string `json:"hostname,omitempty" bson:"hostname,omitempty"`
-	AccountID    string `json:"account_id,omitempty" bson:"account_id,omitempty"`
+	Provider     string   `json:"provider,omitempty" bson:"provider,omitempty"`
+	InstanceID   string   `json:"instance_id,omitempty" bson:"instance_id,omitempty"`
+	InstanceType string   `json:"instance_type,omitempty" bson:"instance_type,omitempty"`
+	Region       string   `json:"region,omitempty" bson:"region,omitempty"`
+	Zone         string   `json:"zone,omitempty" bson:"zone,omitempty"`
+	PrivateIP    string   `json:"private_ip,omitempty" bson:"private_ip,omitempty"`
+	PublicIP     string   `json:"public_ip,omitempty" bson:"public_ip,omitempty"`
+	Hostname     string   `json:"hostname,omitempty" bson:"hostname,omitempty"`
+	AccountID    string   `json:"account_id,omitempty" bson:"account_id,omitempty"`
+	Services     []string `json:"services,omitempty" bson:"services,omitempty"`
 }
 
 type AlertType int


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Enhanced the `CloudMetadata` struct by adding a new field `Services`.
- The `Services` field is a slice of strings that can store information about cloud services.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Add `Services` field to `CloudMetadata` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/runtimeincidents.go

<li>Added a new field <code>Services</code> to the <code>CloudMetadata</code> struct.<br> <li> The <code>Services</code> field is a slice of strings.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/404/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+10/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information