### PR TITLE
feat(hot-cve): enrich HotCVEOnFinishedMessage with Title, References, AffectedWorkloads

### DIFF
--- a/armotypes/hot_cve.go
+++ b/armotypes/hot_cve.go
@@ -34,11 +34,40 @@ type HotCVEEndpointResponse struct {
 	HotCVEs []HotCVE `json:"hotCves"`
 }
 
+// HotCVEAffectedWorkload describes a workload (cluster/namespace/kind/name +
+// the image tag) impacted by a hot CVE. Carried inline on
+// HotCVEOnFinishedMessage so the UNS notification dispatcher can render
+// per-workload context (cluster, namespace, image, ...) into the Slack/Teams
+// alert body without an extra postgres or dashboard round-trip.
+type HotCVEAffectedWorkload struct {
+	Cluster      string `json:"cluster,omitempty" bson:"cluster,omitempty"`
+	Namespace    string `json:"namespace,omitempty" bson:"namespace,omitempty"`
+	WorkloadKind string `json:"workloadKind,omitempty" bson:"workloadKind,omitempty"`
+	WorkloadName string `json:"workloadName,omitempty" bson:"workloadName,omitempty"`
+	ImageTag     string `json:"imageTag,omitempty" bson:"imageTag,omitempty"`
+}
+
 // HotCVEOnFinishedMessage is the Pulsar message published for UNS after hot CVE processing.
+//
+// Title, References and AffectedWorkloads are all `omitempty` so existing
+// publishers that haven't been upgraded continue to produce valid messages
+// (UNS treats absent fields as the zero value).
+//   - Title is sourced from HotCVE.Title (the admin-curated headline).
+//   - References mirror HotCVE.References (admin-curated authoritative URLs:
+//     NVD, vendor advisory, etc.). UNS uses References[0] as the CVELink that
+//     the Slack template renders as a clickable hyperlink under the CVE id.
+//     Hardcoding NVD on the consumer side would override the admin's curated
+//     references — they belong to the publisher, not the consumer.
+//   - AffectedWorkloads enumerates the workloads in *this customer's* tenant
+//     that match the hot CVE — UNS uses them both for rendering context and
+//     for filtering against per-workflow scope (cluster/namespace).
 type HotCVEOnFinishedMessage struct {
-	CustomerGUID string `json:"customerGUID"`
-	CVEID        string `json:"cveId"`
-	Severity     string `json:"severity"`
+	CustomerGUID      string                   `json:"customerGUID"`
+	CVEID             string                   `json:"cveId"`
+	Severity          string                   `json:"severity"`
+	Title             string                   `json:"title,omitempty"`
+	References        []string                 `json:"references,omitempty"`
+	AffectedWorkloads []HotCVEAffectedWorkload `json:"affectedWorkloads,omitempty"`
 }
 
 // hotCVEValidSeverities is the allow-list of severity values the hot-CVE

--- a/armotypes/hot_cve_test.go
+++ b/armotypes/hot_cve_test.go
@@ -216,3 +216,68 @@ func TestHotCVE_Validate(t *testing.T) {
 		})
 	}
 }
