### PR TITLE
allow resetting scan frequency

### DIFF
--- a/armotypes/registrytypes.go
+++ b/armotypes/registrytypes.go
@@ -85,7 +85,7 @@ type BaseContainerImageRegistry struct {
 	ClusterName         string               `json:"clusterName" bson:"clusterName"`
 	Repositories        []string             `json:"repositories" bson:"repositories"`
 	LastScan            *time.Time           `json:"lastScan,omitempty" bson:"lastScan,omitempty"`
-	ScanFrequency       string               `json:"scanFrequency,omitempty" bson:"scanFrequency,omitempty"`
+	ScanFrequency       string               `json:"scanFrequency,omitempty" bson:"scanFrequency"`
 	NextScan            *time.Time           `json:"nextScan,omitempty" bson:"nextScan,omitempty"`
 	ResourceName        string               `json:"resourceName,omitempty" bson:"resourceName,omitempty"`
 	AuthID              string               `json:"authID,omitempty" bson:"authID"`


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Removed the `omitempty` tag from the `ScanFrequency` field in the `BaseContainerImageRegistry` struct to allow resetting the scan frequency.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>registrytypes.go</strong><dd><code>Modify JSON tag for ScanFrequency field in struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/registrytypes.go

<li>Removed <code>omitempty</code> tag from <code>ScanFrequency</code> field in <br><code>BaseContainerImageRegistry</code> struct.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/408/files#diff-48469d7277246ca60884cae3b5a818a6101c583069a4457d8189496e73d3b3bc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information