### PR TITLE
add Children migration in findProcssRecursive

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -248,17 +248,13 @@ func findProcessRecursive(proc *Process, pid uint32) *Process {
 		return proc
 	}
 
+	proc.MigrateToMap()
+
 	for _, child := range proc.ChildrenMap {
 		if found := findProcessRecursive(child, pid); found != nil {
 			return found
 		}
 	}
 
-	// Children is deprecated, but used for backward compatibility
-	for _, child := range proc.Children {
-		if found := findProcessRecursive(&child, pid); found != nil {
-			return found
-		}
-	}
 	return nil
 }

--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -253,5 +253,12 @@ func findProcessRecursive(proc *Process, pid uint32) *Process {
 			return found
 		}
 	}
+
+	// Children is deprecated, but used for backward compatibility
+	for _, child := range proc.Children {
+		if found := findProcessRecursive(&child, pid); found != nil {
+			return found
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
### **User description**
…ssRecursive


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added backward compatibility for deprecated `Children` field.

- Updated `findProcessRecursive` to handle both `ChildrenMap` and `Children`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Add support for deprecated `Children` field in `findProcessRecursive`</code></dd></summary>
<hr>

armotypes/runtimeincidents.go

<li>Added a loop to handle the deprecated <code>Children</code> field.<br> <li> Ensured <code>findProcessRecursive</code> works with both <code>ChildrenMap</code> and <code>Children</code>.<br> <li> Commented on the use of <code>Children</code> for backward compatibility.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/479/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>