### PR TITLE
Add Provider field to CdrAlertBatch struct

### DIFF
--- a/armotypes/cdr/cdr.go
+++ b/armotypes/cdr/cdr.go
@@ -69,6 +69,8 @@ type CdrAlertBatch struct {
 	CustomerGUID string `json:"customerGUID,omitempty"`
 	// CloudAccountID is the unique identifier of the cloud account
 	CloudAccountID string `json:"cloudAccountID,omitempty"`
+	// Provider is the cloud provider
+	Provider CloudProvider `json:"provider,omitempty"`
 	// RuleFailures is the list of rule failures
 	RuleFailures []CdrAlert `json:"ruleFailures,omitempty"`
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added a new `Provider` field to the `CdrAlertBatch` struct.

- Enhanced the struct to include cloud provider information.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cdr.go</strong><dd><code>Added `Provider` field to `CdrAlertBatch` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/cdr/cdr.go

<li>Introduced a new <code>Provider</code> field in the <code>CdrAlertBatch</code> struct.<br> <li> Documented the <code>Provider</code> field as the cloud provider.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/437/files#diff-59a037d92ce0aaef7ceb230f025ba5a6d1347c1efa7a8e17174989be48b03af4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>