### PR TITLE
feat: add ClusterSBOMScanMessage type

### DIFF
--- a/armotypes/cluster_sbom_scan.go
+++ b/armotypes/cluster_sbom_scan.go
@@ -1,0 +1,28 @@
+package armotypes
+
+// ClusterSBOMScanMessage is the Pulsar payload published by the cluster
+// vulnerability scan dispatcher (one per ContainerProfile per tick) and
+// consumed by the backend Vulnerability Scanner. The scanner reads the
+// SBOM blob at SBOMObjectRef from S3, fetches the ContainerProfile row
+// by ContainerProfileName, computes the filtered SBOM, runs Grype, and
+// emits a vuln-scan summary tagged kind=cluster.
+//
+// All identifying fields needed for filtered-SBOM computation and for
+// per-workload attribution downstream travel on the message — the
+// scanner does not need to call back into postgres for them.
+//
+// Field stability: any field added later MUST be `omitempty` so older
+// publishers continue to produce valid payloads (consumer treats absent
+// fields as zero values).
+type ClusterSBOMScanMessage struct {
+	CustomerGUID         string `json:"customerGUID"`
+	Cluster              string `json:"cluster"`
+	WorkloadKind         string `json:"workloadKind"`
+	WorkloadName         string `json:"workloadName"`
+	WorkloadNamespace    string `json:"workloadNamespace"`
+	WorkloadResourceHash string `json:"workloadResourceHash"`
+	ContainerProfileName string `json:"containerProfileName"`
+	ImageDigest          string `json:"imageDigest"`
+	SyftVersion          string `json:"syftVersion"`
+	SBOMObjectRef        string `json:"sbomObjectRef"`
+}

--- a/armotypes/cluster_sbom_scan.go
+++ b/armotypes/cluster_sbom_scan.go
@@ -2,27 +2,37 @@ package armotypes
 
 // ClusterSBOMScanMessage is the Pulsar payload published by the cluster
 // vulnerability scan dispatcher (one per ContainerProfile per tick) and
-// consumed by the backend Vulnerability Scanner. The scanner reads the
-// SBOM blob at SBOMObjectRef from S3, fetches the ContainerProfile row
-// by ContainerProfileName, computes the filtered SBOM, runs Grype, and
-// emits a vuln-scan summary tagged kind=cluster.
+// consumed by the backend Vulnerability Scanner.
 //
-// All identifying fields needed for filtered-SBOM computation and for
-// per-workload attribution downstream travel on the message — the
-// scanner does not need to call back into postgres for them.
+// The scanner reads the SBOM blob from S3 at SBOMObjectRef and fetches
+// the ContainerProfile row from postgres (by ContainerProfileName) so
+// it can compute the filtered SBOM before running Grype. It then emits
+// a vuln-scan summary tagged kind=cluster.
+//
+// The message carries every identity field needed for downstream
+// per-workload attribution (cluster, workload kind/name/namespace,
+// resource hash, image digest, syft version) — that path is
+// postgres-free. Only the filtered-SBOM computation step needs the CP
+// row from the DB.
+//
+// SBOMObjectRef is a JSON-encoded `{"bucket": "...", "key": "..."}`
+// string — kept as a string to pass through unchanged from the
+// `sbom_metadata.resource_object_ref` column rather than serialise +
+// deserialise on the dispatcher's hot path.
 //
 // Field stability: any field added later MUST be `omitempty` so older
-// publishers continue to produce valid payloads (consumer treats absent
-// fields as zero values).
+// publishers continue to produce valid payloads (consumer treats
+// absent fields as zero values).
 type ClusterSBOMScanMessage struct {
-	CustomerGUID         string `json:"customerGUID"`
-	Cluster              string `json:"cluster"`
-	WorkloadKind         string `json:"workloadKind"`
-	WorkloadName         string `json:"workloadName"`
-	WorkloadNamespace    string `json:"workloadNamespace"`
-	WorkloadResourceHash string `json:"workloadResourceHash"`
-	ContainerProfileName string `json:"containerProfileName"`
-	ImageDigest          string `json:"imageDigest"`
-	SyftVersion          string `json:"syftVersion"`
-	SBOMObjectRef        string `json:"sbomObjectRef"`
+	PortalBase           `json:",inline" bson:",inline"`
+	CustomerGUID         string `json:"customerGUID" bson:"customerGUID"`
+	Cluster              string `json:"cluster" bson:"cluster"`
+	WorkloadKind         string `json:"workloadKind" bson:"workloadKind"`
+	WorkloadName         string `json:"workloadName" bson:"workloadName"`
+	WorkloadNamespace    string `json:"workloadNamespace" bson:"workloadNamespace"`
+	WorkloadResourceHash string `json:"workloadResourceHash" bson:"workloadResourceHash"`
+	ContainerProfileName string `json:"containerProfileName" bson:"containerProfileName"`
+	ImageDigest          string `json:"imageDigest" bson:"imageDigest"`
+	SyftVersion          string `json:"syftVersion" bson:"syftVersion"`
+	SBOMObjectRef        string `json:"sbomObjectRef" bson:"sbomObjectRef"`
 }

