### PR TITLE
fix ProfileDataField.UnmarshalJSON to accept null

### DIFF
--- a/armotypes/runtimerule.go
+++ b/armotypes/runtimerule.go
@@ -174,6 +174,7 @@ func (f ProfileDataField) MarshalJSON() ([]byte, error) {
 
 func (f *ProfileDataField) UnmarshalJSON(data []byte) error {
 	if string(bytes.TrimSpace(data)) == "null" {
+		*f = ProfileDataField{}
 		return nil
 	}
 	var s string
@@ -203,6 +204,7 @@ func (f ProfileDataField) MarshalBSONValue() (bsontype.Type, []byte, error) {
 
 func (f *ProfileDataField) UnmarshalBSONValue(t bsontype.Type, data []byte) error {
 	if t == bsontype.Null {
+		*f = ProfileDataField{}
 		return nil
 	}
 	raw := bson.RawValue{Type: t, Value: data}

--- a/armotypes/runtimerule.go
+++ b/armotypes/runtimerule.go
@@ -174,7 +174,7 @@ func (f ProfileDataField) MarshalJSON() ([]byte, error) {
 
 func (f *ProfileDataField) UnmarshalJSON(data []byte) error {
 	if string(bytes.TrimSpace(data)) == "null" {
-		return fmt.Errorf("profileDataField: must be string %q or list, got null", profileDataFieldAllSentinel)
+		return nil
 	}
 	var s string
 	if err := json.Unmarshal(data, &s); err == nil {
@@ -202,6 +202,9 @@ func (f ProfileDataField) MarshalBSONValue() (bsontype.Type, []byte, error) {
 }
 
 func (f *ProfileDataField) UnmarshalBSONValue(t bsontype.Type, data []byte) error {
+	if t == bsontype.Null {
+		return nil
+	}
 	raw := bson.RawValue{Type: t, Value: data}
 	switch t {
 	case bsontype.String:

--- a/armotypes/runtimerule_profile_data_test.go
+++ b/armotypes/runtimerule_profile_data_test.go
@@ -97,6 +97,30 @@ func TestProfileDataField_UnmarshalJSON_AcceptsNull(t *testing.T) {
 	assert.Nil(t, f.Patterns)
 }
 
+func TestProfileDataField_UnmarshalJSON_NullClearsNonZero(t *testing.T) {
+	f := ProfileDataField{All: true, Patterns: []ProfileDataPattern{{Prefix: "/stale"}}}
+	err := json.Unmarshal([]byte(`null`), &f)
+	assert.NoError(t, err)
+	assert.False(t, f.All)
+	assert.Nil(t, f.Patterns)
+}
+
+func TestProfileDataField_UnmarshalBSONValue_AcceptsNull(t *testing.T) {
+	var f ProfileDataField
+	err := f.UnmarshalBSONValue(bson.TypeNull, nil)
+	assert.NoError(t, err)
+	assert.False(t, f.All)
+	assert.Nil(t, f.Patterns)
+}
+
+func TestProfileDataField_UnmarshalBSONValue_NullClearsNonZero(t *testing.T) {
+	f := ProfileDataField{All: true, Patterns: []ProfileDataPattern{{Prefix: "/stale"}}}
+	err := f.UnmarshalBSONValue(bson.TypeNull, nil)
+	assert.NoError(t, err)
+	assert.False(t, f.All)
+	assert.Nil(t, f.Patterns)
+}
+
 func TestProfileDataField_JSONRoundTrip(t *testing.T) {
 	for _, f := range []ProfileDataField{
 		{All: true},

--- a/armotypes/runtimerule_profile_data_test.go
+++ b/armotypes/runtimerule_profile_data_test.go
@@ -89,10 +89,12 @@ func TestProfileDataField_MarshalYAML_Patterns(t *testing.T) {
 	assert.Contains(t, string(out), `exact: /a`)
 }
 
-func TestProfileDataField_UnmarshalJSON_RejectsNull(t *testing.T) {
+func TestProfileDataField_UnmarshalJSON_AcceptsNull(t *testing.T) {
 	var f ProfileDataField
 	err := json.Unmarshal([]byte(`null`), &f)
-	assert.Error(t, err)
+	assert.NoError(t, err)
+	assert.False(t, f.All)
+	assert.Nil(t, f.Patterns)
 }
 
 func TestProfileDataField_JSONRoundTrip(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Profile data configurations now correctly handle null values in JSON and BSON data formats, improving compatibility with existing data structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->