### PR TITLE
chore: make PolicyGUIDToName field optional in NewRuntimeIncident struct

### DIFF
--- a/notifications/runtimeincidents.go
+++ b/notifications/runtimeincidents.go
@@ -20,7 +20,7 @@ type NewRuntimeIncident struct {
 	Link                string                       `json:"link"`
 	Response            *RuntimeIncidentResponse     `json:"response,omitempty"`
 	ReportTime          time.Time                    `json:"reportTime"`
-	PolicyGUIDToName    map[string]string            `json:"policyGUIDToName"`
+	PolicyGUIDToName    map[string]string            `json:"policyGUIDToName,omitempty"`
 }
 
 type RuntimeIncidentResponse struct {


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Make `PolicyGUIDToName` field optional in `NewRuntimeIncident` struct


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runtimeincidents.go</strong><dd><code>Make PolicyGUIDToName field optional</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

notifications/runtimeincidents.go

<li>Added <code>omitempty</code> JSON tag to <code>PolicyGUIDToName</code> field in <br><code>NewRuntimeIncident</code> struct


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/529/files#diff-caf7960ecb78f5b98bb1bc9375470466146f7670ce99e8a998b41c0d0f836451">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>