### PR TITLE
Setting the anomaly flag on a frame

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -51,13 +51,8 @@ type StackFrame struct {
 	UserSpace bool `json:"userSpace,omitempty" bson:"userSpace,omitempty"`
 	// Native/Source code
 	NativeCode *bool `json:"nativeCode,omitempty" bson:"nativeCode,omitempty"`
-}
-
-type StackAnomalyDetails struct {
-	// FromIndex is the index of the first frame in the stack trace that is considered anomalous.
-	FromIndex int `json:"fromIndex,omitempty" bson:"fromIndex,omitempty"`
-	// ToIndex is the index of the last frame in the stack trace that is considered anomalous.
-	ToIndex int `json:"toIndex,omitempty" bson:"toIndex,omitempty"`
+	// Anomaly flag
+	Anomaly bool `json:"anomaly,omitempty" bson:"anomaly,omitempty"`
 }
 
 type Trace struct {
@@ -69,8 +64,6 @@ type Trace struct {
 	Package string `json:"package,omitempty" bson:"package,omitempty"`
 	// Language
 	Language string `json:"language,omitempty" bson:"language,omitempty"`
-	// Anomaly details
-	AnomalyDetails *StackAnomalyDetails `json:"anomalyDetails,omitempty" bson:"anomalyDetails,omitempty"`
 }
 
 type BaseRuntimeAlert struct {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added an `Anomaly` flag to the `StackFrame` struct.

- Removed the `StackAnomalyDetails` struct and its references.

- Simplified anomaly representation in the `Trace` struct.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Simplified anomaly handling in runtime incidents</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/runtimeincidents.go

<li>Added a new <code>Anomaly</code> boolean field to <code>StackFrame</code>.<br> <li> Removed the <code>StackAnomalyDetails</code> struct and its fields.<br> <li> Removed the <code>AnomalyDetails</code> field from the <code>Trace</code> struct.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/439/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+2/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>