### PR TITLE
add ticketsCount field to VulnerabilityWorkload struct

### DIFF
--- a/armotypes/vulnerabilitytypes.go
+++ b/armotypes/vulnerabilitytypes.go
@@ -47,6 +47,7 @@ type VulnerabilityWorkload struct {
 	Images                   []string                 `json:"images"`
 	Tickets                  []Ticket                 `json:"tickets,omitempty"`
 	MissingRuntimeInfoReason MissingRuntimeInfoReason `json:"missingRuntimeInfoReason"`
+	TicketsCount             int                      `json:"ticketsCount,omitempty"`
 }
 
 type ContainerPathInfo struct {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added `ticketsCount` field to `VulnerabilityWorkload` struct.

- Enables tracking the number of tickets per workload.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vulnerabilitytypes.go</strong><dd><code>Add ticketsCount field to VulnerabilityWorkload struct</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/vulnerabilitytypes.go

<li>Introduced new <code>ticketsCount</code> integer field to <code>VulnerabilityWorkload</code>.<br> <li> Field is marked as <code>omitempty</code> for JSON serialization.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/500/files#diff-cac55976184cdb0c77ddde7ecbabd7411490f34df3e11868dd0e67e370c01830">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>