### PR TITLE
Add DefaultFrameworks field to InstallationData struct

### DIFF
--- a/armotypes/portaltypes.go
+++ b/armotypes/portaltypes.go
@@ -90,6 +90,7 @@ type InstallationData struct {
 	ClusterProvider                           string                                    `json:"clusterProvider,omitempty" bson:"clusterProvider,omitempty"`                                                     // cluster provider (aws/azure/gcp)
 	IncludeNamespaces                         []string                                  `json:"includeNamespaces,omitempty" bson:"includeNamespaces,omitempty"`                                                 // perform scanning only on specific namespaces
 	ExcludeNamespaces                         []string                                  `json:"excludeNamespaces,omitempty" bson:"excludeNamespaces,omitempty"`                                                 // fully ignore namespaces
+	DefaultFrameworks                         []string                                  `json:"defaultFrameworks,omitempty" bson:"defaultFrameworks,omitempty"`                                                 // fully ignore namespaces
 }
 
 // hold information of a single subscription.


### PR DESCRIPTION
### **User description**
This will allow the operator to receive the default frameworks as a configuration


___

### **PR Type**
Enhancement


___

### **Description**
- Added new `DefaultFrameworks` field to `InstallationData` struct to allow configuring default frameworks via operator
- Field is defined as string array with proper JSON/BSON serialization tags
- Includes omitempty option to maintain backward compatibility



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>portaltypes.go</strong><dd><code>Add DefaultFrameworks configuration field to InstallationData</code></dd></summary>
<hr>

armotypes/portaltypes.go

<li>Added <code>DefaultFrameworks</code> field to <code>InstallationData</code> struct as a string <br>array<br> <li> Field includes JSON and BSON tags with omitempty option<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/421/files#diff-cdf63575c0bc337e1f9ddd63e8be29140734f38ee7550a487a19861bed59c7a6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information