### PR TITLE
addition of ReasonImageSchemaUnsupported in scanfailure

### DIFF
--- a/scanfailure/types.go
+++ b/scanfailure/types.go
@@ -23,34 +23,36 @@ const (
 // human-friendly text at render time, so notification wording can be changed
 // without redeploying in-cluster scanners.
 const (
-	ReasonSBOMGenerationFailed = "sbom_generation_failed"
-	ReasonImageTooLarge        = "image_too_large"
-	ReasonSBOMTooLarge         = "sbom_too_large"
-	ReasonSBOMIncomplete       = "sbom_incomplete"
-	ReasonImageAuthFailed      = "image_auth_failed"
-	ReasonImageNotFound        = "image_not_found"
-	ReasonCVEMatchingFailed    = "cve_matching_failed"
-	ReasonResultUploadFailed   = "result_upload_failed"
-	ReasonSBOMStorageFailed    = "sbom_storage_failed"
-	ReasonScannerOOMKilled     = "scanner_oom_killed"
-	ReasonScanTimeout          = "scan_timeout"
-	ReasonUnexpected           = "unexpected_error"
+	ReasonSBOMGenerationFailed   = "sbom_generation_failed"
+	ReasonImageTooLarge          = "image_too_large"
+	ReasonSBOMTooLarge           = "sbom_too_large"
+	ReasonSBOMIncomplete         = "sbom_incomplete"
+	ReasonImageAuthFailed        = "image_auth_failed"
+	ReasonImageNotFound          = "image_not_found"
+	ReasonImageSchemaUnsupported = "image_schema_unsupported"
+	ReasonCVEMatchingFailed      = "cve_matching_failed"
+	ReasonResultUploadFailed     = "result_upload_failed"
+	ReasonSBOMStorageFailed      = "sbom_storage_failed"
+	ReasonScannerOOMKilled       = "scanner_oom_killed"
+	ReasonScanTimeout            = "scan_timeout"
+	ReasonUnexpected             = "unexpected_error"
 )
 
 // reasonFriendlyText maps reason codes to human-friendly text for notifications.
 var reasonFriendlyText = map[string]string{
-	ReasonSBOMGenerationFailed: "Failed to generate software inventory (SBOM) for this image",
-	ReasonImageTooLarge:        "Image exceeds the maximum size limit for vulnerability scanning",
-	ReasonSBOMTooLarge:         "Generated software inventory (SBOM) exceeds the maximum size limit",
-	ReasonSBOMIncomplete:       "SBOM generation was incomplete — the scan may have timed out or the image exceeded size limits",
-	ReasonImageAuthFailed:      "Failed to authenticate when pulling the container image",
-	ReasonImageNotFound:        "Container image manifest not found in registry",
-	ReasonCVEMatchingFailed:    "Failed to match image components against vulnerability databases",
-	ReasonResultUploadFailed:   "Scan completed but results could not be uploaded to the platform",
-	ReasonSBOMStorageFailed:    "Failed to store the generated software inventory (SBOM)",
-	ReasonScannerOOMKilled:     "SBOM scanner was killed due to memory limits — consider increasing the scanner memory limit",
-	ReasonScanTimeout:          "Vulnerability scan timed out before completion",
-	ReasonUnexpected:           "An unexpected error occurred during vulnerability scanning",
+	ReasonSBOMGenerationFailed:   "Failed to generate software inventory (SBOM) for this image",
+	ReasonImageTooLarge:          "Image exceeds the maximum size limit for vulnerability scanning",
+	ReasonSBOMTooLarge:           "Generated software inventory (SBOM) exceeds the maximum size limit",
+	ReasonSBOMIncomplete:         "SBOM generation was incomplete — the scan may have timed out or the image exceeded size limits",
+	ReasonImageAuthFailed:        "Failed to authenticate when pulling the container image",
+	ReasonImageNotFound:          "Container image manifest not found in registry",
+	ReasonImageSchemaUnsupported: "The container image manifest uses a schema the scanner cannot read",
+	ReasonCVEMatchingFailed:      "Failed to match image components against vulnerability databases",
+	ReasonResultUploadFailed:     "Scan completed but results could not be uploaded to the platform",
+	ReasonSBOMStorageFailed:      "Failed to store the generated software inventory (SBOM)",
+	ReasonScannerOOMKilled:       "SBOM scanner was killed due to memory limits — consider increasing the scanner memory limit",
+	ReasonScanTimeout:            "Vulnerability scan timed out before completion",
+	ReasonUnexpected:             "An unexpected error occurred during vulnerability scanning",
 }
 
 // ReasonFriendlyText returns the human-friendly notification text for a reason code.

--- a/scanfailure/types_test.go
+++ b/scanfailure/types_test.go
@@ -21,6 +21,11 @@ func TestReasonFriendlyText(t *testing.T) {
 			expected: "SBOM scanner was killed due to memory limits — consider increasing the scanner memory limit",
 		},
 		{
+			name:     "image schema unsupported code",
+			code:     ReasonImageSchemaUnsupported,
+			expected: "The container image manifest uses a schema the scanner cannot read",
+		},
+		{
 			name:     "empty string returns unexpected text",
 			code:     "",
 			expected: reasonFriendlyText[ReasonUnexpected],
@@ -51,7 +56,8 @@ func TestAllReasonCodesHaveFriendlyText(t *testing.T) {
 	codes := []string{
 		ReasonSBOMGenerationFailed, ReasonImageTooLarge, ReasonSBOMTooLarge,
 		ReasonSBOMIncomplete, ReasonImageAuthFailed, ReasonImageNotFound,
-		ReasonCVEMatchingFailed, ReasonResultUploadFailed, ReasonSBOMStorageFailed,
+		ReasonImageSchemaUnsupported, ReasonCVEMatchingFailed, ReasonResultUploadFailed,
+		ReasonSBOMStorageFailed,
 		ReasonScannerOOMKilled, ReasonScanTimeout, ReasonUnexpected,
 	}
 	for _, code := range codes {


### PR DESCRIPTION
## Description:

Adds a new scan-failure reason code for images whose registry serves a manifest schema the scanner can't read.

Today a schema rejection (MANIFEST_SCHEMA_UNSUPPORTED) gets reported under the generic sbom_generation_failed bucket, which is indistinguishable from a real SBOM-tooling crash. This adds a dedicated code so consumers (UNS notifications, dashboards) can tell the two apart:

ReasonImageSchemaUnsupported = "image_schema_unsupported"

## Changes:

New constant in the failure-reason block, plus its entry in reasonFriendlyText: "The container image manifest uses a schema the scanner cannot read"
Test coverage added to TestReasonFriendlyText and TestAllReasonCodesHaveFriendlyText

This is the first of two PRs. The consumer side (kubevuln) is in a follow-up PR that depends on this constant - [kubescape/kubevuln#370](https://github.com/kubescape/kubevuln/pull/370).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code structure improvements.

* **Tests**
  * Expanded test coverage for additional error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->