### PR TITLE
add monitored clusters type

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -199,6 +199,11 @@ type KDRMonitoredEntitiesCounters struct {
 	ContainersCount int `json:"containersCount"`
 }
 
+type KDRMonitoredClusters struct {
+	MonitoredClusters    []string `json:"monitored,omitempty"`
+	NotMonitoredClusters []string `json:"notMonitored,omitempty"`
+}
+
 type RuntimeIncidentExceptionPolicy struct {
 	BaseExceptionPolicy `json:",inline"`
 	Name                string `json:"name"`


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added a new struct `KDRMonitoredClusters` to represent monitored and non-monitored clusters.

- Introduced fields for `MonitoredClusters` and `NotMonitoredClusters` in the new struct.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Introduced `KDRMonitoredClusters` struct for monitoring</code>&nbsp; &nbsp; </dd></summary>
<hr>

armotypes/runtimeincidents.go

<li>Added a new struct <code>KDRMonitoredClusters</code>.<br> <li> Defined fields for monitored and non-monitored clusters.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/460/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>