### PR TITLE
feat: add ResourceGroup field to SynchronizerClient

### DIFF
--- a/armotypes/synchronizerclients.go
+++ b/armotypes/synchronizerclients.go
@@ -18,4 +18,5 @@ type SynchronizerClient struct {
 	ClusterStatus       string    `json:"clusterStatus"`
 	LearningTime        string    `json:"learningTime"`
 	ClusterUID          string    `json:"clusterUID"`
+	ResourceGroup       string    `json:"resourceGroup,omitempty"`
 }


### PR DESCRIPTION
Adds an optional ResourceGroup string field to armotypes.SynchronizerClient so the Azure resource group hosting an AKS cluster can be persisted in the synchronizer_clients table. The field is omitempty to keep wire payloads clean for non-Azure providers.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SynchronizerClient to support resource group information in configuration payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->