### PR TITLE
Add HostPathInfo struct to enhance vulnerability data representation

### DIFF
--- a/armotypes/vulnerabilitytypes.go
+++ b/armotypes/vulnerabilitytypes.go
@@ -61,6 +61,16 @@ type ContainerPathInfo struct {
 	ClusterShortName string `json:"clusterShortName"`
 }
 
+type HostPathInfo struct {
+	HostName     string `json:"hostName"`
+	InstanceHash string `json:"instanceHash"`
+	HostID       string `json:"hostID"`
+	AccountID    string `json:"accountID"`
+	AccountName  string `json:"accountName"`
+	HostType     string `json:"hostType"`
+	Region       string `json:"region"`
+}
+
 type ComponentSummary struct {
 	CustomerGUID    string              `json:"customerGUID"`
 	Name            string              `json:"name"`
@@ -143,6 +153,7 @@ type VulnerabilitiesComponent struct {
 
 type ComponentPathInfo struct {
 	ContainerPathInfo
+	HostPathInfo
 	ImageTag   string   `json:"imageTag"`
 	ImageHash  string   `json:"imageHash"`
 	IsRelevant string   `json:"isRelevant"`


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add `HostPathInfo` struct with host-specific fields

- Embed `HostPathInfo` in `ComponentPathInfo` for enhanced vulnerability tracking


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ComponentPathInfo"] --> B["ContainerPathInfo"]
  A --> C["HostPathInfo"]
  C --> D["Host metadata fields"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vulnerabilitytypes.go</strong><dd><code>Add HostPathInfo struct and embed in ComponentPathInfo</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

armotypes/vulnerabilitytypes.go

<ul><li>Add new <code>HostPathInfo</code> struct with 7 host-related fields<br> <li> Embed <code>HostPathInfo</code> in <code>ComponentPathInfo</code> struct</ul>


</details>


  </td>
  <td><a href="https://github.com/armosec/armoapi-go/pull/555/files#diff-cac55976184cdb0c77ddde7ecbabd7411490f34df3e11868dd0e67e370c01830">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

