### PR TITLE
docs: onboard armoapi-go to docs-system

### DIFF
--- a/.github/workflows/codeowners-gen.yml
+++ b/.github/workflows/codeowners-gen.yml
@@ -1,0 +1,30 @@
+name: codeowners-gen
+
+# Thin wrapper — actual logic lives in
+# armosec-ai-shared-rules/.github/workflows/codeowners-gen-reusable.yml.
+# Updates land automatically on the next CI run via `@main`.
+#
+# `branches: [main, master]` covers both default-branch conventions across
+# the org. GitHub's `branches:` filter does NOT support `${{ }}` expressions
+# (parsed at workflow-load time), so a static dual-list is the cleanest
+# portable fix — no repo in the org has both branches simultaneously.
+
+concurrency:
+  group: codeowners-gen
+  cancel-in-progress: false
+
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - "AGENTS.md"
+      - "docs/**"
+  workflow_dispatch:
+
+jobs:
+  regen:
+    name: codeowners-gen
+    permissions:
+      contents: write
+    uses: armosec/armosec-ai-shared-rules/.github/workflows/codeowners-gen-reusable.yml@main
+    secrets: inherit

--- a/.github/workflows/dispatch-on-service-md-change.yml
+++ b/.github/workflows/dispatch-on-service-md-change.yml
@@ -1,0 +1,25 @@
+name: dispatch-on-service-md-change
+
+# Thin wrapper — actual logic lives in
+# armosec-ai-shared-rules/.github/workflows/dispatch-on-service-md-change-reusable.yml.
+# Triggers the docs-system catalog sync via service-md-changed events.
+# Updates land automatically on the next CI run via `@main`.
+#
+# `branches: [main, master]` covers both default-branch conventions across
+# the org. GitHub's `branches:` filter does NOT support `${{ }}` expressions
+# (parsed at workflow-load time), so a static dual-list is the cleanest
+# portable fix — no repo in the org has both branches simultaneously.
+
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - "docs/services/**/service.md"
+
+jobs:
+  fire:
+    name: dispatch-on-service-md-change
+    permissions:
+      contents: read
+    uses: armosec/armosec-ai-shared-rules/.github/workflows/dispatch-on-service-md-change-reusable.yml@main
+    secrets: inherit

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -1,0 +1,20 @@
+name: docs-lint
+
+# Thin wrapper — actual logic lives in
+# armosec-ai-shared-rules/.github/workflows/docs-lint-reusable.yml.
+# Updates land automatically on the next CI run via `@main`.
+
+on:
+  pull_request:
+    paths:
+      - "AGENTS.md"
+      - "docs/**"
+      - ".github/workflows/docs-lint.yml"
+
+jobs:
+  lint:
+    name: docs-lint
+    uses: armosec/armosec-ai-shared-rules/.github/workflows/docs-lint-reusable.yml@main
+    secrets: inherit
+    with:
+      extra-flags: "--no-services"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+---
+type: agents
+status: approved
+owner: "@armosec/backend"
+scope: repo
+---
+# AGENTS.md — armoapi-go
+
+> AI agents: this file is your high-signal entry point. Engineers: see [README](README.md).
+
+## What this repo is
+
+TODO: one-line description of this repo
+
+## Services produced by this repo
+
+(library — no services produced)
+
+## Where docs live
+
+- Repo-level (code structure, build, repo ADRs): `docs/repo/`
+- Service-level (runtime, runbooks, contracts): `docs/services/<service>/`
+- Cross-cutting features: `docs/features/`
+- Cross-repo projects: `shared-designs-and-docs/projects/`
+
+## Conventions
+
+TODO: list repo conventions worth highlighting for AI agents
+
+## When you change behavior
+
+Refresh the matching doc. Pivots become ADRs. Cross-repo work has a project doc in `shared-designs-and-docs`. See `armosec-ai-shared-rules/docs-system/when-to-document.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,11 @@ scope: repo
 ---
 # AGENTS.md — armoapi-go
 
-> AI agents: this file is your high-signal entry point. Engineers: see [README](README.md).
+> AI agents: this file is your high-signal entry point. Engineers: see [Architecture](docs/repo/architecture.md).
 
 ## What this repo is
 
-TODO: one-line description of this repo
+Canonical shared type library for the Armosec platform. Defines domain types, command structures, and data contracts consumed by all backend services, in-cluster agents, and the portal.
 
 ## Services produced by this repo
 
@@ -19,13 +19,37 @@ TODO: one-line description of this repo
 ## Where docs live
 
 - Repo-level (code structure, build, repo ADRs): `docs/repo/`
-- Service-level (runtime, runbooks, contracts): `docs/services/<service>/`
 - Cross-cutting features: `docs/features/`
 - Cross-repo projects: `shared-designs-and-docs/projects/`
 
+## Key packages
+
+| Package | Purpose |
+|---------|---------|
+| `apis` | Command dispatch, websocket scan commands, connector interfaces, pagination |
+| `armotypes` | Core domain types: clusters, configs, policies, incidents, risk factors, registries |
+| `armotypes/cdr` | Cloud Detection & Response alert types |
+| `identifiers` | Workload/resource designator system (WLID, SID, PortalDesignator) |
+| `containerscan` | Container vulnerability scan report interfaces and v1 implementation |
+| `notifications` | Alert channel configuration, collaboration integrations (Jira, Linear, Slack) |
+| `broadcastevents` | Platform analytics/audit event types |
+| `package_versions` | Multi-format package version parsing (semver, APK, deb, RPM, Maven, PEP440) |
+| `scanfailure` | Scan failure report types and reason codes |
+
+## Consumers
+
+event-ingester-service, cadashboardbe, config-service, kubevuln, kubescape, node-agent, notification-service, gateway, registry-scanner.
+
 ## Conventions
 
-TODO: list repo conventions worth highlighting for AI agents
+- All types use `json` struct tags for REST/Elasticsearch and `bson` tags for MongoDB serialization. Both must be maintained together.
+- Interfaces in `containerscan/` decouple consuming services from concrete implementations (v1). Do not add methods to interfaces without checking all consumers.
+- The `identifiers` package defines `PortalDesignator` — the universal resource-addressing type. Attribute constants (`AttributeCluster`, `AttributeNamespace`) must stay backward-compatible.
+- New types in `armotypes` must include a `PortalBase` embed for consistent metadata (GUID, name, attributes).
+- `package_versions.NewVersion()` / `NewVersionFromPkgType()` are the only approved entry points for version comparison. Do not use raw string comparison on versions.
+- No database connections or runtime dependencies — this is a pure type/utility library.
+- Releases are automated via `.github/workflows/release.yaml` on tag push (`v0.0.XXX`).
+- High-performance JSON paths use `gojay` marshalling; standard `encoding/json` for everything else.
 
 ## When you change behavior
 

--- a/README.md
+++ b/README.md
@@ -2,5 +2,35 @@
 
 # armoapi-go
 
+Canonical shared type library for the Armosec platform. Defines domain types, command structures, and data contracts consumed by all backend services, in-cluster agents, and the portal.
+
+## Packages
+
+| Package | Description |
+|---------|-------------|
+| `apis` | Command dispatch, websocket scan commands, connector interfaces |
+| `armotypes` | Core platform domain types (clusters, configs, policies, incidents, risks) |
+| `identifiers` | Workload/resource designator system (WLID, SID, PortalDesignator) |
+| `containerscan` | Container vulnerability scan report interfaces and implementations |
+| `notifications` | Alert channel and collaboration configuration types |
+| `broadcastevents` | Platform analytics/audit event types |
+| `package_versions` | Multi-format package version parsing and comparison |
+| `scanfailure` | Scan failure report types and reason codes |
+
+## Usage
+
+```go
+import "github.com/armosec/armoapi-go/armotypes"
+import "github.com/armosec/armoapi-go/apis"
+import "github.com/armosec/armoapi-go/identifiers"
+```
+
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [AGENTS.md](AGENTS.md) | AI agent entry point — repo purpose, conventions, key packages |
+| [Architecture](docs/repo/architecture.md) | Package structure, public API surface, versioning |
+
 ## License
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Farmosec%2Farmoapi-go.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Farmosec%2Farmoapi-go?ref=badge_large)

--- a/docs/repo/architecture.md
+++ b/docs/repo/architecture.md
@@ -1,0 +1,21 @@
+---
+type: architecture
+status: proposed
+owner: "@armosec/backend"
+scope: repo
+---
+<!-- docs-system: scaffold v1 -->
+
+# armoapi-go — Architecture
+
+## Code layout
+
+TODO
+
+## Build & test
+
+TODO
+
+## Conventions
+
+TODO

--- a/docs/repo/architecture.md
+++ b/docs/repo/architecture.md
@@ -26,14 +26,16 @@ armoapi-go/
 │   ├── networkpolicies.go   # NetworkPoliciesWorkload
 │   ├── registrytypes.go     # RegistryInfo, RegistryJobParams
 │   ├── cdr/                 # Cloud Detection & Response types
-│   │   └── types.go         # CdrAlert, CloudMetadata, CloudTrailEvent
-│   └── common/              # Shared sub-types (Identifiers)
+│   │   ├── cdr.go           # CdrAlert, CloudMetadata, CdrAlertBatch
+│   │   └── aws.go           # CloudTrailEvent, AWS-specific types
+│   └── common/              # Shared runtime sub-types (ProcessEntity, FileEntity)
 ├── identifiers/             # Resource designator system
 │   ├── designators.go       # PortalDesignator, DesignatorType, constants
 │   ├── armocontext.go       # ArmoContext helpers
 │   └── utils.go             # WLID/SID parsing utilities
 ├── containerscan/           # Vulnerability scan report contracts
-│   ├── commondatastructures.go  # Interfaces: ScanReport, VulnerabilityResult
+│   ├── interfaces.go            # Interfaces: ScanReport, VulnerabilityResult
+│   ├── commondatastructures.go  # CommonContainerVulnerabilityResult, scan structs
 │   ├── commonadapters.go        # Severity mapping, adapter logic
 │   ├── consts.go                # Severity levels, scan status constants
 │   └── v1/                      # Concrete implementation of interfaces

--- a/docs/repo/architecture.md
+++ b/docs/repo/architecture.md
@@ -1,6 +1,6 @@
 ---
 type: architecture
-status: proposed
+status: approved
 owner: "@armosec/backend"
 scope: repo
 ---
@@ -10,12 +10,88 @@ scope: repo
 
 ## Code layout
 
-TODO
+```
+armoapi-go/
+├── apis/                    # Command dispatch & websocket communication
+│   ├── datastructures.go    # Command, Commands, SessionChain, JobTracking
+│   ├── interfaces.go        # Connector, ImageScanCommand interfaces
+│   ├── websocket*.go        # WebSocket scan command types & methods
+│   ├── login*.go            # LoginObject, authentication data structures
+│   └── backendconnector*.go # Backend connector implementation & methods
+├── armotypes/               # Core platform domain types (~75 files)
+│   ├── portaltypes.go       # PortalBase, PortalCluster, InstallationData
+│   ├── configtypes.go       # CustomerConfig, Settings
+│   ├── exceptionpolicy.go   # VulnerabilityExceptionPolicy
+│   ├── attackchainstypes.go # AttackChain, SecurityRisk
+│   ├── networkpolicies.go   # NetworkPoliciesWorkload
+│   ├── registrytypes.go     # RegistryInfo, RegistryJobParams
+│   ├── cdr/                 # Cloud Detection & Response types
+│   │   └── types.go         # CdrAlert, CloudMetadata, CloudTrailEvent
+│   └── common/              # Shared sub-types (Identifiers)
+├── identifiers/             # Resource designator system
+│   ├── designators.go       # PortalDesignator, DesignatorType, constants
+│   ├── armocontext.go       # ArmoContext helpers
+│   └── utils.go             # WLID/SID parsing utilities
+├── containerscan/           # Vulnerability scan report contracts
+│   ├── commondatastructures.go  # Interfaces: ScanReport, VulnerabilityResult
+│   ├── commonadapters.go        # Severity mapping, adapter logic
+│   ├── consts.go                # Severity levels, scan status constants
+│   └── v1/                      # Concrete implementation of interfaces
+├── notifications/           # Alert & collaboration configuration
+│   ├── alertchannelapi.go   # AlertChannelAPI, AlertConfig
+│   ├── collaborationconfig.go # CollaborationConfig (Jira, Linear, etc.)
+│   └── runtimeincidents.go  # Runtime incident notification types
+├── broadcastevents/         # Platform event types for analytics pipeline
+│   ├── events.go            # EventBase, LoginEvent, HelmInstalledEvent
+│   └── factory.go           # Event factory/constructor helpers
+├── package_versions/        # Multi-format version comparison
+│   ├── version.go           # Version interface, NewVersion(), NewVersionFromPkgType()
+│   ├── semantic_version.go  # Semver implementation
+│   ├── apk_version.go       # Alpine APK version comparison
+│   ├── deb_version.go       # Debian version comparison
+│   ├── rpm_version.go       # RPM version comparison
+│   ├── maven_version.go     # Maven version comparison
+│   ├── pep440_version.go    # Python PEP440 version comparison
+│   └── golang_version.go    # Go module version comparison
+└── scanfailure/             # Scan failure reporting
+    └── types.go             # ScanFailureReport, reason codes, ReasonFriendlyText()
+```
 
 ## Build & test
 
-TODO
+**Build (library — no binary):**
+
+```bash
+go build ./...
+```
+
+**Test:**
+
+```bash
+go test ./...            # unit tests
+go test -cover ./...     # with coverage
+go test -race ./...      # race detection
+```
+
+No external dependencies needed for tests.
+
+**Release:**
+
+Tags follow `v0.0.XXX` pattern. Push a tag to trigger `.github/workflows/release.yaml`. Consumers pin versions via `go.mod`.
+
+## Versioning & compatibility
+
+- Module path: `github.com/armosec/armoapi-go`
+- All consumers import via Go modules. Breaking changes to exported types require coordinated updates across consumer services.
+- Interfaces (`containerscan.ScanReport`, `apis.Connector`) are stability contracts. Adding methods is a breaking change.
+- Struct fields with `json`/`bson` tags are serialization contracts. Renaming or removing tags breaks wire compatibility.
 
 ## Conventions
 
-TODO
+- **Struct tags**: Every exported struct field that crosses a service boundary must have both `json` and `bson` tags. The `json` tag is the wire format name.
+- **PortalBase embedding**: Domain entities stored in MongoDB embed `PortalBase` for GUID, name, cluster, and attribute metadata.
+- **Interface-based contracts**: `containerscan/` defines interfaces; `containerscan/v1/` provides the implementation. Consumers depend on the interface package only.
+- **Version comparison**: All version comparison must go through `package_versions.NewVersion()` or `NewVersionFromPkgType()`. Raw string comparison is incorrect for non-semver formats.
+- **No runtime dependencies**: This library must not import HTTP servers, database drivers, or message brokers. It is a pure type + utility library.
+- **Gojay for hot paths**: Types that are marshalled at high throughput (scan results, events) implement `gojay.MarshalerJSONObject` for zero-allocation encoding.
+- **Test fixtures**: Test data lives in `fixtures/` or `testdata/` subdirectories within each package.


### PR DESCRIPTION
## Summary

Onboards `armoapi-go` (shared type library) to the engineering docs-system.

- **AGENTS.md**: AI agent entry point with library purpose, key packages, consumers, and conventions
- **docs/repo/architecture.md**: Package structure, public API surface, build/test, versioning & compatibility rules
- **README.md**: Added package table, usage examples, and documentation section
- **Workflows**: docs-lint, codeowners-gen, dispatch-on-service-md-change

Tracked by SUB-7294.

## Notes

This is a **shared library** (not a service). No `docs/services/` directory — linter runs with `--no-services` flag.

## Test plan

- [x] `docs_lint.py` passes with `--no-services` flag
- [ ] Review AGENTS.md for accuracy of package descriptions
- [ ] Review architecture.md for completeness of conventions

## Required admin action (before / on merge)

The `codeowners-gen` workflow regenerates `CODEOWNERS` from frontmatter and pushes it back to `main`. Branch protection blocks that push unless the `armosec-docs-write` GitHub App is on the bypass list.

- [ ] **Admin:** add `armosec-docs-write` to the bypass list on `main`.