### PR TITLE
feat(armotypes): add Documentation field to RuntimeRule

### DIFF
--- a/armotypes/runtimerule.go
+++ b/armotypes/runtimerule.go
@@ -84,6 +84,10 @@ type RuntimeRule struct {
 	MitreTechnique          string            `json:"mitreTechnique" bson:"mitreTechnique"`
 	Category                string            `json:"category" bson:"category"`
 	IncidentTypeId          string            `json:"incidentTypeId" bson:"incidentTypeId"`
+	// Documentation is the rendered markdown documentation for this rule,
+	// sourced from the rule's README.md in the rulelibrary repo. Empty for
+	// customer-authored rules.
+	Documentation           string            `json:"documentation,omitempty" yaml:"documentation,omitempty" bson:"documentation,omitempty"`
 }
 
 type RuleExpressions struct {

--- a/armotypes/runtimerule_documentation_test.go
+++ b/armotypes/runtimerule_documentation_test.go
@@ -1,0 +1,64 @@
+package armotypes
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+	"gopkg.in/yaml.v3"
+)
+
+func TestRuntimeRule_DocumentationJSONRoundTrip(t *testing.T) {
+	rule := RuntimeRule{
+		ID:            "R0001",
+		Name:          "Unexpected Process Launched",
+		Documentation: "# R0001 — Unexpected Process Launched\n\n## Description\nFoo.\n",
+	}
+
+	data, err := json.Marshal(rule)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"documentation":"# R0001`)
+
+	var got RuntimeRule
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, rule.Documentation, got.Documentation)
+}
+
+func TestRuntimeRule_DocumentationOmitEmpty(t *testing.T) {
+	rule := RuntimeRule{ID: "R0001", Name: "X"}
+
+	data, err := json.Marshal(rule)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), `"documentation"`,
+		"empty documentation should be omitted from JSON")
+}
+
+func TestRuntimeRule_DocumentationBSONRoundTrip(t *testing.T) {
+	rule := RuntimeRule{
+		ID:            "R0001",
+		Documentation: "# Rule\n\n## Description\n",
+	}
+
+	data, err := bson.Marshal(rule)
+	require.NoError(t, err)
+
+	var got RuntimeRule
+	require.NoError(t, bson.Unmarshal(data, &got))
+	assert.Equal(t, rule.Documentation, got.Documentation)
+}
+
+func TestRuntimeRule_DocumentationYAMLRoundTrip(t *testing.T) {
+	rule := RuntimeRule{
+		ID:            "R0001",
+		Documentation: "# Rule\n",
+	}
+
+	data, err := yaml.Marshal(rule)
+	require.NoError(t, err)
+
+	var got RuntimeRule
+	require.NoError(t, yaml.Unmarshal(data, &got))
+	assert.Equal(t, rule.Documentation, got.Documentation)
+}


### PR DESCRIPTION
## Summary
- Adds `Documentation string` field to `armotypes.RuntimeRule` with `json/yaml/bson:"documentation,omitempty"` tags.
- Field carries per-rule markdown documentation from the rulelibrary repos through to the ARMO UI popup (SUB-7177). Empty for customer-authored rules.

## Test plan
- [x] `TestRuntimeRule_DocumentationJSONRoundTrip` — JSON marshal/unmarshal round-trip
- [x] `TestRuntimeRule_DocumentationOmitEmpty` — empty field omitted from JSON output
- [x] `TestRuntimeRule_DocumentationBSONRoundTrip` — BSON round-trip
- [x] `TestRuntimeRule_DocumentationYAMLRoundTrip` — YAML round-trip
- [x] Full module test suite green (`go test ./...`, 380 tests across 11 packages)

Refs: [SUB-7177](https://cyberarmor-io.atlassian.net/browse/SUB-7177)
Design: `shared-designs-and-docs/rule-improvement-epic/rule-documentation-field-design.md`

## Downstream coordination
After this is merged and tagged, the new tag flows into:
1. `armosec-infra` (adds `GetDocumentation()` to the `Rule` interface)
2. `config-service` / `scheduled-db-tasks` / `cadashboardbe` (dep bumps)

[SUB-7177]: https://cyberarmor-io.atlassian.net/browse/SUB-7177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Runtime rules now support documentation fields to store and display rendered rule markdown documentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armosec/armoapi-go/pull/646)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->