### PR TITLE
Fix field name in BaseRuntimeAlert struct to ensure consistent JSON and BSON mapping

### DIFF
--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -106,7 +106,7 @@ type Trace struct {
 
 type BaseRuntimeAlert struct {
 	// AlertName is either RuleName or MalwareName
-	AlertName string `json:"alertName,omitempty" bson:"name,omitempty"`
+	AlertName string `json:"alertName,omitempty" bson:"alertName,omitempty"`
 	// Arguments of specific alerts (e.g. for unexpected files: open file flags; for unexpected process: return code)
 	Arguments map[string]interface{} `json:"arguments,omitempty" bson:"arguments,omitempty"`
 	// Infected process id


### PR DESCRIPTION
This pull request makes a minor fix to the `BaseRuntimeAlert` struct in `armotypes/runtimeincidents.go`. The change ensures that the BSON field name for `AlertName` matches the JSON field name, improving consistency in data serialization. In the current state, `AlertName` was lost in conversion.

* Updated the BSON tag for the `AlertName` field in the `BaseRuntimeAlert` struct from `name` to `alertName` to align with the JSON tag.