### PR TITLE
change IntegrationsConnectionStatus provider field to string

### DIFF
--- a/notifications/collaborationconfig.go
+++ b/notifications/collaborationconfig.go
@@ -88,6 +88,6 @@ const (
 )
 
 type IntegrationsConnectionStatus struct {
-	Provider ChannelProvider             `json:"provider"`
+	Provider string                      `json:"provider"`
 	Status   IntegrationConnectionStatus `json:"status"`
 }


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Changed the type of the `Provider` field in the `IntegrationsConnectionStatus` struct from `ChannelProvider` to `string`.
- This change likely simplifies the handling of provider information by using a basic data type.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>collaborationconfig.go</strong><dd><code>Modify `Provider` field type to string in struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

notifications/collaborationconfig.go

<li>Changed the <code>Provider</code> field type from <code>ChannelProvider</code> to <code>string</code> in <br><code>IntegrationsConnectionStatus</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/406/files#diff-59047d8f2741f85941916f1efa7b619c5917e272ce3052ee88bdb3f9235ae841">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information