### PR TITLE
show region as display name

### DIFF
--- a/armotypes/registrymethods.go
+++ b/armotypes/registrymethods.go
@@ -91,7 +91,7 @@ func (aws *AWSImageRegistry) Validate() error {
 }
 
 func (aws *AWSImageRegistry) GetDisplayName() string {
-	return aws.Registry
+	return aws.RegistryRegion
 }
 
 func (azure *AzureImageRegistry) MaskSecret() {


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the `GetDisplayName` method in the `AWSImageRegistry` to return `aws.RegistryRegion` instead of `aws.Registry`.
- This change ensures that the display name reflects the region of the AWS registry.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>registrymethods.go</strong><dd><code>Update AWSImageRegistry display name to use region</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/registrymethods.go

<li>Changed the return value of <code>GetDisplayName</code> method in <code>AWSImageRegistry</code> <br>from <code>aws.Registry</code> to <code>aws.RegistryRegion</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/405/files#diff-fcffd7c1e64787463a48c94352d89c087444666bdfcbd85955f5ece0733bcfc7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information