### PR TITLE
added full response as string

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -121,10 +121,11 @@ type HttpRuleAlert struct {
 	} `json:"request,omitempty" bson:"request,omitempty"`
 
 	Response struct {
-		StatusCode int               `json:"statusCode,omitempty" bson:"statusCode,omitempty"` // e.g., 200
-		Header     map[string]string `json:"header,omitempty" bson:"header,omitempty"`         // e.g., "Content-Type" -> ["application/json"]
-		Body       string            `json:"body,omitempty" bson:"body,omitempty"`             // e.g., "<html>...</html>"
-		Proto      string            `json:"proto,omitempty" bson:"proto,omitempty"`           // e.g., "HTTP/1.1"
+		StatusCode   int               `json:"statusCode,omitempty" bson:"statusCode,omitempty"`     // e.g., 200
+		Header       map[string]string `json:"header,omitempty" bson:"header,omitempty"`             // e.g., "Content-Type" -> ["application/json"]
+		Body         string            `json:"body,omitempty" bson:"body,omitempty"`                 // e.g., "<html>...</html>"
+		Proto        string            `json:"proto,omitempty" bson:"proto,omitempty"`               // e.g., "HTTP/1.1"
+		FullResponse string            `json:"fullResponse,omitempty" bson:"fullResponse,omitempty"` // e.g., "{...}"
 	} `json:"response,omitempty" bson:"response,omitempty"`
 
 	SourcePodInfo RuntimeAlertK8sDetails `json:"sourcePodInfo,omitempty" bson:"podInfo,omitempty"`


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added `FullResponse` field to `HttpRuleAlert.Response` struct.

- Enhanced HTTP response representation with full response string.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Add `FullResponse` field to `Response` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/runtimeincidents.go

<li>Added a new field <code>FullResponse</code> to the <code>Response</code> struct.<br> <li> Updated the struct to include a full HTTP response string.<br> <li> Improved HTTP response representation for better debugging or logging.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/464/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>