### PR TITLE
Changing alert to contain addresses

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -164,8 +164,8 @@ type RuntimeAlertK8sDetails struct {
 }
 
 type NetworkScanAlert struct {
-	Domain string `json:"domain,omitempty" bson:"domain,omitempty"`
-	Ip     string `json:"ip,omitempty" bson:"ip,omitempty"`
+	Domain    string   `json:"domain,omitempty" bson:"domain,omitempty"`
+	Addresses []string `json:"addresses,omitempty" bson:"addresses,omitempty"`
 }
 
 type RuntimeAlert struct {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Updated `NetworkScanAlert` to include `addresses` field.

- Replaced `ip` field with `addresses` for multiple IP support.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Update `NetworkScanAlert` structure for multiple addresses</code></dd></summary>
<hr>

armotypes/runtimeincidents.go

<li>Added <code>addresses</code> field to <code>NetworkScanAlert</code>.<br> <li> Removed <code>ip</code> field from <code>NetworkScanAlert</code>.<br> <li> Adjusted <code>NetworkScanAlert</code> structure to support multiple addresses.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/449/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>