### PR TITLE
add irrelevant

### DIFF
--- a/armotypes/cloudposturetypes.go
+++ b/armotypes/cloudposturetypes.go
@@ -30,21 +30,23 @@ const (
 
 // cloud check statuses
 const (
-	CloudCheckStatusEmpty    = "EMPTY"
-	CloudCheckStatusFail     = "FAIL"
-	CloudCheckStatusManual   = "MANUAL"
-	CloudCheckStatusPass     = "PASS"
-	CloudCheckStatusSkipped  = "SKIP"
-	CloudCheckStatusAccepted = "ACCEPT"
+	CloudCheckStatusEmpty      = "EMPTY"
+	CloudCheckStatusFail       = "FAIL"
+	CloudCheckStatusManual     = "MANUAL"
+	CloudCheckStatusPass       = "PASS"
+	CloudCheckStatusSkipped    = "SKIP"
+	CloudCheckStatusAccepted   = "ACCEPT"
+	CloudCheckStatusIrrelevant = "IRRELEVANT"
 )
 
 var CloudCheckStatusToInt = map[string]int{
-	CloudCheckStatusEmpty:    -1,
-	CloudCheckStatusFail:     10,
-	CloudCheckStatusManual:   20,
-	CloudCheckStatusPass:     30,
-	CloudCheckStatusSkipped:  40,
-	CloudCheckStatusAccepted: 50,
+	CloudCheckStatusEmpty:      -1,
+	CloudCheckStatusFail:       10,
+	CloudCheckStatusManual:     20,
+	CloudCheckStatusPass:       30,
+	CloudCheckStatusSkipped:    40,
+	CloudCheckStatusAccepted:   50,
+	CloudCheckStatusIrrelevant: 60,
 }
 
 var CloudIntToCheckStatus = map[int]string{
@@ -54,6 +56,7 @@ var CloudIntToCheckStatus = map[int]string{
 	30: CloudCheckStatusPass,
 	40: CloudCheckStatusSkipped,
 	50: CloudCheckStatusAccepted,
+	60: CloudCheckStatusIrrelevant,
 }
 
 // cloud check types

--- a/armotypes/cloudposturetypes.go
+++ b/armotypes/cloudposturetypes.go
@@ -44,9 +44,9 @@ var CloudCheckStatusToInt = map[string]int{
 	CloudCheckStatusFail:       10,
 	CloudCheckStatusManual:     20,
 	CloudCheckStatusPass:       30,
+	CloudCheckStatusIrrelevant: 35,
 	CloudCheckStatusSkipped:    40,
 	CloudCheckStatusAccepted:   50,
-	CloudCheckStatusIrrelevant: 60,
 }
 
 var CloudIntToCheckStatus = map[int]string{
@@ -54,9 +54,9 @@ var CloudIntToCheckStatus = map[int]string{
 	10: CloudCheckStatusFail,
 	20: CloudCheckStatusManual,
 	30: CloudCheckStatusPass,
+	35: CloudCheckStatusIrrelevant,
 	40: CloudCheckStatusSkipped,
 	50: CloudCheckStatusAccepted,
-	60: CloudCheckStatusIrrelevant,
 }
 
 // cloud check types


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added new `IRRELEVANT` status to cloud check statuses.

- Updated status-to-integer and integer-to-status mappings for new status.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cloudposturetypes.go</strong><dd><code>Add 'IRRELEVANT' status and update status mappings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/cloudposturetypes.go

<li>Introduced <code>CloudCheckStatusIrrelevant</code> constant for a new status.<br> <li> Added <code>CloudCheckStatusIrrelevant</code> to <code>CloudCheckStatusToInt</code> map with <br>value 60.<br> <li> Added integer 60 to <code>CloudIntToCheckStatus</code> map for reverse lookup.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/490/files#diff-b3664d35ac74c2a20b3065c3882c7a468863c6ef4e837a07ee17eabafce44fe2">+15/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>