### PR TITLE
add new checkStatus

### DIFF
--- a/armotypes/cloudposturetypes.go
+++ b/armotypes/cloudposturetypes.go
@@ -30,19 +30,21 @@ const (
 
 // cloud check statuses
 const (
-	CloudCheckStatusEmpty   = "EMPTY"
-	CloudCheckStatusFail    = "FAIL"
-	CloudCheckStatusManual  = "MANUAL"
-	CloudCheckStatusPass    = "PASS"
-	CloudCheckStatusSkipped = "SKIPPED"
+	CloudCheckStatusEmpty    = "EMPTY"
+	CloudCheckStatusFail     = "FAIL"
+	CloudCheckStatusManual   = "MANUAL"
+	CloudCheckStatusPass     = "PASS"
+	CloudCheckStatusSkipped  = "SKIPPED"
+	CloudCheckStatusAccepted = "ACCEPTED"
 )
 
 var CloudCheckStatusToInt = map[string]int{
-	CloudCheckStatusEmpty:   -1,
-	CloudCheckStatusFail:    10,
-	CloudCheckStatusManual:  20,
-	CloudCheckStatusPass:    30,
-	CloudCheckStatusSkipped: 40,
+	CloudCheckStatusEmpty:    -1,
+	CloudCheckStatusFail:     10,
+	CloudCheckStatusManual:   20,
+	CloudCheckStatusPass:     30,
+	CloudCheckStatusSkipped:  40,
+	CloudCheckStatusAccepted: 50,
 }
 
 var CloudIntToCheckStatus = map[int]string{
@@ -51,6 +53,7 @@ var CloudIntToCheckStatus = map[int]string{
 	20: CloudCheckStatusManual,
 	30: CloudCheckStatusPass,
 	40: CloudCheckStatusSkipped,
+	50: CloudCheckStatusAccepted,
 }
 
 // cloud check types


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added a new cloud check status `ACCEPTED`.

- Updated mappings for `CloudCheckStatusToInt` and `CloudIntToCheckStatus`.

- Improved code alignment for better readability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cloudposturetypes.go</strong><dd><code>Add new cloud check status and update mappings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/cloudposturetypes.go

<li>Introduced a new cloud check status <code>ACCEPTED</code>.<br> <li> Updated <code>CloudCheckStatusToInt</code> map to include <code>ACCEPTED</code>.<br> <li> Updated <code>CloudIntToCheckStatus</code> map to include <code>ACCEPTED</code>.<br> <li> Adjusted alignment for existing constants and mappings.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/444/files#diff-b3664d35ac74c2a20b3065c3882c7a468863c6ef4e837a07ee17eabafce44fe2">+13/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>