### PR TITLE
add Webhook collaboration type to CollaborationConfigOption

### DIFF
--- a/notifications/collaborationconfig.go
+++ b/notifications/collaborationconfig.go
@@ -49,10 +49,11 @@ type CollaborationConfigOption struct {
 type ChannelProvider string
 
 const (
-	CollaborationTypeJira  ChannelProvider = "jira"
-	CollaborationTypeSlack ChannelProvider = "slack"
-	CollaborationTypeTeams ChannelProvider = "teams"
-	CollaborationTypeEmail ChannelProvider = "email"
+	CollaborationTypeJira    ChannelProvider = "jira"
+	CollaborationTypeSlack   ChannelProvider = "slack"
+	CollaborationTypeTeams   ChannelProvider = "teams"
+	CollaborationTypeEmail   ChannelProvider = "email"
+	CollaborationTypeWebhook ChannelProvider = "webhook"
 )
 
 // swagger:model CollaborationConfig


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added a new collaboration type `webhook` to `ChannelProvider`.

- Updated the `CollaborationConfigOption` to include the new type.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>collaborationconfig.go</strong><dd><code>Add Webhook type to collaboration constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

notifications/collaborationconfig.go

<li>Added <code>CollaborationTypeWebhook</code> to <code>ChannelProvider</code> constants.<br> <li> Adjusted formatting for existing <code>ChannelProvider</code> constants.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/467/files#diff-59047d8f2741f85941916f1efa7b619c5917e272ce3052ee88bdb3f9235ae841">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>