### PR TITLE
add service selector labels, role binding subjects and role refs

### DIFF
--- a/armotypes/kubernetes_objects.go
+++ b/armotypes/kubernetes_objects.go
@@ -34,10 +34,6 @@ type KubernetesObject struct {
 
 	// pod selector labels of network policies
 	NetworkPolicyPodSelectorLabels map[string]string `json:"podSelectorLabels,omitempty"`
-	// indicates if the network policy has egress rules
-	HasEgressRules *bool `json:"hasEgressRules,omitempty"`
-	// indicates if the network policy has ingress rules
-	HasIngressRules *bool `json:"hasIngressRules,omitempty"`
 
 	// pod spec labels of workloads
 	PodSpecLabels map[string]string `json:"podSpecLabels,omitempty"`
@@ -50,6 +46,9 @@ type KubernetesObject struct {
 
 	// subjects of RoleBinding
 	RoleBindingSubjects []RoleBindingSubject `json:"subjects,omitempty"`
+
+	// additional properties of the resource
+	AdditionalProps map[string]string `json:"additionalProps,omitempty"`
 }
 
 type Resource struct {

--- a/armotypes/kubernetes_objects.go
+++ b/armotypes/kubernetes_objects.go
@@ -33,10 +33,19 @@ type KubernetesObject struct {
 	Labels map[string]string `json:"labels"`
 
 	// pod selector labels of network policies
-	PodSelectorLabels map[string]string `json:"podSelectorLabels"`
+	NetworkPolicyPodSelectorLabels map[string]string `json:"podSelectorLabels,omitempty"`
 
 	// pod spec labels of workloads
-	PodSpecLabels map[string]string `json:"podSpecLabels"`
+	PodSpecLabels map[string]string `json:"podSpecLabels,omitempty"`
+
+	// pod selector labels of services
+	ServicePodSelectorLabels map[string]string `json:"servicePodSelectorLabels,omitempty"`
+
+	// roleRef of RoleBinding
+	RoleRef *RoleBindingRoleRef `json:"roleRef,omitempty"`
+
+	// subjects of RoleBinding
+	Subject []RoleBindingSubject `json:"subject,omitempty"`
 }
 
 type Resource struct {
@@ -46,4 +55,18 @@ type Resource struct {
 	Namespace        string `json:"namespace,omitempty" bson:"namespace,omitempty"`
 	Kind             string `json:"kind,omitempty" bson:"kind,omitempty"`
 	Name             string `json:"name,omitempty" bson:"name,omitempty"`
+}
+
+type RoleBindingSubject struct {
+	APIVersion string `json:"apiVersion,omitempty"`
+	Kind       string `json:"kind,omitempty"`
+	Name       string `json:"name,omitempty"`
+	Namespace  string `json:"namespace,omitempty"`
+}
+
+type RoleBindingRoleRef struct {
+	APIVersion string `json:"apiVersion,omitempty"`
+	Kind       string `json:"kind,omitempty"`
+	Name       string `json:"name,omitempty"`
+	Namespace  string `json:"namespace,omitempty"`
 }

--- a/armotypes/kubernetes_objects.go
+++ b/armotypes/kubernetes_objects.go
@@ -42,10 +42,10 @@ type KubernetesObject struct {
 	ServicePodSelectorLabels map[string]string `json:"servicePodSelectorLabels,omitempty"`
 
 	// roleRef of RoleBinding
-	RoleRef *RoleBindingRoleRef `json:"roleRef,omitempty"`
+	RoleBindingRoleRef *RoleBindingRoleRef `json:"roleRef,omitempty"`
 
 	// subjects of RoleBinding
-	Subject []RoleBindingSubject `json:"subject,omitempty"`
+	RoleBindingSubjects []RoleBindingSubject `json:"subjects,omitempty"`
 }
 
 type Resource struct {

--- a/armotypes/kubernetes_objects.go
+++ b/armotypes/kubernetes_objects.go
@@ -34,6 +34,10 @@ type KubernetesObject struct {
 
 	// pod selector labels of network policies
 	NetworkPolicyPodSelectorLabels map[string]string `json:"podSelectorLabels,omitempty"`
+	// indicates if the network policy has egress rules
+	HasEgressRules *bool `json:"hasEgressRules,omitempty"`
+	// indicates if the network policy has ingress rules
+	HasIngressRules *bool `json:"hasIngressRules,omitempty"`
 
 	// pod spec labels of workloads
 	PodSpecLabels map[string]string `json:"podSpecLabels,omitempty"`


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added new fields to `KubernetesObject` for better resource representation.
  - Introduced `ServicePodSelectorLabels` for service pod selectors.
  - Added `RoleRef` and `Subject` fields for RoleBinding details.

- Defined new structs `RoleBindingSubject` and `RoleBindingRoleRef`.

- Updated existing fields to include `omitempty` for optional JSON serialization.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kubernetes_objects.go</strong><dd><code>Enhanced Kubernetes object structure with new fields and structs</code></dd></summary>
<hr>

armotypes/kubernetes_objects.go

<li>Renamed <code>PodSelectorLabels</code> to <code>NetworkPolicyPodSelectorLabels</code>.<br> <li> Added <code>ServicePodSelectorLabels</code>, <code>RoleRef</code>, and <code>Subject</code> fields to <br><code>KubernetesObject</code>.<br> <li> Introduced <code>RoleBindingSubject</code> and <code>RoleBindingRoleRef</code> structs.<br> <li> Updated fields with <code>omitempty</code> for optional JSON serialization.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/466/files#diff-ed902e412315af13ce66142c7a0cebcb72e6badc5f0bba656a8b6b9db8688873">+25/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>