### PR TITLE
feat: add HotCVEMatchMessage and AlertTypeVulnerability for runtime incidents

### DIFF
--- a/armotypes/hot_cve.go
+++ b/armotypes/hot_cve.go
@@ -70,6 +70,28 @@ func (p *HotCVEAffectedPackage) Validate() error {
 	return nil
 }
 
+// HotCVEMatchMessage is published to the KDR ingester topic when a hot CVE
+// matches a customer's SBOM component. The HotCVEMessageProcessor creates
+// runtime incidents from these messages.
+type HotCVEMatchMessage struct {
+	CustomerGUID     string `json:"customerGUID"`
+	CVEID            string `json:"cveId"`
+	Title            string `json:"title"`
+	Description      string `json:"description"`
+	Severity         string `json:"severity"`
+	SeverityScore    int    `json:"severityScore"`
+	Component        string `json:"component"`
+	ComponentVersion string `json:"componentVersion"`
+	PackageType      string `json:"packageType"`
+	FixedVersion     string `json:"fixedVersion"`
+	ResourceHash     string `json:"resourceHash"`
+	ClusterName      string `json:"clusterName"`
+	Namespace        string `json:"namespace"`
+	WorkloadName     string `json:"workloadName"`
+	WorkloadKind     string `json:"workloadKind"`
+	IsInUse          bool   `json:"isInUse"`
+}
+
 const (
 	HotCVESentinelLayerHash = "__hot_cve__"
 	HotCVEStatusActive      = "active"

--- a/armotypes/hot_cve_test.go
+++ b/armotypes/hot_cve_test.go
@@ -181,3 +181,65 @@ func TestHotCVE_Validate(t *testing.T) {
 		})
 	}
 }
+
+func TestHotCVEMatchMessage_Serialization(t *testing.T) {
+	msg := HotCVEMatchMessage{
+		CustomerGUID:     "test-guid-1234",
+		CVEID:            "CVE-2026-9999",
+		Title:            "Critical RCE in libfoo",
+		Description:      "Remote code execution vulnerability",
+		Severity:         "Critical",
+		SeverityScore:    900,
+		Component:        "libfoo",
+		ComponentVersion: "1.2.3",
+		PackageType:      "deb",
+		FixedVersion:     "1.2.4",
+		ResourceHash:     "abc123hash",
+		ClusterName:      "prod-cluster",
+		Namespace:        "default",
+		WorkloadName:     "my-deployment",
+		WorkloadKind:     "Deployment",
+		IsInUse:          true,
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var decoded HotCVEMatchMessage
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, msg, decoded)
+}
+
+func TestHotCVEMatchMessage_IsInUseField(t *testing.T) {
+	tests := []struct {
+		name    string
+		isInUse bool
+	}{
+		{
+			name:    "isInUse true serializes as boolean true",
+			isInUse: true,
+		},
+		{
+			name:    "isInUse false serializes as boolean false",
+			isInUse: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := HotCVEMatchMessage{IsInUse: tt.isInUse}
+			data, err := json.Marshal(msg)
+			require.NoError(t, err)
+
+			var raw map[string]interface{}
+			err = json.Unmarshal(data, &raw)
+			require.NoError(t, err)
+
+			val, ok := raw["isInUse"]
+			require.True(t, ok, "isInUse field must be present in JSON")
+			assert.Equal(t, tt.isInUse, val.(bool))
+		})
+	}
+}

--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -22,7 +22,10 @@ const (
 	AlertTypeCdr
 	AlertTypeHttpRule
 	AlertTypeNetworkScan
+	AlertTypeVulnerability
 )
+
+const HotCVEMatchMessageProperty = "HOT_CVE"
 
 type AlertSourcePlatform int
 


### PR DESCRIPTION
Phase 1 of SUB-7246 — shared types for hot CVE runtime incidents.

- `HotCVEMatchMessage` struct (published to KDR ingester topic per SBOM match)
- `AlertTypeVulnerability = 6` (new alert type for vulnerability incidents)
- `HotCVEMatchMessageProperty = "HOT_CVE"` constant for Pulsar message routing
- Unit tests for serialization and isInUse field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hot CVE vulnerability detection and reporting for application components with severity metrics
  * Extended alert system to track affected components, versions, and fix availability with runtime environment context
  
* **Tests**
  * Added test coverage for vulnerability event serialization and deserialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->