### PR TITLE
feat: enhance ClusterInfo with additional optional fields

### DIFF
--- a/armotypes/clusters.go
+++ b/armotypes/clusters.go
@@ -4,9 +4,13 @@ import "time"
 
 type ClusterInfo struct {
 	Cluster          string       `json:"cluster"`
+	ClusterUID       string       `json:"clusterUID,omitempty"`
 	NodeCount        int          `json:"nodeCount"`
 	CPUSum           int          `json:"cpuSum"`
 	CloudProvider    string       `json:"cloudProvider"`
+	CloudRegion      string       `json:"cloudRegion,omitempty"`
+	CloudAccountID   string       `json:"cloudAccountID,omitempty"`
+	ResourceGroup    *string      `json:"resourceGroup,omitempty"`
 	HelmVersion      string       `json:"helmVersion"`
 	ClusterVersion   string       `json:"clusterVersion"`
 	LastReportTime   *time.Time   `json:"lastReportTime,omitempty"`

--- a/armotypes/clusters.go
+++ b/armotypes/clusters.go
@@ -10,7 +10,7 @@ type ClusterInfo struct {
 	CloudProvider    string       `json:"cloudProvider"`
 	CloudRegion      string       `json:"cloudRegion,omitempty"`
 	CloudAccountID   string       `json:"cloudAccountID,omitempty"`
-	ResourceGroup    *string      `json:"resourceGroup,omitempty"`
+	ResourceGroup    string       `json:"resourceGroup,omitempty"`
 	HelmVersion      string       `json:"helmVersion"`
 	ClusterVersion   string       `json:"clusterVersion"`
 	LastReportTime   *time.Time   `json:"lastReportTime,omitempty"`


### PR DESCRIPTION
Adds optional fields ClusterUID, CloudRegion, CloudAccountID, and ResourceGroup to the ClusterInfo struct for improved cloud metadata representation. These fields are marked as omitempty to maintain backward compatibility with existing data structures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cluster information now includes optional metadata fields for enhanced identification and organization. New fields include cluster UID, cloud region, cloud account ID, and resource group information to support better resource management and tracking across multi-cloud environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->