### PR TITLE
added network scan alert

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -161,6 +161,11 @@ type RuntimeAlertK8sDetails struct {
 	WorkloadKind      string            `json:"workloadKind,omitempty" bson:"workloadKind,omitempty"`
 }
 
+type NetworkScanAlert struct {
+	Dns string `json:"dns,omitempty" bson:"dns,omitempty"`
+	Ip  string `json:"ip,omitempty" bson:"ip,omitempty"`
+}
+
 type RuntimeAlert struct {
 	BaseRuntimeAlert       `json:",inline" bson:"inline"`
 	RuleAlert              `json:",inline" bson:"inline"`
@@ -169,6 +174,7 @@ type RuntimeAlert struct {
 	RuntimeAlertK8sDetails `json:",inline" bson:"inline"`
 	cdr.CdrAlert           `json:"cdrevent,omitempty" bson:"cdrevent"`
 	HttpRuleAlert          `json:",inline" bson:"inline"`
+	NetworkScanAlert       `json:"networkscan,inline" bson:"networkscan"`
 	AlertType              AlertType `json:"alertType" bson:"alertType"`
 	// Rule ID
 	RuleID string `json:"ruleID,omitempty" bson:"ruleID,omitempty"`

--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -162,8 +162,8 @@ type RuntimeAlertK8sDetails struct {
 }
 
 type NetworkScanAlert struct {
-	Dns string `json:"dns,omitempty" bson:"dns,omitempty"`
-	Ip  string `json:"ip,omitempty" bson:"ip,omitempty"`
+	Domain string `json:"domain,omitempty" bson:"domain,omitempty"`
+	Ip     string `json:"ip,omitempty" bson:"ip,omitempty"`
 }
 
 type RuntimeAlert struct {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added a new `NetworkScanAlert` struct with DNS and IP fields.

- Integrated `NetworkScanAlert` into the `RuntimeAlert` struct.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Add NetworkScanAlert struct and integrate into RuntimeAlert</code></dd></summary>
<hr>

armotypes/runtimeincidents.go

<li>Introduced a new <code>NetworkScanAlert</code> struct with <code>Dns</code> and <code>Ip</code> fields.<br> <li> Added <code>NetworkScanAlert</code> as an inline field in the <code>RuntimeAlert</code> struct.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/446/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>