### PR TITLE
use map of pointers for children

### DIFF
--- a/armotypes/linuxobjects_test.go
+++ b/armotypes/linuxobjects_test.go
@@ -1,0 +1,20 @@
+package armotypes
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarshallChildrenMap(t *testing.T) {
+	childrenMap := map[CommPID]*Process{
+		{Comm: "test", PID: 1}: {PID: 1},
+	}
+	data, err := json.Marshal(childrenMap)
+	assert.NoError(t, err)
+	var childrenMap2 map[CommPID]*Process
+	err = json.Unmarshal(data, &childrenMap2)
+	assert.NoError(t, err)
+	assert.Equal(t, childrenMap, childrenMap2)
+}

--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -248,8 +248,8 @@ func findProcessRecursive(proc *Process, pid uint32) *Process {
 		return proc
 	}
 
-	for _, child := range proc.Children {
-		if found := findProcessRecursive(&child, pid); found != nil {
+	for _, child := range proc.ChildrenMap {
+		if found := findProcessRecursive(child, pid); found != nil {
 			return found
 		}
 	}

--- a/armotypes/runtimeincidents_test.go
+++ b/armotypes/runtimeincidents_test.go
@@ -59,10 +59,10 @@ func TestFindProcessRecursive(t *testing.T) {
 		PID:     1,
 		Comm:    "p1",
 		Cmdline: "init",
-		Children: []Process{
-			{PID: 2, Comm: "p2", Cmdline: "bash"},
-			{PID: 3, Comm: "p3", Cmdline: "nginx",
-				Children: []Process{{PID: 4, Comm: "p4", Cmdline: "worker"}}},
+		ChildrenMap: map[CommPID]*Process{
+			{Comm: "p2", PID: 2}: {PID: 2, Comm: "p2", Cmdline: "bash"},
+			{Comm: "p3", PID: 3}: {PID: 3, Comm: "p3", Cmdline: "nginx",
+				ChildrenMap: map[CommPID]*Process{{Comm: "p4", PID: 4}: {PID: 4, Comm: "p4", Cmdline: "worker"}}},
 		},
 	}
 


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Changed `Children` field in `Process` struct to a map of pointers.

- Updated recursive function `findProcessRecursive` to handle the new map structure.

- Modified test cases in `TestFindProcessRecursive` to align with the new `Children` structure.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>linuxobjects.go</strong><dd><code>Refactor `Process.Children` to map of pointers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/linuxobjects.go

<li>Refactored <code>Children</code> field in <code>Process</code> struct to use a map of pointers.<br> <li> Adjusted type from <code>[]Process</code> to <code>map[uint32]*Process</code>.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/469/files#diff-8509862358a005f3dc2bc10ea0d7c99a884118e398d3114dccab4685bf705895">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Update `findProcessRecursive` for map-based `Children`</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/runtimeincidents.go

<li>Updated <code>findProcessRecursive</code> to iterate over map values instead of <br>slice.<br> <li> Adjusted logic to handle <code>Children</code> as a map of pointers.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/469/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents_test.go</strong><dd><code>Update tests for map-based `Children` in `Process`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/runtimeincidents_test.go

<li>Updated test cases in <code>TestFindProcessRecursive</code> to use map-based <br><code>Children</code>.<br> <li> Adjusted test data structure to align with new <code>Children</code> <br>implementation.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/469/files#diff-a55322bfd4651ff3ac5c63185f1a2824ff9f32bfb61e21619df17f533dbf0185">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>