### PR TITLE
Putting MalwareDescription field back

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -101,11 +101,12 @@ type RuleAlert struct {
 }
 
 type MalwareAlert struct {
-	MalwareFile     File             `json:"malwareFile,omitempty" bson:"malwareFile,omitempty"`
-	Action          string           `json:"action,omitempty" bson:"action,omitempty"`
-	DetectionMethod string           `json:"detectionMethod,omitempty" bson:"detectionMethod,omitempty"`
-	ProcessTree     ProcessTree      `json:"processTree,omitempty" bson:"processTree,omitempty"`
-	Signature       MalwareSignature `json:"signature,omitempty" bson:"signature,omitempty"`
+	MalwareFile        File             `json:"malwareFile,omitempty" bson:"malwareFile,omitempty"`
+	Action             string           `json:"action,omitempty" bson:"action,omitempty"`
+	DetectionMethod    string           `json:"detectionMethod,omitempty" bson:"detectionMethod,omitempty"`
+	ProcessTree        ProcessTree      `json:"processTree,omitempty" bson:"processTree,omitempty"`
+	Signature          MalwareSignature `json:"signature,omitempty" bson:"signature,omitempty"`
+	MalwareDescription string           `json:"malwareDescription,omitempty" bson:"malwareDescription,omitempty"`
 }
 
 type HttpRuleAlert struct {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Reintroduced the `MalwareDescription` field in the `MalwareAlert` struct.

- Ensured proper formatting and alignment of struct fields.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Reintroduced `MalwareDescription` field in `MalwareAlert`</code></dd></summary>
<hr>

armotypes/runtimeincidents.go

<li>Added the <code>MalwareDescription</code> field to the <code>MalwareAlert</code> struct.<br> <li> Adjusted field alignment for better readability.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/447/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>