### PR TITLE
add resourceHash field to NetworkPoliciesWorkload struct

### DIFF
--- a/armotypes/networkpolicies.go
+++ b/armotypes/networkpolicies.go
@@ -22,6 +22,7 @@ const (
 // NetworkPoliciesWorkload is used store information about workloads
 // in the customer's clusters related to the NetworkPolicies feature
 type NetworkPoliciesWorkload struct {
+	ResourceHash               string                   `json:"resourceHash"`
 	Name                       string                   `json:"name"`
 	Kind                       string                   `json:"kind"`
 	CustomerGUID               string                   `json:"customerGUID"`


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added a new `resourceHash` field to the `NetworkPoliciesWorkload` struct.

- Enhanced the struct to include resource hashing for better tracking.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>networkpolicies.go</strong><dd><code>Add `resourceHash` field to `NetworkPoliciesWorkload`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/networkpolicies.go

<li>Introduced a new <code>resourceHash</code> field in the <code>NetworkPoliciesWorkload</code> <br>struct.<br> <li> Updated the struct to support resource hash tracking.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/461/files#diff-edffc833afef72270a9815b6c2842d3d28e3eb3cefcae82601a76c0bd97bdbb4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>