### PR TITLE
Add ClusterUID to SynchronizerClient armotype.

### DIFF
--- a/armotypes/synchronizerclients.go
+++ b/armotypes/synchronizerclients.go
@@ -17,4 +17,5 @@ type SynchronizerClient struct {
 	CloudProvider       string    `json:"cloudProvider"`
 	ClusterStatus       string    `json:"clusterStatus"`
 	LearningTime        string    `json:"learningTime"`
+	ClusterUID          string    `json:"clusterUID"`
 }


### PR DESCRIPTION
Stable cluster identifier (kube-system namespace UID) for synchronizer-backed K8s clusters.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Updates**
  * Enhanced synchronizer client structure to support cluster identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->