### PR TITLE
add field to podinfo

### DIFF
--- a/armotypes/podstatus.go
+++ b/armotypes/podstatus.go
@@ -46,17 +46,18 @@ type PodContainer struct {
 }
 
 type PodInfo struct {
-	App             string    `json:"app"`
-	Name            string    `json:"name"`
-	Namespace       string    `json:"namespace"`
-	NodeName        string    `json:"nodeName"`
-	UpdatedAt       time.Time `json:"updatedAt"`
-	CreationTime    time.Time `json:"creationTimestamp"`
-	Phase           string    `json:"phase"`
-	CurrentState    string    `json:"currentState"`
-	LastStateReason string    `json:"lastStateReason"`
-	RestartCount    int       `json:"restartCount"`
-	ContainerImages []string  `json:"containerImages,omitempty"`
+	App                 string    `json:"app"`
+	Name                string    `json:"name"`
+	Namespace           string    `json:"namespace"`
+	NodeName            string    `json:"nodeName"`
+	UpdatedAt           time.Time `json:"updatedAt"`
+	CreationTime        time.Time `json:"creationTimestamp"`
+	Phase               string    `json:"phase"`
+	CurrentState        string    `json:"currentState"`
+	LastStateReason     string    `json:"lastStateReason"`
+	LastStateFinishedAt time.Time `json:"lastStateFinishedAt"`
+	RestartCount        int       `json:"restartCount"`
+	ContainerImages     []string  `json:"containerImages,omitempty"`
 }
 
 func (ps *PodStatus) GetMonitoredContainers() []PodContainer {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added `LastStateFinishedAt` field to `PodInfo` struct

- Enhances pod status tracking with additional timestamp


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>podstatus.go</strong><dd><code>Add LastStateFinishedAt field to PodInfo struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/podstatus.go

<li>Added <code>LastStateFinishedAt</code> field to <code>PodInfo</code> struct<br> <li> Updated struct tags to include the new field in JSON serialization


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/517/files#diff-cda6e0497c1b712a7b4cda2553f53ba51f38383c86101b7cd086ce760ee4e3eb">+12/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>