### PR TITLE
feat: add k8s-admission EventType for operator CEL rules

### DIFF
--- a/armotypes/runtimerule.go
+++ b/armotypes/runtimerule.go
@@ -123,6 +123,7 @@ const (
 	EventTypeHardlink     EventType = "hardlink"
 	EventTypeSSH          EventType = "ssh"
 	EventTypeHTTP         EventType = "http"
+	EventTypeK8sAdmission EventType = "k8s-admission"
 )
 
 // ProfileDataField is a tagged union: either All == true (the rule needs every


### PR DESCRIPTION
## Summary
- Adds `EventTypeK8sAdmission EventType = "k8s-admission"` constant to `armotypes/runtimerule.go`
- Used by the operator to identify CEL rules targeting Kubernetes admission webhook events (exec-to-pod, port-forward, and arbitrary admission events)
- Sits alongside existing event types (`exec`, `open`, `network`, etc.) — the node-agent ignores it, the operator evaluates it

## Test plan
- [x] `go build ./...` passes
- [ ] Verify node-agent builds with this change (no-op, new constant is unused there)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Kubernetes admission runtime events, expanding the types of runtime events the system can process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armosec/armoapi-go/pull/649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->