### PR TITLE
Added pod info to http

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -137,7 +137,8 @@ type HttpRuleAlert struct {
 		Proto      string            `json:"proto,omitempty" bson:"proto,omitempty"`           // e.g., "HTTP/1.1"
 	} `json:"response,omitempty" bson:"response,omitempty"`
 
-	AttackerIp string `json:"attackerIp,omitempty" bson:"attackerIp,omitempty"`
+	SourcePodInfo RuntimeAlertK8sDetails `json:"sourcePodInfo,omitempty" bson:"podInfo,omitempty"`
+	AttackerIp    string                 `json:"attackerIp,omitempty" bson:"attackerIp,omitempty"`
 }
 
 type AdmissionAlert struct {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added `sourcePodInfo` field to `HttpRuleAlert` struct.

- Enhanced HTTP alert structure with Kubernetes pod details.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Add `sourcePodInfo` field to `HttpRuleAlert`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/runtimeincidents.go

<li>Introduced <code>sourcePodInfo</code> field in <code>HttpRuleAlert</code> struct.<br> <li> Updated JSON and BSON tags for the new field.<br> <li> Adjusted field ordering for better readability.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/434/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>