### PR TITLE
Adding anomaly details to struct

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -71,6 +71,13 @@ type StackFrame struct {
 	NativeCode *bool `json:"nativeCode,omitempty" bson:"nativeCode,omitempty"`
 }
 
+type StackAnomalyDetails struct {
+	// FromIndex is the index of the first frame in the stack trace that is considered anomalous.
+	FromIndex int `json:"fromIndex,omitempty" bson:"fromIndex,omitempty"`
+	// ToIndex is the index of the last frame in the stack trace that is considered anomalous.
+	ToIndex int `json:"toIndex,omitempty" bson:"toIndex,omitempty"`
+}
+
 type Trace struct {
 	// Trace ID
 	TraceID string `json:"traceId,omitempty" bson:"traceId,omitempty"`
@@ -80,6 +87,8 @@ type Trace struct {
 	Package string `json:"package,omitempty" bson:"package,omitempty"`
 	// Language
 	Language string `json:"language,omitempty" bson:"language,omitempty"`
+	// Anomaly details
+	AnomalyDetails *StackAnomalyDetails `json:"anomalyDetails,omitempty" bson:"anomalyDetails,omitempty"`
 }
 
 type BaseRuntimeAlert struct {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added `StackAnomalyDetails` struct for anomaly indexing in stack traces.

- Integrated `AnomalyDetails` field into the `Trace` struct.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Add anomaly details to stack trace structures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/runtimeincidents.go

<li>Introduced <code>StackAnomalyDetails</code> struct with <code>FromIndex</code> and <code>ToIndex</code> <br>fields.<br> <li> Added <code>AnomalyDetails</code> field to the <code>Trace</code> struct for anomaly metadata.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/436/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>