### PR TITLE
feat: extend HotCVEOnFinishedMessage for notifications

### DIFF
--- a/armotypes/hot_cve.go
+++ b/armotypes/hot_cve.go
@@ -30,11 +30,22 @@ type HotCVEEndpointResponse struct {
 	HotCVEs []HotCVE `json:"hotCves"`
 }
 
+// HotCVEAffectedWorkload describes a workload affected by a hot CVE.
+type HotCVEAffectedWorkload struct {
+	Cluster      string `json:"cluster"`
+	Namespace    string `json:"namespace"`
+	WorkloadKind string `json:"workloadKind"`
+	WorkloadName string `json:"workloadName"`
+	ImageTag     string `json:"imageTag"`
+}
+
 // HotCVEOnFinishedMessage is the Pulsar message published for UNS after hot CVE processing.
 type HotCVEOnFinishedMessage struct {
-	CustomerGUID string `json:"customerGUID"`
-	CVEID        string `json:"cveId"`
-	Severity     string `json:"severity"`
+	CustomerGUID      string                   `json:"customerGUID"`
+	CVEID             string                   `json:"cveId"`
+	Severity          string                   `json:"severity"`
+	Title             string                   `json:"title,omitempty"`
+	AffectedWorkloads []HotCVEAffectedWorkload `json:"affectedWorkloads,omitempty"`
 }
 
 // Validate checks that the HotCVE has all required fields.

--- a/armotypes/hot_cve_test.go
+++ b/armotypes/hot_cve_test.go
@@ -181,3 +181,95 @@ func TestHotCVE_Validate(t *testing.T) {
 		})
 	}
 }
+
+func TestHotCVEOnFinishedMessage_RoundTrip(t *testing.T) {
+	msg := HotCVEOnFinishedMessage{
+		CustomerGUID: "guid-123",
+		CVEID:        "CVE-2026-1234",
+		Severity:     "Critical",
+		Title:        "Remote code execution in libfoo",
+		AffectedWorkloads: []HotCVEAffectedWorkload{
+			{
+				Cluster:      "prod-cluster",
+				Namespace:    "default",
+				WorkloadKind: "Deployment",
+				WorkloadName: "my-app",
+				ImageTag:     "my-app:v1.2.3",
+			},
+			{
+				Cluster:      "staging-cluster",
+				Namespace:    "kube-system",
+				WorkloadKind: "DaemonSet",
+				WorkloadName: "node-agent",
+				ImageTag:     "node-agent:latest",
+			},
+		},
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var decoded HotCVEOnFinishedMessage
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, msg, decoded)
+}
+
+func TestHotCVEOnFinishedMessage_BackwardCompatibility(t *testing.T) {
+	// Old message format without title and affectedWorkloads
+	oldJSON := `{"customerGUID":"guid-456","cveId":"CVE-2026-5678","severity":"High"}`
+
+	var msg HotCVEOnFinishedMessage
+	err := json.Unmarshal([]byte(oldJSON), &msg)
+	require.NoError(t, err)
+
+	assert.Equal(t, "guid-456", msg.CustomerGUID)
+	assert.Equal(t, "CVE-2026-5678", msg.CVEID)
+	assert.Equal(t, "High", msg.Severity)
+	assert.Empty(t, msg.Title)
+	assert.Nil(t, msg.AffectedWorkloads)
+}
+
+func TestHotCVEOnFinishedMessage_OmitEmptyFields(t *testing.T) {
+	msg := HotCVEOnFinishedMessage{
+		CustomerGUID: "guid-789",
+		CVEID:        "CVE-2026-9999",
+		Severity:     "Medium",
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	err = json.Unmarshal(data, &raw)
+	require.NoError(t, err)
+
+	_, hasTitle := raw["title"]
+	_, hasWorkloads := raw["affectedWorkloads"]
+	assert.False(t, hasTitle, "title should be omitted when empty")
+	assert.False(t, hasWorkloads, "affectedWorkloads should be omitted when nil")
+}
+
+func TestHotCVEAffectedWorkload_Serialization(t *testing.T) {
+	workload := HotCVEAffectedWorkload{
+		Cluster:      "my-cluster",
+		Namespace:    "production",
+		WorkloadKind: "StatefulSet",
+		WorkloadName: "database",
+		ImageTag:     "postgres:15.2",
+	}
+
+	data, err := json.Marshal(workload)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	err = json.Unmarshal(data, &raw)
+	require.NoError(t, err)
+
+	assert.Equal(t, "my-cluster", raw["cluster"])
+	assert.Equal(t, "production", raw["namespace"])
+	assert.Equal(t, "StatefulSet", raw["workloadKind"])
+	assert.Equal(t, "database", raw["workloadName"])
+	assert.Equal(t, "postgres:15.2", raw["imageTag"])
+}


### PR DESCRIPTION
## Summary
- Extend `HotCVEOnFinishedMessage` with `Title` and `AffectedWorkloads` fields for UNS notification dispatch
- Add `HotCVEAffectedWorkload` struct (cluster, namespace, workload kind/name, image tag)
- Both new fields are `omitempty` for backward compatibility with existing consumers

**Part of:** [SUB-7218](https://cyberarmor-io.atlassian.net/browse/SUB-7218) — Hot CVE Notifications

## Test plan
- [x] JSON round-trip serialization test
- [x] Backward compatibility test (old messages without new fields)
- [x] Omitempty verification test
- [x] `go vet` clean


[SUB-7218]: https://cyberarmor-io.atlassian.net/browse/SUB-7218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CVE alerts now include detailed information about affected workloads (cluster, namespace, workload kind, workload name, and image tag) for better visibility into impact.
  * Added support for CVE title fields in notifications.
  * Maintained backward compatibility with previously issued CVE messages.

* **Tests**
  * Added comprehensive test coverage for CVE message serialization and deserialization including backward compatibility validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->