### PR TITLE
removing the uniq ids

### DIFF
--- a/armotypes/integrationtypes.go
+++ b/armotypes/integrationtypes.go
@@ -8,6 +8,7 @@ const (
 
 type Ticket struct {
 	GUID          string              `json:"guid,omitempty"`         //ticket guid in armo
+	IntegrationID string              `json:"integrationID,omitempty"`//integration guid in armo
 	TicketManager TicketManager       `json:"ticketManager"`          //ticket service provider
 	Owner         map[string]string   `json:"owner,omitempty"`        //armo entity that owns the ticket
 	Subjects      []map[string]string `json:"subjects,omitempty"`     //armo entities mentioned in the ticket

--- a/armotypes/integrationtypes.go
+++ b/armotypes/integrationtypes.go
@@ -8,7 +8,6 @@ const (
 
 type Ticket struct {
 	GUID          string              `json:"guid,omitempty"`         //ticket guid in armo
-	IntegrationID string              `json:"integrationID,omitempty"`//integration guid in armo
 	TicketManager TicketManager       `json:"ticketManager"`          //ticket service provider
 	Owner         map[string]string   `json:"owner,omitempty"`        //armo entity that owns the ticket
 	Subjects      []map[string]string `json:"subjects,omitempty"`     //armo entities mentioned in the ticket

--- a/notifications/collaborationconfig.go
+++ b/notifications/collaborationconfig.go
@@ -63,9 +63,6 @@ type CollaborationConfig struct {
 	// Example: jira
 	Provider ChannelProvider `json:"provider,omitempty" bson:"provider,omitempty"`
 
-	// Integration ID for supporting multiple integrations to jira
-	IntegrationID string `json:"IntegrationID,omitempty" bson:"integrationID,omitempty"`
-
 	// Host name for private hosting
 	// Example: http://example.com
 	HostName string `json:"hostName,omitempty" bson:"hostName,omitempty"`


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Removed the `IntegrationID` field from the `Ticket` struct in `armotypes/integrationtypes.go`.
- Removed the `IntegrationID` field from the `CollaborationConfig` struct in `notifications/collaborationconfig.go`.
- Simplified the data structures by eliminating unnecessary fields related to integration IDs.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>integrationtypes.go</strong><dd><code>Remove `IntegrationID` from `Ticket` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/integrationtypes.go

<li>Removed the <code>IntegrationID</code> field from the <code>Ticket</code> struct.<br> <li> Simplified the <code>Ticket</code> struct by eliminating unnecessary fields.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/411/files#diff-d0bbd8123c6caf6d59e03d8cf5eaee42d2e382bc73405144e1d3f19838d2bb64">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>collaborationconfig.go</strong><dd><code>Remove `IntegrationID` from `CollaborationConfig` struct</code>&nbsp; </dd></summary>
<hr>

notifications/collaborationconfig.go

<li>Removed the <code>IntegrationID</code> field from the <code>CollaborationConfig</code> struct.<br> <li> Streamlined the <code>CollaborationConfig</code> struct by removing redundant <br>fields.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/411/files#diff-59047d8f2741f85941916f1efa7b619c5917e272ce3052ee88bdb3f9235ae841">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information