### PR TITLE
fixing struct

### DIFF
--- a/armotypes/portaltypes.go
+++ b/armotypes/portaltypes.go
@@ -94,7 +94,7 @@ type InstallationData struct {
 }
 
 type NodeAgentConfig struct {
-	MaxSniffingTime string `json:"maxSniffingTime"`
+	MaxSniffingTime string `json:"maxSniffingTimePerContainer"`
 }
 
 // hold information of a single subscription.


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Renamed `MaxSniffingTime` JSON field to `maxSniffingTimePerContainer`

- Ensures correct struct field mapping for NodeAgentConfig


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>portaltypes.go</strong><dd><code>Correct NodeAgentConfig JSON field name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/portaltypes.go

<li>Changed JSON tag for <code>MaxSniffingTime</code> from <code>maxSniffingTime</code> to <br><code>maxSniffingTimePerContainer</code><br> <li> Improves accuracy of JSON serialization/deserialization


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/511/files#diff-cdf63575c0bc337e1f9ddd63e8be29140734f38ee7550a487a19861bed59c7a6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>