### PR TITLE
Add CreatedBy field to IntegrationReference struct

### DIFF
--- a/notifications/integrationref.go
+++ b/notifications/integrationref.go
@@ -29,6 +29,7 @@ type IntegrationReference struct {
 	Owner                *EntityIdentifiers  `json:"owner,omitempty" bson:"owner,omitempty"`                   //owner identifiers of this reference (e.g resourceHash, wlid)
 	RelatedObjects       EntitiesIdentifiers `json:"relatedObjects,omitempty" bson:"relatedObjects,omitempty"` //related entities identifiers of this reference (e.g cves, controls)
 	CreationTime         time.Time           `json:"creationTime" bson:"creationTime"`                         //creation time of the reference
+	CreatedBy            CreatedBy           `json:"createdBy,omitempty" bson:"createdBy,omitempty"`           //created by user or uns
 }
 
 // EntityIdentifiers is a struct that holds the identifiers of an entity (hard typed designators)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added a new `CreatedBy` field to the `IntegrationReference` struct.

- Enhanced the struct to include information about the creator.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>integrationref.go</strong><dd><code>Add `CreatedBy` field to `IntegrationReference` struct</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

notifications/integrationref.go

<li>Added a new <code>CreatedBy</code> field to the <code>IntegrationReference</code> struct.<br> <li> Updated JSON and BSON tags for the new field.<br> <li> Documented the purpose of the <code>CreatedBy</code> field in comments.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/456/files#diff-c2b85aafaedffc508a0331728f554442605db085a97714482e6925f7c683c0ab">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>