### PR TITLE
feat: add GitHub ticketing types (SUB-7375, SUB-7376)

### DIFF
--- a/docs/services/armoapi-go/service.md
+++ b/docs/services/armoapi-go/service.md
@@ -25,7 +25,7 @@ This is a **pure type/utility library** with no runtime services (no HTTP server
 | `identifiers` | Workload and resource designator system (WLID, SID, PortalDesignator) with parsing utilities |
 | `containerscan` | Container vulnerability scan report interfaces defining the contract between scanner and consumers |
 | `containerscan/v1` | Concrete implementation of the `containerscan` interfaces |
-| `notifications` | Alert channel configuration, collaboration integrations (Jira, Linear, Slack), SIEM, and incident notification types |
+| `notifications` | Alert channel configuration, collaboration integrations (Jira, Linear, Slack, GitHub), SIEM, and incident notification types |
 | `broadcastevents` | Platform analytics and audit event types with factory constructors |
 | `package_versions` | Multi-format package version parsing and comparison (semver, APK, deb, RPM, Maven, PEP440, Go modules) |
 | `scanfailure` | Scan failure report types, reason codes, and human-readable failure descriptions |

--- a/notifications/alertchannelapi.go
+++ b/notifications/alertchannelapi.go
@@ -22,4 +22,8 @@ type AlertChannelAPI struct {
 	// Linear ticket identifiers for automatic ticket creation
 	// Example: [{workspaceId: "abc", teamId: "xyz"}]
 	LinearTicketIdentifiers []LinearTicketIdentifiers `json:"linearTicketIdentifiers,omitempty"`
+
+	// GitHub ticket identifiers for automatic ticket creation
+	// Example: [{collaborationGUID: "abc", organizationName: "my-org", repositoryName: "my-repo"}]
+	GitHubTicketIdentifiers []GitHubTicketIdentifiers `json:"githubTicketIdentifiers,omitempty"`
 }

--- a/notifications/collaborationconfig.go
+++ b/notifications/collaborationconfig.go
@@ -57,6 +57,7 @@ const (
 	CollaborationTypeEmail   ChannelProvider = "email"
 	CollaborationTypeWebhook ChannelProvider = "webhook"
 	CollaborationTypeLinear  ChannelProvider = "linear"
+	CollaborationTypeGitHub  ChannelProvider = "github"
 )
 
 // swagger:model CollaborationConfig

--- a/notifications/github_ticket_identifiers_test.go
+++ b/notifications/github_ticket_identifiers_test.go
@@ -21,6 +21,15 @@ func TestGitHubTicketIdentifiers_Serialization(t *testing.T) {
 	data, err := json.Marshal(identifiers)
 	require.NoError(t, err)
 
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+	require.Contains(t, raw, "collaborationGUID")
+	require.Contains(t, raw, "organizationName")
+	require.Contains(t, raw, "repositoryName")
+	require.Contains(t, raw, "labels")
+	require.Contains(t, raw, "assignees")
+	require.Contains(t, raw, "milestoneId")
+
 	var decoded GitHubTicketIdentifiers
 	require.NoError(t, json.Unmarshal(data, &decoded))
 

--- a/notifications/github_ticket_identifiers_test.go
+++ b/notifications/github_ticket_identifiers_test.go
@@ -1,0 +1,68 @@
+package notifications
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitHubTicketIdentifiers_Serialization(t *testing.T) {
+	milestoneID := 7
+	identifiers := GitHubTicketIdentifiers{
+		CollaborationGUID: "collab-guid-123",
+		OrganizationName:  "my-org",
+		RepositoryName:    "my-repo",
+		Labels:            []string{"bug", "priority:high"},
+		Assignees:         []string{"alice"},
+		MilestoneID:       &milestoneID,
+	}
+
+	data, err := json.Marshal(identifiers)
+	require.NoError(t, err)
+
+	var decoded GitHubTicketIdentifiers
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	require.Equal(t, identifiers.CollaborationGUID, decoded.CollaborationGUID)
+	require.Equal(t, identifiers.OrganizationName, decoded.OrganizationName)
+	require.Equal(t, identifiers.RepositoryName, decoded.RepositoryName)
+	require.Equal(t, identifiers.Labels, decoded.Labels)
+	require.Equal(t, identifiers.Assignees, decoded.Assignees)
+	require.Equal(t, *identifiers.MilestoneID, *decoded.MilestoneID)
+}
+
+func TestGitHubTicketIdentifiers_OmitsEmptyOptionals(t *testing.T) {
+	identifiers := GitHubTicketIdentifiers{}
+
+	data, err := json.Marshal(identifiers)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	require.Empty(t, raw, "empty GitHubTicketIdentifiers should serialize to {}")
+}
+
+func TestAlertChannel_GitHubTicketIdentifiers(t *testing.T) {
+	channel := AlertChannel{
+		GitHubTicketIdentifiers: []GitHubTicketIdentifiers{
+			{
+				CollaborationGUID: "collab-guid-123",
+				OrganizationName:  "my-org",
+				RepositoryName:    "my-repo",
+			},
+		},
+	}
+
+	data, err := json.Marshal(channel)
+	require.NoError(t, err)
+
+	var decoded AlertChannel
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	require.Len(t, decoded.GitHubTicketIdentifiers, 1)
+	require.Equal(t, "collab-guid-123", decoded.GitHubTicketIdentifiers[0].CollaborationGUID)
+	require.Equal(t, "my-org", decoded.GitHubTicketIdentifiers[0].OrganizationName)
+	require.Equal(t, "my-repo", decoded.GitHubTicketIdentifiers[0].RepositoryName)
+}

--- a/notifications/usernotificationreporttypes.go
+++ b/notifications/usernotificationreporttypes.go
@@ -80,7 +80,7 @@ type GitHubTicketIdentifiers struct {
 	RepositoryName    string   `json:"repositoryName,omitempty" bson:"repositoryName,omitempty"`
 	Labels            []string `json:"labels,omitempty" bson:"labels,omitempty"`
 	Assignees         []string `json:"assignees,omitempty" bson:"assignees,omitempty"`
-	MilestoneID       *int     `json:"milestoneID,omitempty" bson:"milestoneID,omitempty"`
+	MilestoneID       *int     `json:"milestoneId,omitempty" bson:"milestoneId,omitempty"`
 }
 
 type AlertChannel struct {

--- a/notifications/usernotificationreporttypes.go
+++ b/notifications/usernotificationreporttypes.go
@@ -74,6 +74,15 @@ type LinearTicketIdentifiers struct {
 	Fields      map[string]interface{} `json:"fields,omitempty" bson:"fields,omitempty"`
 }
 
+type GitHubTicketIdentifiers struct {
+	CollaborationGUID string   `json:"collaborationGUID,omitempty" bson:"collaborationGUID,omitempty"`
+	OrganizationName  string   `json:"organizationName,omitempty" bson:"organizationName,omitempty"`
+	RepositoryName    string   `json:"repositoryName,omitempty" bson:"repositoryName,omitempty"`
+	Labels            []string `json:"labels,omitempty" bson:"labels,omitempty"`
+	Assignees         []string `json:"assignees,omitempty" bson:"assignees,omitempty"`
+	MilestoneID       *int     `json:"milestoneID,omitempty" bson:"milestoneID,omitempty"`
+}
+
 type AlertChannel struct {
 	ChannelType             ChannelProvider           `json:"channelType,omitempty" bson:"channelType,omitempty"`
 	Scope                   []AlertScope              `json:"scope,omitempty" bson:"scope,omitempty"`
@@ -81,6 +90,7 @@ type AlertChannel struct {
 	Alerts                  []AlertConfig             `json:"notifications,omitempty" bson:"notifications,omitempty"`
 	JiraTicketIdentifiers   []JiraTicketIdentifiers   `json:"jiraTicketIdentifiers,omitempty" bson:"jiraTicketIdentifiers,omitempty"`
 	LinearTicketIdentifiers []LinearTicketIdentifiers `json:"linearTicketIdentifiers,omitempty" bson:"linearTicketIdentifiers,omitempty"`
+	GitHubTicketIdentifiers []GitHubTicketIdentifiers `json:"githubTicketIdentifiers,omitempty" bson:"githubTicketIdentifiers,omitempty"`
 }
 
 type NotificationParams struct {
@@ -92,14 +102,14 @@ type NotificationParams struct {
 	Severities []string `json:"severities,omitempty" bson:"severities,omitempty"`
 
 	// vulnerability params
-	KnownExploited *bool    `json:"knownExploited,omitempty" bson:"knownExploited,omitempty"` // Known Exploited (CISA KEV)
-	HighLikelihood *bool    `json:"highLikelihood,omitempty" bson:"highLikelihood,omitempty"` // High Likelihood (EPSS ≥ 10%)
-	CVSS              *float32 `json:"cvss,omitempty" bson:"cvss,omitempty"`                           // CVSS (Common Vulnerability Scoring System) min threshold (≥)
-	CVSSMax           *float32 `json:"cvssMax,omitempty" bson:"cvssMax,omitempty"`                     // CVSS max threshold (≤)
-	InUse             *bool    `json:"inUse,omitempty" bson:"inUse,omitempty"`                         // In Use (CISA IU)
-	Fixable           *bool    `json:"fixable,omitempty" bson:"fixable,omitempty"`                     // Fixable (CISA FX)
-	NoExploitability  *bool    `json:"noExploitability,omitempty" bson:"noExploitability,omitempty"`   // No exploit intelligence
-	RiskFactors       []string `json:"riskFactors,omitempty" bson:"riskFactors,omitempty"`             // Risk Factors
+	KnownExploited   *bool    `json:"knownExploited,omitempty" bson:"knownExploited,omitempty"`     // Known Exploited (CISA KEV)
+	HighLikelihood   *bool    `json:"highLikelihood,omitempty" bson:"highLikelihood,omitempty"`     // High Likelihood (EPSS ≥ 10%)
+	CVSS             *float32 `json:"cvss,omitempty" bson:"cvss,omitempty"`                         // CVSS (Common Vulnerability Scoring System) min threshold (≥)
+	CVSSMax          *float32 `json:"cvssMax,omitempty" bson:"cvssMax,omitempty"`                   // CVSS max threshold (≤)
+	InUse            *bool    `json:"inUse,omitempty" bson:"inUse,omitempty"`                       // In Use (CISA IU)
+	Fixable          *bool    `json:"fixable,omitempty" bson:"fixable,omitempty"`                   // Fixable (CISA FX)
+	NoExploitability *bool    `json:"noExploitability,omitempty" bson:"noExploitability,omitempty"` // No exploit intelligence
+	RiskFactors      []string `json:"riskFactors,omitempty" bson:"riskFactors,omitempty"`           // Risk Factors
 
 	// security risks params
 	SecurityRiskIDs []string `json:"securityRiskIDs,omitempty" bson:"securityRiskIDs,omitempty"` // Security Risk ID
@@ -147,7 +157,7 @@ const (
 	NotificationTypeSecurityRiskNew    NotificationType = NotificationTypeSecurityRiskPush + ":newSecurityRisk"
 	NotificationTypeRuntimeIncidentNew NotificationType = NotificationTypeRuntimeIncidentPush + ":newRuntimeIncident"
 
-	NotificationTypeScanFailurePush NotificationType = "scanFailurePush"                          // scan failure
+	NotificationTypeScanFailurePush NotificationType = "scanFailurePush"                                   // scan failure
 	NotificationTypeScanFailureNew  NotificationType = NotificationTypeScanFailurePush + ":newScanFailure" // new scan failure event
 )
 


### PR DESCRIPTION
## Summary
- Add `GitHubTicketIdentifiers` struct with org, repo, labels, assignees, milestone fields
- Add `GitHubTicketIdentifiers` slice to `AlertChannel` (alongside Jira and Linear)
- Add `CollaborationTypeGitHub ChannelProvider = "github"` constant

## Test plan
- [x] Serialization round-trip tests for `GitHubTicketIdentifiers`
- [x] `omitempty` verification for empty struct
- [x] `AlertChannel` integration test with GitHub identifiers
- [x] Full test suite passes (22 tests in notifications, 383 across all packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub as a supported collaboration integration for notifications and alerts.

* **Documentation**
  * Updated service documentation to include GitHub in collaboration integrations.

* **Tests**
  * Added unit tests for GitHub ticket identifier serialization and deserialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armosec/armoapi-go/pull/647?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->