### PR TITLE
feat: add isHotCVE/hasHotCVE to vulnerability API response types (SUB-7201)

### DIFF
--- a/armotypes/vulnerabilitytypes.go
+++ b/armotypes/vulnerabilitytypes.go
@@ -96,6 +96,7 @@ type ComponentSummary struct {
 	TicketManager   TicketManager       `json:"ticketManager,omitempty"`
 	Tickets         []Ticket            `json:"tickets,omitempty"`
 	TicketsCount    int                 `json:"ticketsCount,omitempty"`
+	HasHotCVE       bool                `json:"hasHotCVE,omitempty" bson:"hasHotCVE,omitempty"`
 }
 
 type ImageSummary struct {
@@ -325,5 +326,6 @@ type VulnerabilityToHost struct {
 	HostErrorDescription     string                     `json:"hostErrorDescription,omitempty"` // enriched on API level with host error descriptions for UI
 	VolumesInfo              map[string]VolumeScanState `json:"volumeScanStates"`
 	VolumeErrorDescriptions  []string                   `json:"volumeErrorDescriptions,omitempty"` // enriched on API level with volume error descriptions for UI
+	HasHotCVE                bool                       `json:"hasHotCVE,omitempty" bson:"hasHotCVE,omitempty"`
 
 }

--- a/armotypes/vulnerabilitytypes.go
+++ b/armotypes/vulnerabilitytypes.go
@@ -49,7 +49,7 @@ type VulnerabilityWorkload struct {
 	Tickets                  []Ticket                 `json:"tickets,omitempty"`
 	MissingRuntimeInfoReason MissingRuntimeInfoReason `json:"missingRuntimeInfoReason"`
 	TicketsCount             int                      `json:"ticketsCount,omitempty"`
-	HasHotCVE                bool                     `json:"hasHotCVE,omitempty" bson:"hasHotCVE,omitempty"`
+	HasHotCVE                bool                     `json:"hasHotCVE"`
 }
 
 type ContainerPathInfo struct {
@@ -96,7 +96,7 @@ type ComponentSummary struct {
 	TicketManager   TicketManager       `json:"ticketManager,omitempty"`
 	Tickets         []Ticket            `json:"tickets,omitempty"`
 	TicketsCount    int                 `json:"ticketsCount,omitempty"`
-	HasHotCVE       bool                `json:"hasHotCVE,omitempty" bson:"hasHotCVE,omitempty"`
+	HasHotCVE       bool                `json:"hasHotCVE"`
 }
 
 type ImageSummary struct {
@@ -128,7 +128,7 @@ type ImageSummary struct {
 	TicketManager   TicketManager       `json:"ticketManager,omitempty"`
 	Tickets         []Ticket            `json:"tickets,omitempty"`
 	TicketsCount    int                 `json:"ticketsCount,omitempty"`
-	HasHotCVE       bool                `json:"hasHotCVE,omitempty" bson:"hasHotCVE,omitempty"`
+	HasHotCVE       bool                `json:"hasHotCVE"`
 }
 
 type BaseImage struct {
@@ -190,7 +190,7 @@ type Vulnerability struct {
 	Tickets            []Ticket                     `json:"tickets,omitempty"`
 	HasTickets         bool                         `json:"hasTickets,omitempty"`
 	TicketsCount       int                          `json:"ticketsCount,omitempty"`
-	IsHotCVE           *bool                        `json:"isHotCVE,omitempty" bson:"isHotCVE,omitempty"`
+	IsHotCVE           *bool                        `json:"isHotCVE,omitempty"`
 }
 
 type CvssInfo struct {
@@ -326,6 +326,6 @@ type VulnerabilityToHost struct {
 	HostErrorDescription     string                     `json:"hostErrorDescription,omitempty"` // enriched on API level with host error descriptions for UI
 	VolumesInfo              map[string]VolumeScanState `json:"volumeScanStates"`
 	VolumeErrorDescriptions  []string                   `json:"volumeErrorDescriptions,omitempty"` // enriched on API level with volume error descriptions for UI
-	HasHotCVE                bool                       `json:"hasHotCVE,omitempty" bson:"hasHotCVE,omitempty"`
+	HasHotCVE                bool                       `json:"hasHotCVE"`
 
 }

--- a/armotypes/vulnerabilitytypes.go
+++ b/armotypes/vulnerabilitytypes.go
@@ -49,6 +49,7 @@ type VulnerabilityWorkload struct {
 	Tickets                  []Ticket                 `json:"tickets,omitempty"`
 	MissingRuntimeInfoReason MissingRuntimeInfoReason `json:"missingRuntimeInfoReason"`
 	TicketsCount             int                      `json:"ticketsCount,omitempty"`
+	HasHotCVE                bool                     `json:"hasHotCVE,omitempty" bson:"hasHotCVE,omitempty"`
 }
 
 type ContainerPathInfo struct {
@@ -126,6 +127,7 @@ type ImageSummary struct {
 	TicketManager   TicketManager       `json:"ticketManager,omitempty"`
 	Tickets         []Ticket            `json:"tickets,omitempty"`
 	TicketsCount    int                 `json:"ticketsCount,omitempty"`
+	HasHotCVE       bool                `json:"hasHotCVE,omitempty" bson:"hasHotCVE,omitempty"`
 }
 
 type BaseImage struct {
@@ -187,6 +189,7 @@ type Vulnerability struct {
 	Tickets            []Ticket                     `json:"tickets,omitempty"`
 	HasTickets         bool                         `json:"hasTickets,omitempty"`
 	TicketsCount       int                          `json:"ticketsCount,omitempty"`
+	IsHotCVE           *bool                        `json:"isHotCVE,omitempty" bson:"isHotCVE,omitempty"`
 }
 
 type CvssInfo struct {


### PR DESCRIPTION
## Summary

Add hot CVE fields to API response types so vulnerability V2 APIs return hot CVE status.

- `Vulnerability.IsHotCVE *bool` — CVE-level hot CVE flag
- `VulnerabilityWorkload.HasHotCVE bool` — workload has at least one hot CVE
- `ImageSummary.HasHotCVE bool` — image has at least one hot CVE

These fields are populated by the view SQL templates (BOOL_OR on sentinel layer_hash) and flow through postgres-connector models to these response types.

SUB-7201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking and displaying hot vulnerabilities across workloads, images, and individual vulnerability records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->