### PR TITLE
deprecate control name in posture exception policies

### DIFF
--- a/armotypes/postureexceptionpolicytypes.go
+++ b/armotypes/postureexceptionpolicytypes.go
@@ -2,8 +2,9 @@ package armotypes
 
 import (
 	"encoding/json"
-	"github.com/armosec/armoapi-go/identifiers"
 	"time"
+
+	"github.com/armosec/armoapi-go/identifiers"
 )
 
 type PostureExceptionPolicyActions string
@@ -38,6 +39,7 @@ type PostureExceptionPolicy struct {
 
 type PosturePolicy struct {
 	FrameworkName string `json:"frameworkName" bson:"frameworkName"`
+	// deprecated - use ControlID instead
 	ControlName   string `json:"controlName,omitempty" bson:"controlName,omitempty"`
 	ControlID     string `json:"controlID,omitempty" bson:"controlID,omitempty"`
 	RuleName      string `json:"ruleName,omitempty" bson:"ruleName,omitempty"`


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation


___

### **Description**
- Deprecated the `ControlName` field in `PosturePolicy`.

- Added a comment to use `ControlID` instead of `ControlName`.

- Adjusted imports for better formatting.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>postureexceptionpolicytypes.go</strong><dd><code>Deprecate `ControlName` and recommend `ControlID`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/postureexceptionpolicytypes.go

<li>Deprecated the <code>ControlName</code> field in <code>PosturePolicy</code>.<br> <li> Added a comment recommending <code>ControlID</code> instead.<br> <li> Adjusted import statements for better formatting.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/450/files#diff-43b0aa7c3fe4a631648481af18411e1e75cbe507d842245ca971a41028c586e9">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>