### PR TITLE
feat: reject non-canonical severity values in HotCVE.Validate

### DIFF
--- a/armotypes/hot_cve.go
+++ b/armotypes/hot_cve.go
@@ -1,6 +1,10 @@
 package armotypes
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
 
 // HotCVEAffectedPackage defines a package affected by a hot CVE.
 type HotCVEAffectedPackage struct {
@@ -37,7 +41,7 @@ type HotCVEOnFinishedMessage struct {
 	Severity     string `json:"severity"`
 }
 
-// HotCVEValidSeverities is the allow-list of severity values the hot-CVE
+// hotCVEValidSeverities is the allow-list of severity values the hot-CVE
 // pipeline can propagate end-to-end. Values MUST be titlecase — the
 // postgres-connector vulnerabilities_cves view upsert INNER-joins
 // vulnerabilities_v1 with `severity = 'Critical' OR 'High' OR ...`
@@ -47,13 +51,38 @@ type HotCVEOnFinishedMessage struct {
 // confirmation on 2026-04-21: 13 lowercase "critical" rows in dev
 // vulnerabilities_v1 were filtered out of 260,278 vulnerabilities_cves
 // rows, resulting in zero is_hot_cve=true rows cluster-wide.
-var HotCVEValidSeverities = map[string]struct{}{
+//
+// Unexported so external callers cannot mutate the allow-list at runtime;
+// use IsValidHotCVESeverity for membership checks.
+var hotCVEValidSeverities = map[string]struct{}{
 	"Critical":   {},
 	"High":       {},
 	"Medium":     {},
 	"Low":        {},
 	"Unknown":    {},
 	"Negligible": {},
+}
+
+// IsValidHotCVESeverity reports whether severity is accepted by the hot-CVE
+// pipeline. Callers outside this package should use this helper rather than
+// touching the underlying map, so the allow-list stays immutable at runtime.
+func IsValidHotCVESeverity(severity string) bool {
+	_, ok := hotCVEValidSeverities[severity]
+	return ok
+}
+
+// hotCVEValidSeveritiesList returns the allow-list as a sorted slice — used
+// to build deterministic error messages without duplicating the severity
+// strings between the allow-list and the error text. Building the list at
+// call time (rather than caching) avoids any mutation risk and keeps the
+// validator output in lockstep with the map.
+func hotCVEValidSeveritiesList() []string {
+	out := make([]string, 0, len(hotCVEValidSeverities))
+	for s := range hotCVEValidSeverities {
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // Validate checks that the HotCVE has all required fields.
@@ -64,8 +93,8 @@ func (h *HotCVE) Validate() error {
 	if h.Severity == "" {
 		return fmt.Errorf("severity is required")
 	}
-	if _, ok := HotCVEValidSeverities[h.Severity]; !ok {
-		return fmt.Errorf("invalid severity %q: must be one of Critical, High, Medium, Low, Unknown, Negligible (titlecase)", h.Severity)
+	if !IsValidHotCVESeverity(h.Severity) {
+		return fmt.Errorf("invalid severity %q: must be one of %s (titlecase)", h.Severity, strings.Join(hotCVEValidSeveritiesList(), ", "))
 	}
 	if len(h.AffectedPackages) == 0 {
 		return fmt.Errorf("affectedPackages is required and must not be empty")

--- a/armotypes/hot_cve.go
+++ b/armotypes/hot_cve.go
@@ -37,6 +37,25 @@ type HotCVEOnFinishedMessage struct {
 	Severity     string `json:"severity"`
 }
 
+// HotCVEValidSeverities is the allow-list of severity values the hot-CVE
+// pipeline can propagate end-to-end. Values MUST be titlecase — the
+// postgres-connector vulnerabilities_cves view upsert INNER-joins
+// vulnerabilities_v1 with `severity = 'Critical' OR 'High' OR ...`
+// (titlecase only), and that join silently drops anything else. Keep this
+// list in lockstep with the SQL filter in postgres-connector/internal/
+// dalhelpers/templates/vulnerabilitiesCVEsViewUpsert.sql. Empirical
+// confirmation on 2026-04-21: 13 lowercase "critical" rows in dev
+// vulnerabilities_v1 were filtered out of 260,278 vulnerabilities_cves
+// rows, resulting in zero is_hot_cve=true rows cluster-wide.
+var HotCVEValidSeverities = map[string]struct{}{
+	"Critical":   {},
+	"High":       {},
+	"Medium":     {},
+	"Low":        {},
+	"Unknown":    {},
+	"Negligible": {},
+}
+
 // Validate checks that the HotCVE has all required fields.
 func (h *HotCVE) Validate() error {
 	if h.CVEID == "" {
@@ -44,6 +63,9 @@ func (h *HotCVE) Validate() error {
 	}
 	if h.Severity == "" {
 		return fmt.Errorf("severity is required")
+	}
+	if _, ok := HotCVEValidSeverities[h.Severity]; !ok {
+		return fmt.Errorf("invalid severity %q: must be one of Critical, High, Medium, Low, Unknown, Negligible (titlecase)", h.Severity)
 	}
 	if len(h.AffectedPackages) == 0 {
 		return fmt.Errorf("affectedPackages is required and must not be empty")

--- a/armotypes/hot_cve_test.go
+++ b/armotypes/hot_cve_test.go
@@ -34,7 +34,7 @@ func TestHotCVE_Validate_FromJSON(t *testing.T) {
 	// Verify specific fields from the example
 	assert.Equal(t, "CVE-2024-3094", hotCVEs[0].CVEID)
 	assert.Equal(t, "xz/liblzma backdoor", hotCVEs[0].Title)
-	assert.Equal(t, "critical", hotCVEs[0].Severity)
+	assert.Equal(t, "Critical", hotCVEs[0].Severity)
 	assert.Equal(t, 900, hotCVEs[0].SeverityScore)
 	assert.Len(t, hotCVEs[0].AffectedPackages, 4)
 	assert.Equal(t, "xz-utils", hotCVEs[0].AffectedPackages[0].PackageName)
@@ -60,7 +60,7 @@ func TestHotCVE_Validate(t *testing.T) {
 			name: "valid hot CVE",
 			cve: HotCVE{
 				CVEID:            "CVE-2024-3094",
-				Severity:         "critical",
+				Severity:         "Critical",
 				AffectedPackages: []HotCVEAffectedPackage{validPkg},
 			},
 		},
@@ -68,7 +68,7 @@ func TestHotCVE_Validate(t *testing.T) {
 			name: "valid with status active",
 			cve: HotCVE{
 				CVEID:            "CVE-2024-3094",
-				Severity:         "high",
+				Severity:         "High",
 				Status:           HotCVEStatusActive,
 				AffectedPackages: []HotCVEAffectedPackage{validPkg},
 			},
@@ -77,7 +77,7 @@ func TestHotCVE_Validate(t *testing.T) {
 			name: "valid with status inactive",
 			cve: HotCVE{
 				CVEID:            "CVE-2024-3094",
-				Severity:         "medium",
+				Severity:         "Medium",
 				Status:           HotCVEStatusInactive,
 				AffectedPackages: []HotCVEAffectedPackage{validPkg},
 			},
@@ -85,7 +85,7 @@ func TestHotCVE_Validate(t *testing.T) {
 		{
 			name: "missing cveId",
 			cve: HotCVE{
-				Severity:         "critical",
+				Severity:         "Critical",
 				AffectedPackages: []HotCVEAffectedPackage{validPkg},
 			},
 			wantErr: "cveId is required",
@@ -102,7 +102,7 @@ func TestHotCVE_Validate(t *testing.T) {
 			name: "empty affected packages",
 			cve: HotCVE{
 				CVEID:            "CVE-2024-3094",
-				Severity:         "critical",
+				Severity:         "Critical",
 				AffectedPackages: []HotCVEAffectedPackage{},
 			},
 			wantErr: "affectedPackages is required",
@@ -111,7 +111,7 @@ func TestHotCVE_Validate(t *testing.T) {
 			name: "nil affected packages",
 			cve: HotCVE{
 				CVEID:    "CVE-2024-3094",
-				Severity: "critical",
+				Severity: "Critical",
 			},
 			wantErr: "affectedPackages is required",
 		},
@@ -119,7 +119,7 @@ func TestHotCVE_Validate(t *testing.T) {
 			name: "invalid status",
 			cve: HotCVE{
 				CVEID:            "CVE-2024-3094",
-				Severity:         "critical",
+				Severity:         "Critical",
 				Status:           "pending",
 				AffectedPackages: []HotCVEAffectedPackage{validPkg},
 			},
@@ -129,7 +129,7 @@ func TestHotCVE_Validate(t *testing.T) {
 			name: "invalid affected package — missing packageName",
 			cve: HotCVE{
 				CVEID:    "CVE-2024-3094",
-				Severity: "critical",
+				Severity: "Critical",
 				AffectedPackages: []HotCVEAffectedPackage{
 					{VersionStart: "1.0.0"},
 				},
@@ -140,7 +140,7 @@ func TestHotCVE_Validate(t *testing.T) {
 			name: "invalid affected package — no version constraint",
 			cve: HotCVE{
 				CVEID:    "CVE-2024-3094",
-				Severity: "critical",
+				Severity: "Critical",
 				AffectedPackages: []HotCVEAffectedPackage{
 					{PackageName: "xz-utils"},
 				},
@@ -151,7 +151,7 @@ func TestHotCVE_Validate(t *testing.T) {
 			name: "valid with exact version only",
 			cve: HotCVE{
 				CVEID:    "CVE-2024-3094",
-				Severity: "critical",
+				Severity: "Critical",
 				AffectedPackages: []HotCVEAffectedPackage{
 					{PackageName: "xz-utils", VersionExact: []string{"5.6.1"}},
 				},
@@ -161,11 +161,46 @@ func TestHotCVE_Validate(t *testing.T) {
 			name: "valid with start only (no upper bound)",
 			cve: HotCVE{
 				CVEID:    "CVE-2024-3094",
-				Severity: "critical",
+				Severity: "Critical",
 				AffectedPackages: []HotCVEAffectedPackage{
 					{PackageName: "xz-utils", VersionStart: "5.6.0"},
 				},
 			},
+		},
+
+		// Severity whitelist — the postgres-connector view upsert silently
+		// filters out anything other than titlecase Critical/High/Medium/Low/
+		// Unknown/Negligible (see HotCVEValidSeverities doc). These cases are
+		// the regression guards for the SUB-7201 bug where lowercase "critical"
+		// was accepted and then silently dropped by the SQL join, resulting in
+		// zero is_hot_cve=true rows across 260k vulnerabilities_cves rows in
+		// dev until this validator was tightened.
+		{
+			name:    "rejects lowercase critical",
+			cve:     HotCVE{CVEID: "CVE-2024-3094", Severity: "critical", AffectedPackages: []HotCVEAffectedPackage{validPkg}},
+			wantErr: "invalid severity",
+		},
+		{
+			name:    "rejects titlecase-but-nonmember NegligibleTypo",
+			cve:     HotCVE{CVEID: "CVE-2024-3094", Severity: "Informational", AffectedPackages: []HotCVEAffectedPackage{validPkg}},
+			wantErr: "invalid severity",
+		},
+		{
+			name:    "rejects whitespace-padded Critical",
+			cve:     HotCVE{CVEID: "CVE-2024-3094", Severity: " Critical", AffectedPackages: []HotCVEAffectedPackage{validPkg}},
+			wantErr: "invalid severity",
+		},
+		{
+			name: "accepts Negligible (scanners produce this)",
+			cve:  HotCVE{CVEID: "CVE-2024-3094", Severity: "Negligible", AffectedPackages: []HotCVEAffectedPackage{validPkg}},
+		},
+		{
+			name: "accepts Unknown",
+			cve:  HotCVE{CVEID: "CVE-2024-3094", Severity: "Unknown", AffectedPackages: []HotCVEAffectedPackage{validPkg}},
+		},
+		{
+			name: "accepts Low",
+			cve:  HotCVE{CVEID: "CVE-2024-3094", Severity: "Low", AffectedPackages: []HotCVEAffectedPackage{validPkg}},
 		},
 	}
 

--- a/armotypes/hot_cve_test.go
+++ b/armotypes/hot_cve_test.go
@@ -170,7 +170,7 @@ func TestHotCVE_Validate(t *testing.T) {
 
 		// Severity whitelist — the postgres-connector view upsert silently
 		// filters out anything other than titlecase Critical/High/Medium/Low/
-		// Unknown/Negligible (see HotCVEValidSeverities doc). These cases are
+		// Unknown/Negligible (see hotCVEValidSeverities doc). These cases are
 		// the regression guards for the SUB-7201 bug where lowercase "critical"
 		// was accepted and then silently dropped by the SQL join, resulting in
 		// zero is_hot_cve=true rows across 260k vulnerabilities_cves rows in
@@ -181,7 +181,7 @@ func TestHotCVE_Validate(t *testing.T) {
 			wantErr: "invalid severity",
 		},
 		{
-			name:    "rejects titlecase-but-nonmember NegligibleTypo",
+			name:    "rejects titlecase-but-nonmember Informational",
 			cve:     HotCVE{CVEID: "CVE-2024-3094", Severity: "Informational", AffectedPackages: []HotCVEAffectedPackage{validPkg}},
 			wantErr: "invalid severity",
 		},

--- a/armotypes/testdata/hot_cve_example.json
+++ b/armotypes/testdata/hot_cve_example.json
@@ -3,7 +3,7 @@
     "cveId": "CVE-2024-3094",
     "title": "xz/liblzma backdoor",
     "description": "Malicious code was discovered in xz-utils versions 5.6.0 and 5.6.1. The backdoor affects the sshd service via systemd.",
-    "severity": "critical",
+    "severity": "Critical",
     "severityScore": 900,
 
     "references": [
@@ -46,7 +46,7 @@
     "cveId": "CVE-2024-9999",
     "title": "Example Node.js zero-day",
     "description": "Critical remote code execution in Node.js http module.",
-    "severity": "high",
+    "severity": "High",
     "severityScore": 750,
 
     "references": [


### PR DESCRIPTION
## Summary
- Tighten `HotCVE.Validate()` to reject any `Severity` not in the allow-list `{Critical, High, Medium, Low, Unknown, Negligible}` (titlecase).
- Update `testdata/hot_cve_example.json` and existing test cases to use titlecase so the existing validator test still passes.
- Add 6 regression test cases for the new rule, including the exact lowercase-`critical` case that was silently broken in production.

## Why

Live dev-DB inspection on 2026-04-21 (while debugging the `hot_cve_detection` system test) showed that every hot CVE ever sent through the pipeline has been silently dropped. Across 260,278 rows in `vulnerabilities_cves`, exactly **zero** have `is_hot_cve=true` — for any customer, for any CVE.

The chain:

1. Admin POST → dashboard-backend → `HotCVE.Validate()` (armoapi-go). Today only checks `Severity != ""`. Accepts anything.
2. event-ingester `hot_cve.go:150-157` writes `hotCVE.Severity` verbatim into `hot_cves` and (via `InjectHotCVEFinding`) `vulnerabilities_v1`.
3. postgres-connector `vulnerabilitiesCVEsViewUpsert.sql:55-62`:
   ```sql
   INNER JOIN vulnerabilities_v1 ON vulnerabilities_v1.vulnerability_id = vulnerability_findings_v1.vulnerability_id
   AND (
     vulnerabilities_v1.severity = 'Critical'
     OR vulnerabilities_v1.severity = 'High'
     OR ...
   )
   ```
   Titlecase-only filter. Anything else is silently filtered out, the join produces zero rows, `vulnerabilities_cves` stays empty, `is_hot_cve` never becomes true.

The 13 lowercase `critical` rows sitting in dev `vulnerabilities_v1` today are the persisted evidence of every previous run that went straight through the broken path with no error, no log.

## Why this layer

`cadashboardbe/httphandlerv2/hotcvehandler.go:40` already calls `Validate()` on every incoming hot CVE in the POST body. Strengthening the validator here takes effect at the admin API boundary immediately — no new call-site and no new integration.

The alternative (making the SQL filter case-insensitive with `LOWER()`) would paper over the contract violation and let similar input bugs recur elsewhere. Better to reject at the boundary.

## Breakage surface
- **System test** (`armosec/system-tests` PR #1112): was sending `"critical"`. Fix commit `1ad0ebc` on that branch already switches to `"Critical"`.
- **Other callers** of `HotCVE.Validate()`: grepped `armosec/cadashboardbe`, `armosec/event-ingester-service`, `armosec/users-notification-service`. Only cadashboardbe calls it on POSTed bodies; all other consumers receive already-validated data from postgres.
- **Existing dev DB data** (13 lowercase-`critical` rows): intentionally not backfilled. They've never matched the join and never produced any effect; re-casing them without replaying the rest of the pipeline would also not make `is_hot_cve` true. They'll age out naturally.

## Test plan
- [x] `go test ./armotypes/ -run TestHotCVE` — 18 cases pass (12 existing updated + 6 new)
- [x] `go build ./...` clean
- [ ] After merge: bump armoapi-go in cadashboardbe + run its test suite
- [ ] After both merge: trigger `hot_cve_detection` and watch `vulnerabilities_cves.is_hot_cve=true` appear for the test CVE for the first time ever


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Severity validation now enforces a defined set of valid values: Critical, High, Medium, Low, Unknown, and Negligible. Invalid or improperly formatted severity values are rejected with a clear error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->