### PR TITLE
add DeepCopy method to Process

### DIFF
--- a/armotypes/linuxobjects.go
+++ b/armotypes/linuxobjects.go
@@ -65,6 +65,40 @@ type Process struct {
 	ChildrenMap map[CommPID]*Process `json:"childrenMap,omitempty" bson:"childrenMap,omitempty"`
 }
 
+// DeepCopy creates a deep copy of the Process struct.
+func (p *Process) DeepCopy() *Process {
+	if p == nil {
+		return nil
+	}
+
+	p.MigrateToMap()
+	newProcess := &Process{
+		PID:        p.PID,
+		Cmdline:    p.Cmdline,
+		Comm:       p.Comm,
+		PPID:       p.PPID,
+		Pcomm:      p.Pcomm,
+		Hardlink:   p.Hardlink,
+		Uid:        p.Uid,
+		Gid:        p.Gid,
+		UserName:   p.UserName,
+		GroupName:  p.GroupName,
+		StartTime:  p.StartTime,
+		UpperLayer: p.UpperLayer,
+		Cwd:        p.Cwd,
+		Path:       p.Path,
+		// Initialize ChildrenMap
+		ChildrenMap: make(map[CommPID]*Process),
+	}
+
+	// Deep copy ChildrenMap
+	for k, child := range p.ChildrenMap {
+		newProcess.ChildrenMap[k] = child.DeepCopy()
+	}
+
+	return newProcess
+}
+
 // MigrateToMap migrates the Children slice to ChildrenMap to accommodate for older versions of the Process struct
 func (p *Process) MigrateToMap() {
 	if p.ChildrenMap == nil {


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added a DeepCopy method to the Process struct.

- Enables deep copying of Process, including ChildrenMap.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>linuxobjects.go</strong><dd><code>Add DeepCopy method to Process for deep struct copying</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/linuxobjects.go

<li>Introduced a DeepCopy method for the Process struct.<br> <li> DeepCopy recursively copies ChildrenMap entries.<br> <li> Ensures new Process instances are independent copies.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/487/files#diff-8509862358a005f3dc2bc10ea0d7c99a884118e398d3114dccab4685bf705895">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>