+
+// TestHotCVEOnFinishedMessage_RoundTrip verifies a message with all current
+// fields (including the SUB-7201 follow-up additions: Title, References,
+// AffectedWorkloads) serializes and deserializes losslessly. The UNS
+// dispatcher reads References[0] for CVELink and AffectedWorkloads for
+// per-workload Slack/Teams context — any silent JSON tag rename here
+// breaks the production hot-CVE alert rendering.
+func TestHotCVEOnFinishedMessage_RoundTrip(t *testing.T) {
+	original := HotCVEOnFinishedMessage{
+		CustomerGUID: "tenant-1",
+		CVEID:        "CVE-2024-9999",
+		Severity:     "Critical",
+		Title:        "Demo hot CVE",
+		References: []string{
+			"https://nvd.nist.gov/vuln/detail/CVE-2024-9999",
+			"https://example.com/advisory",
+		},
+		AffectedWorkloads: []HotCVEAffectedWorkload{
+			{Cluster: "prod-eu", Namespace: "checkout", WorkloadKind: "Deployment", WorkloadName: "api", ImageTag: "registry.example/app:v1"},
+			{Cluster: "prod-us", Namespace: "checkout", WorkloadKind: "Deployment", WorkloadName: "api", ImageTag: "registry.example/app:v1"},
+		},
+	}
+	b, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var got HotCVEOnFinishedMessage
+	require.NoError(t, json.Unmarshal(b, &got))
+	assert.Equal(t, original, got)
+}
+
+// TestHotCVEOnFinishedMessage_BackwardCompatible_DecodesOldPayload guards
+// the contract that a message produced by an older publisher (before Title /
+// References / AffectedWorkloads were added) still decodes correctly.
+// Otherwise rolling out the new struct breaks readers of in-flight messages
+// from un-upgraded publishers.
+func TestHotCVEOnFinishedMessage_BackwardCompatible_DecodesOldPayload(t *testing.T) {
+	old := []byte(`{"customerGUID":"tenant-1","cveId":"CVE-2024-9999","severity":"Critical"}`)
+	var got HotCVEOnFinishedMessage
+	require.NoError(t, json.Unmarshal(old, &got))
+	assert.Equal(t, "tenant-1", got.CustomerGUID)
+	assert.Equal(t, "CVE-2024-9999", got.CVEID)
+	assert.Equal(t, "Critical", got.Severity)
+	assert.Empty(t, got.Title)
+	assert.Empty(t, got.References)
+	assert.Empty(t, got.AffectedWorkloads)
+}
+
+// TestHotCVEOnFinishedMessage_OmitemptyOnAddedFields guards the JSON tags:
+// the three additions are `omitempty` so a publisher that doesn't populate
+// them produces a message indistinguishable from the pre-enrichment shape.
+// Drops in `omitempty` here would force every consumer to handle
+// `"title":""` / `"references":null` / `"affectedWorkloads":null`.
+func TestHotCVEOnFinishedMessage_OmitemptyOnAddedFields(t *testing.T) {
+	minimal := HotCVEOnFinishedMessage{
+		CustomerGUID: "tenant-1",
+		CVEID:        "CVE-2024-9999",
+		Severity:     "Critical",
+	}
+	b, err := json.Marshal(minimal)
+	require.NoError(t, err)
+	body := string(b)
+	assert.NotContains(t, body, `"title"`)
+	assert.NotContains(t, body, `"references"`)
+	assert.NotContains(t, body, `"affectedWorkloads"`)
+}


### PR DESCRIPTION
## Summary

Adds three optional fields to `HotCVEOnFinishedMessage` so the UNS notification dispatcher can render a complete hot-CVE Slack/Teams alert and correctly filter against per-workflow scope:

- **`Title`** — admin-curated headline (mirrors `HotCVE.Title`).
- **`References []string`** — admin-curated authoritative URLs (NVD, vendor advisory, …). UNS uses `References[0]` as the `CVELink` the Slack template renders. Sourcing from the admin (`HotCVE.References`) instead of hardcoding NVD on the consumer side preserves curation intent across CVE sources.
- **`AffectedWorkloads []HotCVEAffectedWorkload`** — per-customer workload context (cluster/namespace/kind/name + image tag). UNS uses these for both rendering and per-workflow scope filtering (cluster/namespace match) so a workflow scoped to one cluster doesn't receive alerts about other clusters.

All three are `omitempty` for backward compatibility — pre-upgrade publishers continue to produce valid messages; new consumers treat absent fields as the zero value.

## Background

PR #634 originally proposed `Title` + `AffectedWorkloads` and was closed on the assumption that UNS would use the existing vuln pipeline's `isHotCVE` filter (no enrichment needed). Production proved that pipeline silently drops hot CVEs (SUB-7201) — the cached-aggregator path filters by workflow scope fields the hot-CVE flow has no source for. UNS PR #407 (merged) bypassed the cached aggregator; this PR carries the data the bypass needs to render a useful alert and to honour workflow scope.

This PR is a fresh take (not a re-open of #634) because it also adds `References` and includes an updated rationale.

## Cross-repo PR chain

This is PR 1 of 3:
1. **`armoapi-go`** (this PR) — add the fields.
2. **`event-ingester-service`** — drop the local duplicate `HotCVEOnFinishedMessage` struct, use `armotypes.HotCVEOnFinishedMessage`, populate `Title`/`References`/`AffectedWorkloads` from the source `HotCVE` + per-customer scan IDs.
3. **`users-notification-service`** — bump pin, set `CVELink = msg.References[0]`, honour `condition.Parameters.Severities` and `workflow.Scope` (cluster/namespace) when matching workflows + filtering `AffectedWorkloads`.

## Test plan

- [x] `go test ./armotypes/ -run HotCVE` — all green
- [x] `go build ./...` — clean
- [x] New tests:
  - `TestHotCVEOnFinishedMessage_RoundTrip` — full struct survives marshal/unmarshal
  - `TestHotCVEOnFinishedMessage_BackwardCompatible_DecodesOldPayload` — pre-enrichment publishers still parse
  - `TestHotCVEOnFinishedMessage_OmitemptyOnAddedFields` — minimal message has no `title`/`references`/`affectedWorkloads` keys
- [ ] After merge: tag a release; consuming repos (event-ingester-service, users-notification-service) bump their pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced CVE notifications with additional context including titles, references, and affected workload details.

* **Improvements**
  * Backward-compatible message format ensuring compatibility with existing systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->