### PR TITLE
Removing omitempty from struct

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -50,10 +50,10 @@ type ProfileMetadata struct {
 	Status            string            `json:"status,omitempty" bson:"status,omitempty"`
 	Completion        string            `json:"completion,omitempty" bson:"completion,omitempty"`
 	Name              string            `json:"name,omitempty" bson:"name,omitempty"`
-	FailOnProfile     bool              `json:"failOnProfile,omitempty" bson:"failOnProfile,omitempty"`
-	Type              ProfileType       `json:"type,omitempty" bson:"type,omitempty"`
+	FailOnProfile     bool              `json:"failOnProfile" bson:"failOnProfile"`
+	Type              ProfileType       `json:"type" bson:"type"`
 	ProfileDependency ProfileDependency `json:"profileDependency,omitempty" bson:"profileDependency,omitempty"`
-	Error             error            `json:"error,omitempty" bson:"error,omitempty"`
+	Error             error             `json:"error,omitempty" bson:"error,omitempty"`
 }
 
 type CloudMetadata struct {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed `omitempty` from `FailOnProfile` and `Type` fields in `ProfileMetadata`

- Ensures these fields are always serialized in JSON/BSON output


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Remove omitempty from ProfileMetadata struct fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/runtimeincidents.go

<li>Removed <code>omitempty</code> from <code>FailOnProfile</code> and <code>Type</code> fields in <br><code>ProfileMetadata</code><br> <li> These fields will now always be included in JSON/BSON serialization


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/521/files#diff-d508180698efb5d5f7174c1ebe521251d68beca70abf2bd3c38ef4855233d8f1">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>