### PR TITLE
add container images to pod info & pod status

### DIFF
--- a/armotypes/podstatus.go
+++ b/armotypes/podstatus.go
@@ -31,6 +31,7 @@ type PodStatus struct {
 	HasApplicableRuleBindings  bool           `json:"hasApplicableRuleBindings"`
 	HasRelevancyCalculating    bool           `json:"hasRelevancyCalculating"`
 	IsKDRMonitored             bool           `json:"isKDRMonitored"`
+	ContainerImages            []string       `json:"containerImages,omitempty"`
 }
 
 type PodContainer struct {
@@ -55,6 +56,7 @@ type PodInfo struct {
 	CurrentState    string    `json:"currentState"`
 	LastStateReason string    `json:"lastStateReason"`
 	RestartCount    int       `json:"restartCount"`
+	ContainerImages []string  `json:"containerImages,omitempty"`
 }
 
 func (ps *PodStatus) GetMonitoredContainers() []PodContainer {


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added `containerImages` field to `PodStatus` struct.

- Added `containerImages` field to `PodInfo` struct.

- Enables tracking of container images in pod-related data.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>podstatus.go</strong><dd><code>Add container images tracking to pod status and info</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/podstatus.go

<li>Introduced <code>ContainerImages</code> field to <code>PodStatus</code> struct.<br> <li> Added <code>ContainerImages</code> field to <code>PodInfo</code> struct.<br> <li> Both fields are optional and store image names as string slices.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/502/files#diff-cda6e0497c1b712a7b4cda2553f53ba51f38383c86101b7cd086ce760ee4e3eb">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>