### PR TITLE
feat(armotypes): add ProfileDataRequired contract for profile-data projection

### DIFF
--- a/armotypes/runtimerule.go
+++ b/armotypes/runtimerule.go
@@ -70,7 +70,8 @@ type RuntimeRule struct {
 	Name                    string            `json:"name" yaml:"name" bson:"name"`
 	Description             string            `json:"description" yaml:"description" bson:"description"`
 	Expressions             RuleExpressions   `json:"expressions" yaml:"expressions" bson:"expressions"`
-	ProfileDependency       ProfileDependency `json:"profileDependency" yaml:"profileDependency" bson:"profileDependency"`
+	ProfileDependency       ProfileDependency      `json:"profileDependency" yaml:"profileDependency" bson:"profileDependency"`
+	ProfileDataRequired    *ProfileDataRequired   `json:"profileDataRequired,omitempty" yaml:"profileDataRequired,omitempty" bson:"profileDataRequired,omitempty"`
 	Severity                int               `json:"severity" bson:"severity"`
 	SeverityString          string            `json:"severityString" bson:"severityString"`
 	SupportPolicy           bool              `json:"supportPolicy" yaml:"supportPolicy" bson:"supportPolicy"`

--- a/armotypes/runtimerule.go
+++ b/armotypes/runtimerule.go
@@ -222,3 +222,77 @@ func (f *ProfileDataField) UnmarshalBSONValue(t bsontype.Type, data []byte) erro
 		return fmt.Errorf("profileDataField: bson type must be string or array, got %v", t)
 	}
 }
