### PR TITLE
add AlertSourcePlatform field to RuntimeAlert struct

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -187,7 +187,8 @@ type RuntimeAlert struct {
 	cdr.CdrAlert           `json:"cdrevent,omitempty" bson:"cdrevent"`
 	HttpRuleAlert          `json:",inline" bson:"inline"`
 	NetworkScanAlert       `json:"networkscan,inline" bson:"networkscan"`
-	AlertType              AlertType `json:"alertType" bson:"alertType"`
+	AlertType              AlertType           `json:"alertType" bson:"alertType"`
+	AlertSourcePlatform    AlertSourcePlatform `json:"alertSourcePlatform" bson:"alertSourcePlatform"`
 	// Rule ID
 	RuleID string `json:"ruleID,omitempty" bson:"ruleID,omitempty"`
 	// Hostname is the name of the node agent pod


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added `AlertSourcePlatform` field to `RuntimeAlert` struct.

- Enhanced the `RuntimeAlert` struct for better platform identification.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Added `AlertSourcePlatform` field to `RuntimeAlert` struct</code></dd></summary>
<hr>

armotypes/runtimeincidents.go

<li>Introduced a new field <code>AlertSourcePlatform</code> in the <code>RuntimeAlert</code> struct.<br> <li> Updated JSON and BSON annotations for the new field.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/471/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>