### PR TITLE
add Zone and InstanceType cloud metadata attribute constants

### DIFF
--- a/identifiers/designators.go
+++ b/identifiers/designators.go
@@ -114,6 +114,8 @@ const (
 	AttributeVolumeScanId            = "volumeScanId"
 	AttributeVolumeId                = "volumeId"
 	AttributeInstanceId              = "instanceId"
+	AttributeInstanceType            = "instanceType"
+	AttributeZone                    = "zone"
 	AttributeHostType                = "hostType"
 	AttributeInstanceHash            = "instanceHash"
 	AttributeInstanceScanId          = "instanceScanId"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for instance type and zone attributes in resource designators, enabling more granular resource identification and categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->