### PR TITLE
Add ClusterStatus field to NotificationParams struct

### DIFF
--- a/notifications/usernotificationreporttypes.go
+++ b/notifications/usernotificationreporttypes.go
@@ -85,6 +85,8 @@ type NotificationParams struct {
 	// security risks params
 	SecurityRiskIDs []string `json:"securityRiskIDs,omitempty" bson:"securityRiskIDs,omitempty"` // Security Risk ID
 
+	// cluster status params
+	ClusterStatus []string `json:"clusterStatus,omitempty" bson:"clusterStatus,omitempty"` // Cluster Status
 }
 
 type AlertConfig struct {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added `ClusterStatus` field to `NotificationParams` struct.

- Enables passing cluster status information in notifications.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>usernotificationreporttypes.go</strong><dd><code>Add ClusterStatus field to NotificationParams struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

notifications/usernotificationreporttypes.go

<li>Introduced new <code>ClusterStatus</code> field to <code>NotificationParams</code> struct.<br> <li> Allows inclusion of cluster status as a string slice in notifications.


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/513/files#diff-3c7e18817dc4b7f569df2e93256fc6f6f4da980004aa57447583deca6cd9ea06">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>