### PR TITLE
drop omitempty

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -63,7 +63,7 @@ type StackFrame struct {
 	// Arguments
 	Arguments []string `json:"arguments,omitempty" bson:"arguments,omitempty"`
 	// User/Kernel space
-	UserSpace bool `json:"userSpace,omitempty" bson:"userSpace,omitempty"`
+	UserSpace bool `json:"userSpace" bson:"userSpace"`
 	// Native/Source code
 	NativeCode *bool `json:"nativeCode,omitempty" bson:"nativeCode,omitempty"`
 }


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Removed the `omitempty` tag from the `UserSpace` field in the `StackFrame` struct within `armotypes/runtimeincidents.go`.
- This change ensures that the `UserSpace` field is always included during JSON and BSON serialization, even if it is set to its zero value.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Remove `omitempty` from `UserSpace` field in `StackFrame`</code></dd></summary>
<hr>

armotypes/runtimeincidents.go

<li>Removed <code>omitempty</code> tag from <code>UserSpace</code> field in <code>StackFrame</code> struct.<br> <li> Ensures <code>UserSpace</code> is always included in JSON and BSON serialization.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/413/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information