### PR TITLE
Adding http rule structs

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -49,6 +49,7 @@ const (
 	AlertTypeMalware
 	AlertTypeAdmission
 	AlertTypeCdr
+	AlertTypeHttpRule
 )
 
 type StackFrame struct {
@@ -119,6 +120,23 @@ type MalwareAlert struct {
 	MalwareDescription string `json:"malwareDescription,omitempty" bson:"malwareDescription,omitempty"`
 }
 
+type HttpRuleAlert struct {
+	Request struct {
+		Method string            `json:"method,omitempty" bson:"method,omitempty"` // e.g., "GET"
+		URL    string            `json:"url,omitempty" bson:"url,omitempty"`       // e.g., "/index.html"
+		Header map[string]string `json:"header,omitempty" bson:"header,omitempty"` // e.g., "Content-Type" -> ["application/json"]
+		Body   string            `json:"body,omitempty" bson:"body,omitempty"`     // e.g., "<html>...</html>"
+		Proto  string            `json:"proto,omitempty" bson:"proto,omitempty"`   // e.g., "HTTP/1.1"
+	} `json:"request,omitempty" bson:"request,omitempty"`
+
+	Response struct {
+		StatusCode int               `json:"statusCode,omitempty" bson:"statusCode,omitempty"` // e.g., 200
+		Header     map[string]string `json:"header,omitempty" bson:"header,omitempty"`         // e.g., "Content-Type" -> ["application/json"]
+		Body       string            `json:"body,omitempty" bson:"body,omitempty"`             // e.g., "<html>...</html>"
+		Proto      string            `json:"proto,omitempty" bson:"proto,omitempty"`           // e.g., "HTTP/1.1"
+	} `json:"response,omitempty" bson:"response,omitempty"`
+}
+
 type AdmissionAlert struct {
 	Kind             schema.GroupVersionKind     `json:"kind,omitempty" bson:"kind,omitempty"`
 	RequestNamespace string                      `json:"requestNamespace,omitempty" bson:"requestNamespace,omitempty"`
@@ -158,6 +176,7 @@ type RuntimeAlert struct {
 	AdmissionAlert         `json:",inline" bson:"inline"`
 	RuntimeAlertK8sDetails `json:",inline" bson:"inline"`
 	cdr.CdrAlert           `json:"cdrevent" bson:"cdrevent"`
+	HttpRuleAlert          `json:",inline" bson:"inline"`
 	AlertType              AlertType `json:"alertType" bson:"alertType"`
 	// Rule ID
 	RuleID string `json:"ruleID,omitempty" bson:"ruleID,omitempty"`


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added a new `HttpRuleAlert` struct for HTTP-specific alerts.

- Introduced `AlertTypeHttpRule` to the `AlertType` enum.

- Integrated `HttpRuleAlert` into the `RuntimeAlert` struct.

- Enhanced alert handling with HTTP request and response details.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Add HTTP rule alert support to runtime incidents</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/runtimeincidents.go

<li>Added <code>HttpRuleAlert</code> struct to handle HTTP alerts.<br> <li> Introduced <code>AlertTypeHttpRule</code> to the <code>AlertType</code> enum.<br> <li> Updated <code>RuntimeAlert</code> to include <code>HttpRuleAlert</code>.<br> <li> Enhanced alert structures with HTTP request/response details.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/428/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information