### PR TITLE
Remove VolumeInfo interface from armotypes package

### DIFF
--- a/armotypes/interfaces.go
+++ b/armotypes/interfaces.go
@@ -1,9 +1,0 @@
-package armotypes
-
-type VolumeInfo interface {
-	GetProvider() string
-	GetAccountId() string
-	GetInstanceId() string
-	GetVolumeId() string
-	GetVolumeScanId() string
-}


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Remove `VolumeInfo` interface from armotypes package


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>interfaces.go</strong><dd><code>Delete VolumeInfo interface completely</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/interfaces.go

<ul><li>Delete entire <code>VolumeInfo</code> interface definition<br> <li> Remove methods: <code>GetProvider()</code>, <code>GetAccountId()</code>, <code>GetInstanceId()</code>, <br><code>GetVolumeId()</code>, <code>GetVolumeScanId()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/534/files#diff-5af7dc96378f045a517f8914116075fbb16ecac0c25637e5fb4b5911e80c4054">+0/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