--- a/armotypes/cluster_sbom_scan_test.go
+++ b/armotypes/cluster_sbom_scan_test.go
@@ -13,6 +13,10 @@ import (
 // removing fields the consumer relies on.
 func TestClusterSBOMScanMessage_RoundTrip(t *testing.T) {
 	orig := ClusterSBOMScanMessage{
+		PortalBase: PortalBase{
+			GUID: "msg-7a3f", // per-message id, useful for tracing/dedup downstream
+			Name: "cluster-sbom-scan",
+		},
 		CustomerGUID:         "11111111-1111-1111-1111-111111111111",
 		Cluster:              "prod-east-1",
 		WorkloadKind:         "Deployment",
@@ -35,8 +39,13 @@ func TestClusterSBOMScanMessage_RoundTrip(t *testing.T) {
 
 // The consumer reads exact json tag names, so freeze them — a rename
 // here would silently break the Vulnerability Scanner's deserialiser.
+// PortalBase contributes guid/name (always serialized) and
+// attributes/updatedTime (omitempty); only the always-emitted PortalBase
+// fields are asserted here so the test stays focused on the cluster-
+// scan-specific wire shape.
 func TestClusterSBOMScanMessage_JSONFieldNames(t *testing.T) {
 	wire, err := json.Marshal(ClusterSBOMScanMessage{
+		PortalBase:           PortalBase{GUID: "g", Name: "n"},
 		CustomerGUID:         "c",
 		Cluster:              "cl",
 		WorkloadKind:         "wk",
@@ -53,6 +62,8 @@ func TestClusterSBOMScanMessage_JSONFieldNames(t *testing.T) {
 	var asMap map[string]string
 	require.NoError(t, json.Unmarshal(wire, &asMap))
 	assert.Equal(t, map[string]string{
+		"guid":                 "g",
+		"name":                 "n",
 		"customerGUID":         "c",
 		"cluster":              "cl",
 		"workloadKind":         "wk",

--- a/armotypes/cluster_sbom_scan_test.go
+++ b/armotypes/cluster_sbom_scan_test.go
@@ -1,0 +1,67 @@
+package armotypes
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Round-trip a fully-populated message and assert no field is lost on
+// the wire. Guards against accidental json-tag typos and against
+// removing fields the consumer relies on.
+func TestClusterSBOMScanMessage_RoundTrip(t *testing.T) {
+	orig := ClusterSBOMScanMessage{
+		CustomerGUID:         "11111111-1111-1111-1111-111111111111",
+		Cluster:              "prod-east-1",
+		WorkloadKind:         "Deployment",
+		WorkloadName:         "checkout-api",
+		WorkloadNamespace:    "shop",
+		WorkloadResourceHash: "wlhash-deadbeef",
+		ContainerProfileName: "cp-checkout-api-main",
+		ImageDigest:          "sha256:abc123",
+		SyftVersion:          "1.20.0",
+		SBOMObjectRef:        `{"bucket":"sboms","key":"11111111/abc123/1.20.0/sbom.json"}`,
+	}
+
+	wire, err := json.Marshal(orig)
+	require.NoError(t, err)
+
+	var got ClusterSBOMScanMessage
+	require.NoError(t, json.Unmarshal(wire, &got))
+	assert.Equal(t, orig, got)
+}
+
+// The consumer reads exact json tag names, so freeze them — a rename
+// here would silently break the Vulnerability Scanner's deserialiser.
+func TestClusterSBOMScanMessage_JSONFieldNames(t *testing.T) {
+	wire, err := json.Marshal(ClusterSBOMScanMessage{
+		CustomerGUID:         "c",
+		Cluster:              "cl",
+		WorkloadKind:         "wk",
+		WorkloadName:         "wn",
+		WorkloadNamespace:    "wns",
+		WorkloadResourceHash: "wrh",
+		ContainerProfileName: "cpn",
+		ImageDigest:          "id",
+		SyftVersion:          "sv",
+		SBOMObjectRef:        "sor",
+	})
+	require.NoError(t, err)
+
+	var asMap map[string]string
+	require.NoError(t, json.Unmarshal(wire, &asMap))
+	assert.Equal(t, map[string]string{
+		"customerGUID":         "c",
+		"cluster":              "cl",
+		"workloadKind":         "wk",
+		"workloadName":         "wn",
+		"workloadNamespace":    "wns",
+		"workloadResourceHash": "wrh",
+		"containerProfileName": "cpn",
+		"imageDigest":          "id",
+		"syftVersion":          "sv",
+		"sbomObjectRef":        "sor",
+	}, asMap)
+}


### PR DESCRIPTION
## Summary
- Adds `armotypes.ClusterSBOMScanMessage` — the Pulsar payload published per ContainerProfile per tick by the new cluster vuln scan dispatcher in `event-ingester-service` and consumed by the backend Vulnerability Scanner.
- Carries the cluster-workload identity, ContainerProfile reference, image digest, syft version, and SBOM S3 ref so the scanner can compute the filtered SBOM and run Grype without a postgres round-trip.

## Context
Part of NAUT-1310 (storage deprecation for ARMO customers). This is the message type — the producer lives in `event-ingester-service` (separate PR), the consumer extension lives in the backend Vulnerability Scanner (separate work).

Field set follows §5.7 of the design (kind=cluster context). A sibling `RegistrySBOMScanMessage` will be added in the Registry Epic; intentionally not unioned here.

## Test plan
- [x] `TestClusterSBOMScanMessage_RoundTrip` — full-field JSON round-trip
- [x] `TestClusterSBOMScanMessage_JSONFieldNames` — freezes wire-format json tag names so a rename here can't silently break the scanner consumer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cluster vulnerability SBOM scanning capability with support for workload metadata, image digests, and scan result storage references.

* **Tests**
  * Added validation tests for SBOM scan message serialization and JSON field naming.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/armosec/armoapi-go/pull/650?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->