### PR TITLE
add `operatorAction` command contract for CLI-driven cluster operations

### DIFF
--- a/apis/clusterapis.go
+++ b/apis/clusterapis.go
@@ -53,4 +53,8 @@ const (
 	// Delete a CronJob that runs registry scans
 	TypeDeleteRegistryScanCronJob NotificationPolicyType = "deleteRegistryScanCronJob"
 	TypeTestRegistryConnectivity  NotificationPolicyType = "testRegistryConnectivity"
+	// Trigger an operator cluster operation (post-scan remediation, e.g.
+	// annotate/quarantine/cordon). The concrete operation is carried in
+	// Command.Args as an OperatorActionArgs; see operatoraction.go.
+	TypeOperatorAction NotificationPolicyType = "operatorAction"
 )

--- a/apis/operatoraction.go
+++ b/apis/operatoraction.go
@@ -22,8 +22,7 @@ const (
 )
 
 // OperatorActionTarget identifies a single concrete object an action operates
-// on. Either a fully-specified Target or a findings-driven Selector is provided;
-// when both are present the Selector resolves an additional target set.
+// on.
 type OperatorActionTarget struct {
 	Kind      string `json:"kind,omitempty"`
 	Namespace string `json:"namespace,omitempty"`
@@ -45,6 +44,9 @@ type OperatorActionSelector struct {
 
 // OperatorActionArgs is the typed schema for Command.Args when
 // Command.CommandName == TypeOperatorAction.
+//
+// Either a fully-specified Target or a findings-driven Selector is provided;
+// when both are present the Selector resolves an additional target set.
 //
 // Safe-by-default: DryRun is a *bool so its zero value (nil / absent on the
 // wire) means dry-run. The operator therefore treats any request that does not

--- a/apis/operatoraction.go
+++ b/apis/operatoraction.go
@@ -1,0 +1,104 @@
+package apis
+
+import "encoding/json"
+
+// OperatorActionType enumerates the concrete cluster operations that a
+// TypeOperatorAction command can request. It is carried in
+// OperatorActionArgs.Action and dispatched by the operator to the matching
+// Remediator implementation.
+type OperatorActionType string
+
+const (
+	// OperatorActionAnnotate adds a label/annotation to a workload (the
+	// lowest-blast-radius action; shipped first to prove the pipeline).
+	OperatorActionAnnotate OperatorActionType = "annotate"
+	// OperatorActionQuarantine isolates a workload (deny-all NetworkPolicy +
+	// quarantine label).
+	OperatorActionQuarantine OperatorActionType = "quarantine"
+	// OperatorActionCordon marks a node unschedulable.
+	OperatorActionCordon OperatorActionType = "cordon"
+	// OperatorActionRevert undoes a previously applied action on a target.
+	OperatorActionRevert OperatorActionType = "revert"
+)
+
+// OperatorActionTarget identifies a single concrete object an action operates
+// on. Either a fully-specified Target or a findings-driven Selector is provided;
+// when both are present the Selector resolves an additional target set.
+type OperatorActionTarget struct {
+	Kind      string `json:"kind,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name,omitempty"`
+}
+
+// OperatorActionSelector resolves a findings-driven target set from the
+// scan-result CRDs already stored in the cluster (e.g. "workloads failing
+// control C-0016 with severity >= High"). No re-scan is performed.
+type OperatorActionSelector struct {
+	// Control is the Kubescape control ID to select failing workloads for
+	// (e.g. "C-0016").
+	Control string `json:"control,omitempty"`
+	// MinSeverity is the minimum finding severity to act on (e.g. "High").
+	MinSeverity string `json:"minSeverity,omitempty"`
+	// Namespace optionally limits the selector to a single namespace.
+	Namespace string `json:"namespace,omitempty"`
+}
+
+// OperatorActionArgs is the typed schema for Command.Args when
+// Command.CommandName == TypeOperatorAction.
+//
+// Safe-by-default: DryRun is a *bool so its zero value (nil / absent on the
+// wire) means dry-run. The operator therefore treats any request that does not
+// carry an explicit DryRun=false as a plan-only dry-run. Only an explicit
+// DryRun=false (the CLI's --confirm) performs a real cluster write. Use
+// IsDryRun to interpret the field rather than dereferencing it directly.
+type OperatorActionArgs struct {
+	// Action is the operation to perform.
+	Action OperatorActionType `json:"action"`
+	// Target is an explicit single object to act on (optional if Selector is set).
+	Target *OperatorActionTarget `json:"target,omitempty"`
+	// Selector resolves targets from stored findings (optional if Target is set).
+	Selector *OperatorActionSelector `json:"selector,omitempty"`
+	// FindingRef references the scan-result CRD that justifies the action, for
+	// audit (e.g. "workloadconfigurationscansummaries/payments/api").
+	FindingRef string `json:"findingRef,omitempty"`
+	// DryRun gates real cluster writes. nil (absent) or true means plan-only;
+	// only an explicit false applies the change. See IsDryRun.
+	DryRun *bool `json:"dryRun,omitempty"`
+	// TTL optionally schedules an automatic revert after the given duration
+	// (e.g. "24h").
+	TTL string `json:"ttl,omitempty"`
+	// Reason is a human-readable justification recorded in the audit trail.
+	Reason string `json:"reason,omitempty"`
+}
+
+// IsDryRun reports whether the action should be treated as a plan-only dry-run.
+// It returns true unless DryRun was explicitly set to false, so a request that
+// omits the field can never silently perform a real cluster write.
+func (a OperatorActionArgs) IsDryRun() bool {
+	return a.DryRun == nil || *a.DryRun
+}
+
+// ToArgs serializes the typed action args into the generic Command.Args map.
+func (a OperatorActionArgs) ToArgs() (map[string]interface{}, error) {
+	b, err := json.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// OperatorActionArgsFromMap parses a generic Command.Args map back into the
+// typed action args.
+func OperatorActionArgsFromMap(m map[string]interface{}) (OperatorActionArgs, error) {
+	var a OperatorActionArgs
+	b, err := json.Marshal(m)
+	if err != nil {
+		return a, err
+	}
+	err = json.Unmarshal(b, &a)
+	return a, err
+}

--- a/apis/operatoraction_test.go
+++ b/apis/operatoraction_test.go
@@ -72,7 +72,16 @@ func TestOperatorActionArgsDryRunDefaultsSafe(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, out.IsDryRun(), "operator must read an omitted DryRun as a dry-run")
 
-	// Only an explicit false applies.
+	// Only an explicit false applies, and that must survive the wire round-trip:
+	// DryRun=false serializes as "dryRun": false and reads back as apply.
 	apply := OperatorActionArgs{Action: OperatorActionCordon, DryRun: boolPtr(false)}
 	assert.False(t, apply.IsDryRun())
+
+	am, err := apply.ToArgs()
+	require.NoError(t, err)
+	assert.Equal(t, false, am["dryRun"], "explicit DryRun=false must serialize on the wire")
+
+	applyOut, err := OperatorActionArgsFromMap(am)
+	require.NoError(t, err)
+	assert.False(t, applyOut.IsDryRun(), "operator must read an explicit DryRun=false as apply")
 }

--- a/apis/operatoraction_test.go
+++ b/apis/operatoraction_test.go
@@ -1,0 +1,78 @@
+package apis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestOperatorActionArgsRoundTrip(t *testing.T) {
+	in := OperatorActionArgs{
+		Action: OperatorActionQuarantine,
+		Target: &OperatorActionTarget{
+			Kind:      "Deployment",
+			Namespace: "payments",
+			Name:      "api",
+		},
+		Selector: &OperatorActionSelector{
+			Control:     "C-0016",
+			MinSeverity: "High",
+		},
+		FindingRef: "workloadconfigurationscansummaries/payments/api",
+		DryRun:     boolPtr(true),
+		TTL:        "24h",
+		Reason:     "C-0016 allowPrivilegeEscalation",
+	}
+
+	m, err := in.ToArgs()
+	require.NoError(t, err)
+
+	out, err := OperatorActionArgsFromMap(m)
+	require.NoError(t, err)
+	assert.Equal(t, in, out)
+}
+
+// A command carrying the typed args through the generic map should be
+// recoverable on the receiving (operator) side.
+func TestOperatorActionArgsViaCommand(t *testing.T) {
+	args, err := OperatorActionArgs{
+		Action: OperatorActionAnnotate,
+		Target: &OperatorActionTarget{Kind: "Deployment", Namespace: "default", Name: "web"},
+		DryRun: boolPtr(true),
+	}.ToArgs()
+	require.NoError(t, err)
+
+	c := Command{CommandName: TypeOperatorAction, Args: args}
+
+	got, err := OperatorActionArgsFromMap(c.Args)
+	require.NoError(t, err)
+	assert.Equal(t, OperatorActionAnnotate, got.Action)
+	assert.True(t, got.IsDryRun())
+	assert.Equal(t, "web", got.Target.Name)
+}
+
+// Safe-by-default: a producer that omits DryRun must be treated as a dry-run by
+// the operator, and must never round-trip into an explicit "apply".
+func TestOperatorActionArgsDryRunDefaultsSafe(t *testing.T) {
+	in := OperatorActionArgs{
+		Action: OperatorActionQuarantine,
+		Target: &OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
+	}
+	assert.True(t, in.IsDryRun(), "omitted DryRun must be treated as dry-run")
+
+	m, err := in.ToArgs()
+	require.NoError(t, err)
+	_, present := m["dryRun"]
+	assert.False(t, present, "omitted DryRun must not be serialized as an explicit value")
+
+	out, err := OperatorActionArgsFromMap(m)
+	require.NoError(t, err)
+	assert.True(t, out.IsDryRun(), "operator must read an omitted DryRun as a dry-run")
+
+	// Only an explicit false applies.
+	apply := OperatorActionArgs{Action: OperatorActionCordon, DryRun: boolPtr(false)}
+	assert.False(t, apply.IsDryRun())
+}


### PR DESCRIPTION
**Related issue:** [kubescape/kubescape#1770 — Kubescape CLI control over cluster operations](https://github.com/kubescape/kubescape/issues/1770)
**Design:** [kubescape/designs-and-proposals#5 — Kubescape CLI Control over Cluster Operations](https://github.com/kubescape/designs-and-proposals/pull/5) (merged)

## What this PR does

This is the **first, foundational PR** for the design above: it adds the typed
command contract that the CLI, operator, and (later) the ARMO synchronizer all
agree on. It is intentionally a thin, dependency-free schema change in
`armoapi-go` — no behavior, no cluster writes — so the rest of the work can build
on a stable contract.

- `apis/clusterapis.go`: new verb `TypeOperatorAction = "operatorAction"`, added
  to the existing `NotificationPolicyType` set alongside `kubescapeScan`, `scan`,
  etc.
- `apis/operatoraction.go`: the typed `Args` schema carried by that command —
  `OperatorActionArgs` (action, target, findings-driven selector, dry-run, TTL,
  reason, audit `findingRef`), the `OperatorActionType` verbs
  (`annotate`/`quarantine`/`cordon`/`revert`), plus `ToArgs`/`OperatorActionArgsFromMap`
  helpers to move between the typed struct and the generic
  `Command.Args map[string]interface{}`.
- `apis/operatoraction_test.go`: round-trip, via-`Command`, and safe-default tests.

## Why we need it

Issue  [kubescape/kubescape#1770 — Kubescape CLI control over cluster operations](https://github.com/kubescape/kubescape/issues/1770) converged on a concrete need (from the thread): act on scan findings
from the CLI — quarantine a workload, cordon a node, annotate a resource — instead
of hand-piping `kubescape scan` output into `kubectl`. Today there is no built-in
"scan → do something about it" path, so users wrap the CLI in fragile scripts with
no dry-run, no audit trail, and no safety rails.

The design's key insight is that the CLI→operator transport **already exists** (the
`apis.Command` pipeline behind `kubescape operator scan`). Remediation is a new
*verb* on that pipeline, not a new endpoint. This PR adds exactly that verb and its
payload schema — the single piece every downstream component depends on — so the
CLI, operator, and synchronizer can be developed against one fixed contract.

## Safe-by-default dry-run (design choice worth flagging)

The design makes "dry-run by default, only `--confirm` writes" a headline safety
property. To make that enforceable at the type level, `DryRun` is a `*bool`:

- absent (`nil`) or `true` → plan-only dry-run;
- only an explicit `false` (the CLI's `--confirm`) performs a real write.

This closes the Go zero-value trap where a plain `bool DryRun` would serialize an
omitted field as `false` (apply) and leave the operator unable to tell "forgot to
set it" from "meant to apply." Callers should use `OperatorActionArgs.IsDryRun()`
rather than dereferencing the field. The wire field name (`dryRun`) is unchanged
from the approved proposal.

## How this fits the incoming PRs

This contract is Phase 0→1 of the merged design's phasing. Subsequent PRs build on
it, in separate repos:

1. **`armoapi-go` (this PR):** the `operatorAction` command + typed `Args` schema.
2. **`operator`:** `case apis.TypeOperatorAction` in the dispatch switch, a
   `mainhandler/actionhandler.go` `Remediator` registry, and the first action
   (`annotate`) with dry-run — proving the end-to-end pipeline at ~zero blast radius.
3. **`kubescape` (CLI):** a `kubescape operator remediate <action>` subcommand,
   reusing the existing `v1/triggerAction` transport; `--dry-run` default,
   `--confirm` to apply.
4. **`operator` + `helm-charts`:** `quarantine` (deny-all NetworkPolicy + label),
   findings-driven targeting against stored scan-result CRDs, and opt-in mutating
   RBAC behind a Helm `capabilities.remediation` flag (default off).
5. **Later phases:** `cordon`, operator-native auto-remediation, TTL/auto-revert,
   and a Headlamp UI to preview/trigger via the `OperatorCommand` CRD.

The generic single-verb design (`operatorAction` + `Args.action`) is deliberate per
the proposal's resolved questions: it keeps the contract stable while future active-
response verbs (`kill`/`pause`/`stop`) are added without touching the core schema,
and it lets the ARMO commercial path wrap the very same `Command` through the
synchronizer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added operator action support for post-scan remediation with annotate, quarantine, cordon, and revert operations on cluster resources.
  * Actions can target specific resources or be driven by security findings.
  * Dry-run mode available for safe validation before actual cluster modifications.
  * Automatic revert support with configurable TTL for remediation actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->