### PR TITLE
add cluster version

### DIFF
--- a/armotypes/clusters.go
+++ b/armotypes/clusters.go
@@ -8,6 +8,7 @@ type ClusterInfo struct {
 	CPUSum         int          `json:"cpuSum"`
 	CloudProvider  string       `json:"cloudProvider"`
 	HelmVersion    string       `json:"helmVersion"`
+	ClusterVersion string       `json:"clusterVersion"`
 	LastReportTime *time.Time   `json:"lastReportTime"`
 	IsConnected    bool         `json:"isConnected"`
 	Capabilities   []Capability `json:"capabilities,omitempty"`


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added `ClusterVersion` field to `ClusterInfo` struct.

- Enables tracking of cluster version information.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clusters.go</strong><dd><code>Add ClusterVersion field to ClusterInfo struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/clusters.go

<li>Introduced new <code>ClusterVersion</code> string field to <code>ClusterInfo</code>.<br> <li> Enhances cluster metadata with version information.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/491/files#diff-72e24f32a983713146617e22adcb91b86e2e7f87b9909f795af97276773c9124">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>