### PR TITLE
Add new risk factor mapping for C-0266 and update test expectations

### DIFF
--- a/armotypes/common.go
+++ b/armotypes/common.go
@@ -27,6 +27,7 @@ const (
 
 var RiskFactorMapping = map[string]RiskFactor{
 	"C-0256": RiskFactorExternalFacing,
+	"C-0266": RiskFactorExternalFacing,
 	"C-0046": RiskFactorPrivileged,
 	"C-0057": RiskFactorPrivileged,
 	"C-0255": RiskFactorSecretAccess,

--- a/armotypes/common_test.go
+++ b/armotypes/common_test.go
@@ -1,9 +1,10 @@
 package armotypes
 
 import (
-	"github.com/stretchr/testify/assert"
 	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetControlIDsByRiskFactors(t *testing.T) {
@@ -15,7 +16,7 @@ func TestGetControlIDsByRiskFactors(t *testing.T) {
 		{
 			name:     "Single Risk Factor",
 			input:    "External facing",
-			expected: []string{"C-0256"},
+			expected: []string{"C-0256", "C-0266"},
 		},
 		{
 			name:     "Multiple Risk Factors",


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added new risk factor mapping for control ID `C-0266` as external facing in the risk factor mapping configuration
- Updated corresponding test cases to include the new control ID in external facing scenarios
- Minor code improvement: reorganized imports in test file



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>common.go</strong><dd><code>Add new external facing risk factor mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/common.go

<li>Added new risk factor mapping for control ID 'C-0266' as <br>RiskFactorExternalFacing<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/422/files#diff-b068a137ca7a626e7b47f1ad240412c08daea90099c2e9851e9df06c9cb35412">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>common_test.go</strong><dd><code>Update test cases for new risk factor mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/common_test.go

<li>Updated test expectations to include 'C-0266' in external facing risk <br>factor test case<br> <li> Reorganized imports for better code formatting<br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/422/files#diff-ef6aa77a2e42be16d61cc6bfc317f1cec15585e73045056ad145fdfc9a76d6b3">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information