### PR TITLE
add ClusterInfo struct to armotypes package

### DIFF
--- a/armotypes/clusters.go
+++ b/armotypes/clusters.go
@@ -1,0 +1,13 @@
+package armotypes
+
+import "time"
+
+type ClusterInfo struct {
+	Cluster        string     `json:"cluster"`
+	NodeCount      int        `json:"nodeCount"`
+	CPUSum         int        `json:"cpuSum"`
+	CloudProvider  string     `json:"cloudProvider"`
+	HelmVersion    string     `json:"helmVersion"`
+	LastReportTime *time.Time `json:"lastReportTime"`
+	IsConnected    bool       `json:"isConnected"`
+}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added new `ClusterInfo` struct to `armotypes` package to track cluster metadata and state
- The struct includes fields for:
  - Basic cluster info: name, node count, total CPU, cloud provider
  - Version tracking: Helm version
  - Monitoring fields: last report time and connection status
- All fields are JSON-tagged for serialization



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clusters.go</strong><dd><code>Add ClusterInfo struct for cluster metadata tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/clusters.go

<li>Added new <code>ClusterInfo</code> struct with fields for cluster metadata like <br>node count, CPU sum, cloud provider<br> <li> Included fields for monitoring cluster state like <code>LastReportTime</code> and <br><code>IsConnected</code><br>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/424/files#diff-72e24f32a983713146617e22adcb91b86e2e7f87b9909f795af97276773c9124">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information