### PR TITLE
add hasTickets field to VulnerabilityWorkload and ImageSummary types

### DIFF
--- a/armotypes/vulnerabilitytypes.go
+++ b/armotypes/vulnerabilitytypes.go
@@ -47,6 +47,7 @@ type VulnerabilityWorkload struct {
 	Images                   []string                 `json:"images"`
 	Tickets                  []Ticket                 `json:"tickets,omitempty"`
 	MissingRuntimeInfoReason MissingRuntimeInfoReason `json:"missingRuntimeInfoReason"`
+	HasTickets               bool                     `json:"hasTickets,omitempty"`
 }
 
 type ContainerPathInfo struct {
@@ -108,6 +109,7 @@ type ImageSummary struct {
 	WorkloadsCount  int                 `json:"workloadsCount"`
 	ContainersCount int                 `json:"containersCount"`
 	Tickets         []Ticket            `json:"tickets,omitempty"`
+	HasTickets      bool                `json:"hasTickets,omitempty"`
 }
 
 type BaseImage struct {


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added `HasTickets` boolean field to `VulnerabilityWorkload` struct.

- Added `HasTickets` boolean field to `ImageSummary` struct.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vulnerabilitytypes.go</strong><dd><code>Add HasTickets field to vulnerability-related structs</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/vulnerabilitytypes.go

<li>Introduced <code>HasTickets</code> field to <code>VulnerabilityWorkload</code> struct.<br> <li> Introduced <code>HasTickets</code> field to <code>ImageSummary</code> struct.<br> <li> Both fields are marked as <code>omitempty</code> for JSON serialization.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/494/files#diff-cac55976184cdb0c77ddde7ecbabd7411490f34df3e11868dd0e67e370c01830">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>