### PR TITLE
feat: add TicketManagerGitHub constant

### DIFF
--- a/armotypes/integrationtypes.go
+++ b/armotypes/integrationtypes.go
@@ -7,6 +7,7 @@ type TicketManager string
 const (
 	TicketManagerJira   TicketManager = "jira"
 	TicketManagerLinear TicketManager = "linear"
+	TicketManagerGitHub TicketManager = "github"
 )
 
 type Ticket struct {

--- a/docs/services/armoapi-go/service.md
+++ b/docs/services/armoapi-go/service.md
@@ -25,6 +25,7 @@ This is a **pure type/utility library** with no runtime services (no HTTP server
 | `identifiers` | Workload and resource designator system (WLID, SID, PortalDesignator) with parsing utilities |
 | `containerscan` | Container vulnerability scan report interfaces defining the contract between scanner and consumers |
 | `containerscan/v1` | Concrete implementation of the `containerscan` interfaces |
+| `armotypes` (ticketing) | `TicketManager` type and provider constants (`TicketManagerJira`, `TicketManagerLinear`, `TicketManagerGitHub`), `Ticket` struct |
 | `notifications` | Alert channel configuration, collaboration integrations (Jira, Linear, Slack, GitHub), SIEM, and incident notification types |
 | `broadcastevents` | Platform analytics and audit event types with factory constructors |
 | `package_versions` | Multi-format package version parsing and comparison (semver, APK, deb, RPM, Maven, PEP440, Go modules) |


### PR DESCRIPTION
## Summary
- Add `TicketManagerGitHub TicketManager = "github"` constant to `armotypes/integrationtypes.go`
- Completes the set alongside `TicketManagerJira` and `TicketManagerLinear`
- Part of GitHub Issues ticketing integration (SUB-7361)

## Test plan
- [x] `go build ./armotypes/...` passes
- [x] `go test ./armotypes/...` passes (123 tests)
- [ ] cadashboardbe PR #2788 will switch from local const to this one after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)