### PR TITLE
Creating new cloud service structure

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -28,18 +28,20 @@ type Process struct {
 	Children   []Process `json:"children,omitempty" bson:"children,omitempty"`
 }
 
+type PidToCloudServices map[uint32][]string
+
 type CloudMetadata struct {
 	// Provider is the cloud provider name (e.g. aws, gcp, azure).
-	Provider     string   `json:"provider,omitempty" bson:"provider,omitempty"`
-	InstanceID   string   `json:"instance_id,omitempty" bson:"instance_id,omitempty"`
-	InstanceType string   `json:"instance_type,omitempty" bson:"instance_type,omitempty"`
-	Region       string   `json:"region,omitempty" bson:"region,omitempty"`
-	Zone         string   `json:"zone,omitempty" bson:"zone,omitempty"`
-	PrivateIP    string   `json:"private_ip,omitempty" bson:"private_ip,omitempty"`
-	PublicIP     string   `json:"public_ip,omitempty" bson:"public_ip,omitempty"`
-	Hostname     string   `json:"hostname,omitempty" bson:"hostname,omitempty"`
-	AccountID    string   `json:"account_id,omitempty" bson:"account_id,omitempty"`
-	Services     []string `json:"services,omitempty" bson:"services,omitempty"`
+	Provider           string             `json:"provider,omitempty" bson:"provider,omitempty"`
+	InstanceID         string             `json:"instance_id,omitempty" bson:"instance_id,omitempty"`
+	InstanceType       string             `json:"instance_type,omitempty" bson:"instance_type,omitempty"`
+	Region             string             `json:"region,omitempty" bson:"region,omitempty"`
+	Zone               string             `json:"zone,omitempty" bson:"zone,omitempty"`
+	PrivateIP          string             `json:"private_ip,omitempty" bson:"private_ip,omitempty"`
+	PublicIP           string             `json:"public_ip,omitempty" bson:"public_ip,omitempty"`
+	Hostname           string             `json:"hostname,omitempty" bson:"hostname,omitempty"`
+	AccountID          string             `json:"account_id,omitempty" bson:"account_id,omitempty"`
+	PidToCloudServices PidToCloudServices `json:"pidToCloudServices,omitempty" bson:"pidToCloudServices,omitempty"`
 }
 
 type AlertType int


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added new mapping structure `PidToCloudServices` to track cloud services by process ID
- Enhanced `CloudMetadata` struct by replacing simple services list with PID-based mapping
- Improved cloud service tracking granularity by associating services with specific processes
- Maintained backward compatibility with existing cloud metadata fields



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Add process ID to cloud services mapping structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/runtimeincidents.go

<li>Added new type <code>PidToCloudServices</code> to map process IDs to cloud services<br> <li> Replaced <code>Services []string</code> field with <code>PidToCloudServices</code> in <br>CloudMetadata struct<br> <li> Improved cloud service tracking by associating services with specific <br>process IDs<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/419/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+12/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information