### PR TITLE
add reportTime field to NewRuntimeIncident for incident reporting

### DIFF
--- a/notifications/runtimeincidents.go
+++ b/notifications/runtimeincidents.go
@@ -1,6 +1,10 @@
 package notifications
 
-import "github.com/armosec/armoapi-go/identifiers"
+import (
+	"time"
+
+	"github.com/armosec/armoapi-go/identifiers"
+)
 
 type RuntimeIncidentPushNotification struct {
 	NewRuntimeIncident NewRuntimeIncident
@@ -15,6 +19,7 @@ type NewRuntimeIncident struct {
 	Resource            identifiers.PortalDesignator `json:"resource"` // Pod, Node, Workload, Namespace, Cluster, etc.
 	Link                string                       `json:"link"`
 	Response            *RuntimeIncidentResponse     `json:"response,omitempty"`
+	ReportTime          time.Time                    `json:"reportTime"`
 }
 
 type RuntimeIncidentResponse struct {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added a new `reportTime` field to the `NewRuntimeIncident` struct.

- Updated imports to include the `time` package.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Add `reportTime` field and update imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

notifications/runtimeincidents.go

<li>Added a <code>reportTime</code> field to the <code>NewRuntimeIncident</code> struct.<br> <li> Updated imports to include the <code>time</code> package.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/468/files#diff-caf7960ecb78f5b98bb1bc9375470466146f7670ce99e8a998b41c0d0f836451">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>