+
+// ProfileDataRequired declares which subsets of the container profile this rule
+// needs at runtime. Each surface field is optional; absence means "this rule
+// does not query this surface".
+type ProfileDataRequired struct {
+	Opens            *ProfileDataField `json:"opens,omitempty"            yaml:"opens,omitempty"            bson:"opens,omitempty"`
+	Execs            *ProfileDataField `json:"execs,omitempty"            yaml:"execs,omitempty"            bson:"execs,omitempty"`
+	Capabilities     *ProfileDataField `json:"capabilities,omitempty"     yaml:"capabilities,omitempty"     bson:"capabilities,omitempty"`
+	Syscalls         *ProfileDataField `json:"syscalls,omitempty"         yaml:"syscalls,omitempty"         bson:"syscalls,omitempty"`
+	Endpoints        *ProfileDataField `json:"endpoints,omitempty"        yaml:"endpoints,omitempty"        bson:"endpoints,omitempty"`
+	EgressDomains    *ProfileDataField `json:"egressDomains,omitempty"    yaml:"egressDomains,omitempty"    bson:"egressDomains,omitempty"`
+	EgressAddresses  *ProfileDataField `json:"egressAddresses,omitempty"  yaml:"egressAddresses,omitempty"  bson:"egressAddresses,omitempty"`
+	IngressDomains   *ProfileDataField `json:"ingressDomains,omitempty"   yaml:"ingressDomains,omitempty"   bson:"ingressDomains,omitempty"`
+	IngressAddresses *ProfileDataField `json:"ingressAddresses,omitempty" yaml:"ingressAddresses,omitempty" bson:"ingressAddresses,omitempty"`
+}
+
+// IsEmpty reports whether every surface field is nil. Used to detect
+// "profileDataRequired: {}" — structurally valid YAML that declares nothing.
+func (p *ProfileDataRequired) IsEmpty() bool {
+	if p == nil {
+		return true
+	}
+	return p.Opens == nil && p.Execs == nil && p.Capabilities == nil &&
+		p.Syscalls == nil && p.Endpoints == nil && p.EgressDomains == nil &&
+		p.EgressAddresses == nil && p.IngressDomains == nil && p.IngressAddresses == nil
+}
+
+// Validate reports schema violations. Single source of truth for both the
+// rulelibrary lint and node-agent's load-time check.
+func (p *ProfileDataRequired) Validate() error {
+	if p == nil {
+		return nil
+	}
+	for name, field := range map[string]*ProfileDataField{
+		"opens":            p.Opens,
+		"execs":            p.Execs,
+		"capabilities":     p.Capabilities,
+		"syscalls":         p.Syscalls,
+		"endpoints":        p.Endpoints,
+		"egressDomains":    p.EgressDomains,
+		"egressAddresses":  p.EgressAddresses,
+		"ingressDomains":   p.IngressDomains,
+		"ingressAddresses": p.IngressAddresses,
+	} {
+		if field == nil {
+			continue
+		}
+		if err := validateProfileDataField(name, field); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateProfileDataField(name string, f *ProfileDataField) error {
+	if f.All && len(f.Patterns) > 0 {
+		return fmt.Errorf("profileDataRequired.%s: cannot have both 'all' and pattern list", name)
+	}
+	if !f.All && len(f.Patterns) == 0 {
+		return fmt.Errorf("profileDataRequired.%s: must declare 'all' or at least one pattern", name)
+	}
+	for i, pat := range f.Patterns {
+		filled := 0
+		for _, v := range []string{pat.Exact, pat.Prefix, pat.Suffix, pat.Contains} {
+			if v != "" {
+				filled++
+			}
+		}
+		if filled != 1 {
+			return fmt.Errorf("profileDataRequired.%s[%d]: exactly one of {exact, prefix, suffix, contains} must be set, got %d", name, i, filled)
+		}
+	}
+	return nil
+}

--- a/armotypes/runtimerule.go
+++ b/armotypes/runtimerule.go
@@ -1,6 +1,7 @@
 package armotypes
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -172,6 +173,9 @@ func (f ProfileDataField) MarshalJSON() ([]byte, error) {
 }
 
 func (f *ProfileDataField) UnmarshalJSON(data []byte) error {
+	if string(bytes.TrimSpace(data)) == "null" {
+		return fmt.Errorf("profileDataField: must be string %q or list, got null", profileDataFieldAllSentinel)
+	}
 	var s string
 	if err := json.Unmarshal(data, &s); err == nil {
 		if s != profileDataFieldAllSentinel {

--- a/armotypes/runtimerule.go
+++ b/armotypes/runtimerule.go
@@ -86,6 +86,15 @@ type RuleExpression struct {
 	Expression string    `json:"expression" yaml:"expression" bson:"expression"`
 }
 
+// ProfileDataPattern declares a single match pattern for a profile-data
+// surface. Exactly one of the four fields must be non-empty.
+type ProfileDataPattern struct {
+	Exact    string `json:"exact,omitempty"    yaml:"exact,omitempty"    bson:"exact,omitempty"`
+	Prefix   string `json:"prefix,omitempty"   yaml:"prefix,omitempty"   bson:"prefix,omitempty"`
+	Suffix   string `json:"suffix,omitempty"   yaml:"suffix,omitempty"   bson:"suffix,omitempty"`
+	Contains string `json:"contains,omitempty" yaml:"contains,omitempty" bson:"contains,omitempty"`
+}
+
 type EventType string
 
 const (

--- a/armotypes/runtimerule.go
+++ b/armotypes/runtimerule.go
@@ -1,5 +1,14 @@
 package armotypes
 
+import (
+	"encoding/json"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/bsontype"
+	"gopkg.in/yaml.v3"
+)
+
 // copied from kubescape/node-agent/pkg/ruleengine/v1/rule.go
 const (
 	RuleSeverityNone        = 0
@@ -109,3 +118,107 @@ const (
 	EventTypeSSH          EventType = "ssh"
 	EventTypeHTTP         EventType = "http"
 )
+
+// ProfileDataField is a tagged union: either All == true (the rule needs every
+// entry on this surface) or Patterns is non-empty (the rule needs entries
+// matching any pattern). The YAML/JSON form is either the literal string "all"
+// or a list of ProfileDataPattern objects.
+type ProfileDataField struct {
+	All      bool
+	Patterns []ProfileDataPattern
+}
+
+const profileDataFieldAllSentinel = "all"
+
+func (f ProfileDataField) MarshalYAML() (any, error) {
+	if f.All {
+		return profileDataFieldAllSentinel, nil
+	}
+	return f.Patterns, nil
+}
+
+func (f *ProfileDataField) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		var s string
+		if err := node.Decode(&s); err != nil {
+			return fmt.Errorf("profileDataField: scalar must be string %q: %w", profileDataFieldAllSentinel, err)
+		}
+		if s != profileDataFieldAllSentinel {
+			return fmt.Errorf("profileDataField: scalar value must be %q, got %q", profileDataFieldAllSentinel, s)
+		}
+		f.All = true
+		f.Patterns = nil
+		return nil
+	case yaml.SequenceNode:
+		var patterns []ProfileDataPattern
+		if err := node.Decode(&patterns); err != nil {
+			return err
+		}
+		f.All = false
+		f.Patterns = patterns
+		return nil
+	default:
+		return fmt.Errorf("profileDataField: must be string %q or list, got %v", profileDataFieldAllSentinel, node.Kind)
+	}
+}
+
+func (f ProfileDataField) MarshalJSON() ([]byte, error) {
+	if f.All {
+		return json.Marshal(profileDataFieldAllSentinel)
+	}
+	return json.Marshal(f.Patterns)
+}
+
+func (f *ProfileDataField) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		if s != profileDataFieldAllSentinel {
+			return fmt.Errorf("profileDataField: scalar must be %q, got %q", profileDataFieldAllSentinel, s)
+		}
+		f.All = true
+		f.Patterns = nil
+		return nil
+	}
+	var patterns []ProfileDataPattern
+	if err := json.Unmarshal(data, &patterns); err != nil {
+		return fmt.Errorf("profileDataField: must be string %q or list: %w", profileDataFieldAllSentinel, err)
+	}
+	f.All = false
+	f.Patterns = patterns
+	return nil
+}
+
+func (f ProfileDataField) MarshalBSONValue() (bsontype.Type, []byte, error) {
+	if f.All {
+		return bson.MarshalValue(profileDataFieldAllSentinel)
+	}
+	return bson.MarshalValue(f.Patterns)
+}
+
+func (f *ProfileDataField) UnmarshalBSONValue(t bsontype.Type, data []byte) error {
+	raw := bson.RawValue{Type: t, Value: data}
+	switch t {
+	case bsontype.String:
+		s, ok := raw.StringValueOK()
+		if !ok {
+			return fmt.Errorf("profileDataField: bson string decode failed")
+		}
+		if s != profileDataFieldAllSentinel {
+			return fmt.Errorf("profileDataField: bson scalar must be %q, got %q", profileDataFieldAllSentinel, s)
+		}
+		f.All = true
+		f.Patterns = nil
+		return nil
+	case bsontype.Array:
+		var patterns []ProfileDataPattern
+		if err := raw.Unmarshal(&patterns); err != nil {
+			return err
+		}
+		f.All = false
+		f.Patterns = patterns
+		return nil
+	default:
+		return fmt.Errorf("profileDataField: bson type must be string or array, got %v", t)
+	}
+}

--- a/armotypes/runtimerule_profile_data_test.go
+++ b/armotypes/runtimerule_profile_data_test.go
@@ -1,0 +1,47 @@
+package armotypes
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestProfileDataPattern_YAMLRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		want ProfileDataPattern
+	}{
+		{"exact", `exact: "/var/run/docker.sock"`, ProfileDataPattern{Exact: "/var/run/docker.sock"}},
+		{"prefix", `prefix: "/etc/cron.d/"`, ProfileDataPattern{Prefix: "/etc/cron.d/"}},
+		{"suffix", `suffix: "/authorized_keys"`, ProfileDataPattern{Suffix: "/authorized_keys"}},
+		{"contains", `contains: "authorized_keys"`, ProfileDataPattern{Contains: "authorized_keys"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var got ProfileDataPattern
+			require.NoError(t, yaml.Unmarshal([]byte(c.yaml), &got))
+			assert.Equal(t, c.want, got)
+
+			out, err := yaml.Marshal(got)
+			require.NoError(t, err)
+			var roundTripped ProfileDataPattern
+			require.NoError(t, yaml.Unmarshal(out, &roundTripped))
+			assert.Equal(t, c.want, roundTripped)
+		})
+	}
+}
+
+func TestProfileDataPattern_JSONRoundTrip(t *testing.T) {
+	p := ProfileDataPattern{Prefix: "/etc/cron.d/"}
+	b, err := json.Marshal(p)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"prefix":"/etc/cron.d/"}`, string(b))
+
+	var got ProfileDataPattern
+	require.NoError(t, json.Unmarshal(b, &got))
+	assert.Equal(t, p, got)
+}

--- a/armotypes/runtimerule_profile_data_test.go
+++ b/armotypes/runtimerule_profile_data_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
 	"gopkg.in/yaml.v3"
 )
 
@@ -44,4 +45,75 @@ func TestProfileDataPattern_JSONRoundTrip(t *testing.T) {
 	var got ProfileDataPattern
 	require.NoError(t, json.Unmarshal(b, &got))
 	assert.Equal(t, p, got)
+}
+
+func TestProfileDataField_UnmarshalYAML_All(t *testing.T) {
+	var f ProfileDataField
+	require.NoError(t, yaml.Unmarshal([]byte(`all`), &f))
+	assert.True(t, f.All)
+	assert.Empty(t, f.Patterns)
+}
+
+func TestProfileDataField_UnmarshalYAML_Patterns(t *testing.T) {
+	var f ProfileDataField
+	require.NoError(t, yaml.Unmarshal([]byte(`
+- exact: "/var/run/docker.sock"
+- prefix: "/etc/cron.d/"
+`), &f))
+	assert.False(t, f.All)
+	require.Len(t, f.Patterns, 2)
+	assert.Equal(t, "/var/run/docker.sock", f.Patterns[0].Exact)
+	assert.Equal(t, "/etc/cron.d/", f.Patterns[1].Prefix)
+}
+
+func TestProfileDataField_UnmarshalYAML_RejectsUnknown(t *testing.T) {
+	var f ProfileDataField
+	err := yaml.Unmarshal([]byte(`42`), &f)
+	assert.Error(t, err)
+
+	err = yaml.Unmarshal([]byte(`"some"`), &f)
+	assert.Error(t, err)
+}
+
+func TestProfileDataField_MarshalYAML_All(t *testing.T) {
+	f := ProfileDataField{All: true}
+	out, err := yaml.Marshal(f)
+	require.NoError(t, err)
+	assert.Equal(t, "all\n", string(out))
+}
+
+func TestProfileDataField_MarshalYAML_Patterns(t *testing.T) {
+	f := ProfileDataField{Patterns: []ProfileDataPattern{{Exact: "/a"}}}
+	out, err := yaml.Marshal(f)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), `exact: /a`)
+}
+
+func TestProfileDataField_JSONRoundTrip(t *testing.T) {
+	for _, f := range []ProfileDataField{
+		{All: true},
+		{Patterns: []ProfileDataPattern{{Prefix: "/x"}, {Suffix: "/y"}}},
+	} {
+		b, err := json.Marshal(f)
+		require.NoError(t, err)
+		var got ProfileDataField
+		require.NoError(t, json.Unmarshal(b, &got))
+		assert.Equal(t, f, got)
+	}
+}
+
+func TestProfileDataField_BSONRoundTrip(t *testing.T) {
+	type wrapper struct {
+		Field ProfileDataField `bson:"field"`
+	}
+	for _, f := range []ProfileDataField{
+		{All: true},
+		{Patterns: []ProfileDataPattern{{Prefix: "/x"}, {Suffix: "/y"}}},
+	} {
+		b, err := bson.Marshal(wrapper{Field: f})
+		require.NoError(t, err)
+		var got wrapper
+		require.NoError(t, bson.Unmarshal(b, &got))
+		assert.Equal(t, f, got.Field)
+	}
 }

--- a/armotypes/runtimerule_profile_data_test.go
+++ b/armotypes/runtimerule_profile_data_test.go
@@ -160,6 +160,8 @@ func TestProfileDataRequired_Validate_AllAndPatterns(t *testing.T) {
 }
 
 func TestProfileDataRequired_IsEmpty(t *testing.T) {
+	var nilP *ProfileDataRequired
+	assert.True(t, nilP.IsEmpty())
 	assert.True(t, (&ProfileDataRequired{}).IsEmpty())
 	assert.False(t, (&ProfileDataRequired{Opens: &ProfileDataField{All: true}}).IsEmpty())
 }

--- a/armotypes/runtimerule_profile_data_test.go
+++ b/armotypes/runtimerule_profile_data_test.go
@@ -165,3 +165,38 @@ func TestProfileDataRequired_IsEmpty(t *testing.T) {
 	assert.True(t, (&ProfileDataRequired{}).IsEmpty())
 	assert.False(t, (&ProfileDataRequired{Opens: &ProfileDataField{All: true}}).IsEmpty())
 }
+
+func TestRuntimeRule_ProfileDataRequired_YAML(t *testing.T) {
+	src := `
+id: R0001
+profileDependency: 0
+profileDataRequired:
+  opens:
+    - exact: "/var/run/docker.sock"
+  execs: all
+`
+	var rule RuntimeRule
+	require.NoError(t, yaml.Unmarshal([]byte(src), &rule))
+	require.NotNil(t, rule.ProfileDataRequired)
+	require.NotNil(t, rule.ProfileDataRequired.Opens)
+	assert.Equal(t, "/var/run/docker.sock", rule.ProfileDataRequired.Opens.Patterns[0].Exact)
+	require.NotNil(t, rule.ProfileDataRequired.Execs)
+	assert.True(t, rule.ProfileDataRequired.Execs.All)
+
+	out, err := yaml.Marshal(rule)
+	require.NoError(t, err)
+	var roundTripped RuntimeRule
+	require.NoError(t, yaml.Unmarshal(out, &roundTripped))
+	assert.Equal(t, rule.ProfileDataRequired, roundTripped.ProfileDataRequired)
+}
+
+func TestRuntimeRule_ProfileDataRequired_OmittedWhenNil(t *testing.T) {
+	rule := RuntimeRule{ID: "R0002", ProfileDependency: NotRequired}
+	out, err := yaml.Marshal(rule)
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), "profileDataRequired")
+
+	b, err := json.Marshal(rule)
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), "profileDataRequired")
+}

--- a/armotypes/runtimerule_profile_data_test.go
+++ b/armotypes/runtimerule_profile_data_test.go
@@ -117,3 +117,49 @@ func TestProfileDataField_BSONRoundTrip(t *testing.T) {
 		assert.Equal(t, f, got.Field)
 	}
 }
+
+func TestProfileDataRequired_Validate_Valid(t *testing.T) {
+	p := &ProfileDataRequired{
+		Opens: &ProfileDataField{Patterns: []ProfileDataPattern{{Exact: "/a"}}},
+		Execs: &ProfileDataField{All: true},
+	}
+	assert.NoError(t, p.Validate())
+}
+
+func TestProfileDataRequired_Validate_FieldEmpty(t *testing.T) {
+	p := &ProfileDataRequired{Opens: &ProfileDataField{}}
+	err := p.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "opens")
+}
+
+func TestProfileDataRequired_Validate_PatternMultiKey(t *testing.T) {
+	p := &ProfileDataRequired{
+		Opens: &ProfileDataField{Patterns: []ProfileDataPattern{{Exact: "a", Prefix: "b"}}},
+	}
+	err := p.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly one")
+}
+
+func TestProfileDataRequired_Validate_PatternEmpty(t *testing.T) {
+	p := &ProfileDataRequired{
+		Opens: &ProfileDataField{Patterns: []ProfileDataPattern{{}}},
+	}
+	err := p.Validate()
+	require.Error(t, err)
+}
+
+func TestProfileDataRequired_Validate_AllAndPatterns(t *testing.T) {
+	p := &ProfileDataRequired{
+		Opens: &ProfileDataField{All: true, Patterns: []ProfileDataPattern{{Exact: "a"}}},
+	}
+	err := p.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "all")
+}
+
+func TestProfileDataRequired_IsEmpty(t *testing.T) {
+	assert.True(t, (&ProfileDataRequired{}).IsEmpty())
+	assert.False(t, (&ProfileDataRequired{Opens: &ProfileDataField{All: true}}).IsEmpty())
+}

--- a/armotypes/runtimerule_profile_data_test.go
+++ b/armotypes/runtimerule_profile_data_test.go
@@ -89,6 +89,12 @@ func TestProfileDataField_MarshalYAML_Patterns(t *testing.T) {
 	assert.Contains(t, string(out), `exact: /a`)
 }
 
+func TestProfileDataField_UnmarshalJSON_RejectsNull(t *testing.T) {
+	var f ProfileDataField
+	err := json.Unmarshal([]byte(`null`), &f)
+	assert.Error(t, err)
+}
+
 func TestProfileDataField_JSONRoundTrip(t *testing.T) {
 	for _, f := range []ProfileDataField{
 		{All: true},


### PR DESCRIPTION
## Summary

- Adds `ProfileDataPattern`, `ProfileDataField` (tagged-union), and `ProfileDataRequired` types to `armotypes/runtimerule.go` — the schema contract for NAUT-1295 rule-aware profile projection.
- Wires `ProfileDataRequired *ProfileDataRequired` (omitempty) into `RuntimeRule` alongside `ProfileDependency`.
- `ProfileDataField` supports custom YAML/JSON/BSON codecs: marshals as the string `"all"` or as a list of pattern objects.
- `ProfileDataRequired.Validate()` and `IsEmpty()` are the single source of truth used by the rulelibrary lint (Phase 2) and node-agent load-time check.

## Test plan

- [x] `TestProfileDataPattern_YAMLRoundTrip` — all four match types
- [x] `TestProfileDataPattern_JSONRoundTrip`
- [x] `TestProfileDataField_UnmarshalYAML_All/Patterns/RejectsUnknown`
- [x] `TestProfileDataField_MarshalYAML_All/Patterns`
- [x] `TestProfileDataField_JSONRoundTrip`
- [x] `TestProfileDataField_BSONRoundTrip`
- [x] `TestProfileDataRequired_Validate_Valid/FieldEmpty/PatternMultiKey/PatternEmpty/AllAndPatterns`
- [x] `TestProfileDataRequired_IsEmpty` (including nil-receiver)
- [x] `TestRuntimeRule_ProfileDataRequired_YAML` — round-trip through RuntimeRule
- [x] `TestRuntimeRule_ProfileDataRequired_OmittedWhenNil`

Related: NAUT-1300 / NAUT-1295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added profile data requirement configuration to runtime rules, enabling per-surface declarations of needed profile data through flexible matching options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->