### PR TITLE
add saved filter type

### DIFF
--- a/armotypes/savedfilters.go
+++ b/armotypes/savedfilters.go
@@ -1,0 +1,9 @@
+package armotypes
+
+type SavedFilter struct {
+	PortalBase `json:",inline" bson:"inline"`
+	Subject    string              `json:"subject" bson:"subject"`
+	View       string              `json:"view" bson:"view"`
+	Filters    []map[string]string `json:"filters" bson:"filters"`
+	IsDefault  bool                `json:"isDefault" bson:"isDefault"`
+}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Introduced a new `SavedFilter` type in the `armotypes` package.

- Added fields to define saved filters including `Subject`, `View`, `Filters`, and `IsDefault`.

- Enabled inline serialization for `PortalBase` in the new type.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>savedfilters.go</strong><dd><code>Introduced `SavedFilter` struct with relevant fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/savedfilters.go

<li>Added a new <code>SavedFilter</code> struct.<br> <li> Included fields for <code>Subject</code>, <code>View</code>, <code>Filters</code>, and <code>IsDefault</code>.<br> <li> Enabled inline serialization for <code>PortalBase</code>.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/462/files#diff-f8f924506513c68355e7bba3eef35e2c9c2c54afdba78be7998b03b4aedba340">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>