### PR TITLE
add CreatedBy type and integrate into EntityIdentifiers struct

### DIFF
--- a/notifications/integrationref.go
+++ b/notifications/integrationref.go
@@ -32,6 +32,7 @@ type IntegrationReference struct {
 
 // EntityIdentifiers is a struct that holds the identifiers of an entity (hard typed designators)
 type EntityType string
+type CreatedBy string
 
 const (
 	EntityTypePostureResource       EntityType = "postureResource"
@@ -43,6 +44,9 @@ const (
 	EntityTypeControl               EntityType = "control"
 	EntityTypeSecurityRiskResource  EntityType = "securityRiskResource"
 	EntityTypeSecurityRisk          EntityType = "securityRisk"
+
+	CreatedByUser CreatedBy = "user"
+	CreatedByUNS  CreatedBy = "uns"
 )
 
 type EntitiesIdentifiers []EntityIdentifiers
@@ -85,6 +89,8 @@ type EntityIdentifiers struct {
 	SecurityRiskCategory string `json:"securityRiskCategory,omitempty" bson:"securityRiskCategory,omitempty"`
 	SecurityRiskName     string `json:"securityRiskName,omitempty" bson:"securityRiskName,omitempty"`
 	SmartRemediation     bool   `json:"smartRemediation,omitempty" bson:"smartRemediation,omitempty"`
+
+	CreatedBy CreatedBy `json:"createdBy,omitempty" bson:"createdBy,omitempty"`
 }
 
 func NewClusterResourceIdentifiers(resource armotypes.PostureResourceSummary) EntityIdentifiers {


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Introduced a new type `CreatedBy` to represent the creator of an entity.
- Added constants `CreatedByUser` and `CreatedByUNS` to specify the creator type.
- Enhanced the `EntityIdentifiers` struct by including the `CreatedBy` field.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>integrationref.go</strong><dd><code>Add and integrate `CreatedBy` type into `EntityIdentifiers`</code></dd></summary>
<hr>

notifications/integrationref.go

<li>Added a new type <code>CreatedBy</code>.<br> <li> Introduced constants <code>CreatedByUser</code> and <code>CreatedByUNS</code>.<br> <li> Integrated <code>CreatedBy</code> into the <code>EntityIdentifiers</code> struct.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/415/files#diff-c2b85aafaedffc508a0331728f554442605db085a97714482e6925f7c683c0ab">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information