### PR TITLE
Add HasTickets field to Vulnerability struct

### DIFF
--- a/armotypes/vulnerabilitytypes.go
+++ b/armotypes/vulnerabilitytypes.go
@@ -160,6 +160,7 @@ type Vulnerability struct {
 	ImagesCount        int                          `json:"imagesCount"`
 	IgnoreRulesSummary map[string]IgnoreRuleSummary `json:"ignoreRulesSummary"`
 	Tickets            []Ticket                     `json:"tickets,omitempty"`
+	HasTickets         bool                         `json:"hasTickets,omitempty"`
 }
 
 type CvssInfo struct {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added a new `HasTickets` field to the `Vulnerability` struct.

- The new field indicates the presence of tickets.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vulnerabilitytypes.go</strong><dd><code>Add `HasTickets` field to `Vulnerability` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/vulnerabilitytypes.go

<li>Added a new boolean field <code>HasTickets</code> to the <code>Vulnerability</code> struct.<br> <li> The field is marked as <code>omitempty</code> for JSON serialization.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/455/files#diff-cac55976184cdb0c77ddde7ecbabd7411490f34df3e11868dd0e67e370c01830">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>