### PR TITLE
add AP scanning related types

### DIFF
--- a/apis/clusterapis.go
+++ b/apis/clusterapis.go
@@ -2,12 +2,13 @@ package apis
 
 // WebsocketScanCommand api
 const (
-	VulnerabilityScanCommandVersion string = "v1"
-	ContainerScanCommandPath        string = "scanImage"
-	RegistryScanCommandPath         string = "scanRegistryImage"
-	SBOMCalculationCommandPath      string = "generateSBOM"
-	DBCommandPath                   string = "DBCommand"
-	ServerReady                     string = "ready"
+	VulnerabilityScanCommandVersion   string = "v1"
+	ApplicationProfileScanCommandPath string = "scanApplicationProfile"
+	ContainerScanCommandPath          string = "scanImage"
+	RegistryScanCommandPath           string = "scanRegistryImage"
+	SBOMCalculationCommandPath        string = "generateSBOM"
+	DBCommandPath                     string = "DBCommand"
+	ServerReady                       string = "ready"
 )
 
 // Supported NotificationTypes
@@ -37,6 +38,8 @@ const (
 	TypeDeleteVulnScanCronJob NotificationPolicyType = "deleteVulnScanCronJob"
 	// Trigger an image scan
 	TypeScanImages NotificationPolicyType = "scan"
+	// Trigger an Application Profile scan
+	TypeScanApplicationProfile NotificationPolicyType = "scanApplicationProfile"
 	// Trigger a relevancy image scan
 	TypeCalculateSBOM NotificationPolicyType = "calculateSBOM"
 	// Trigger a registry scan


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added support for Application Profile scanning functionality by introducing new API constants and notification types:
  - New command path constant `ApplicationProfileScanCommandPath` with value "scanApplicationProfile"
  - New notification policy type `TypeScanApplicationProfile` with value "scanApplicationProfile"
- Maintained consistent code formatting and structure with existing scan-related constants



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clusterapis.go</strong><dd><code>Add Application Profile scanning constants and types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apis/clusterapis.go

<li>Added new constant <code>ApplicationProfileScanCommandPath</code> for scanning <br>application profiles<br> <li> Added new notification policy type <code>TypeScanApplicationProfile</code> for <br>triggering application profile scans<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/414/files#diff-ce8460085c011bac1484629707af29d1c4d09b62cca6180e1ff8551686b5ac09">+9/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information