### PR TITLE
added cdr event as key

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -157,7 +157,7 @@ type RuntimeAlert struct {
 	MalwareAlert           `json:",inline" bson:"inline"`
 	AdmissionAlert         `json:",inline" bson:"inline"`
 	RuntimeAlertK8sDetails `json:",inline" bson:"inline"`
-	cdr.CdrAlert           `json:",inline" bson:"inline"`
+	cdr.CdrAlert           `json:"cdrevent" bson:"cdrevent"`
 	AlertType              AlertType `json:"alertType" bson:"alertType"`
 	// Rule ID
 	RuleID string `json:"ruleID,omitempty" bson:"ruleID,omitempty"`


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed the serialization tags for the `cdr.CdrAlert` field in the `RuntimeAlert` struct to ensure proper handling of JSON and BSON data.
- Changed the tags from inline to `cdrevent` for both JSON and BSON.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Fix serialization tags for CdrAlert in RuntimeAlert struct</code></dd></summary>
<hr>

armotypes/runtimeincidents.go

<li>Changed the JSON and BSON tags for <code>cdr.CdrAlert</code> from inline to <br><code>cdrevent</code>.<br> <li> This change ensures correct serialization and deserialization of <br><code>cdr.CdrAlert</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/418/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information