### PR TITLE
feat(ai-sandbox): serving DTOs (AiSandboxInfo / AiSandboxInstanceInfo)

### DIFF
--- a/armotypes/ai_sandbox.go
+++ b/armotypes/ai_sandbox.go
@@ -34,6 +34,8 @@ type AiSandboxInfo struct {
 
 	HostID string `json:"hostID"`
 
+	ExposureFlags []string `json:"exposureFlags"`
+
 	// EnablementState is observing|active.
 	EnablementState string    `json:"enablementState"`
 	FirstSeen       time.Time `json:"firstSeen"`

--- a/armotypes/ai_sandbox.go
+++ b/armotypes/ai_sandbox.go
@@ -2,17 +2,17 @@ package armotypes
 
 import "time"
 
-// AiSandboxInfo is the shared serving DTO for one sandboxed subject — a
-// Kubernetes workload, an ECS service, or a host — in the AI-Sandbox
-// (AI-SPM) feature. It crosses repos: postgres-connector maps it to/from
-// the ai_sandboxes serving row and cadashboardbe serves it to the UI.
+// AiSandboxInfo is the WRITE model for one sandboxed subject — a Kubernetes
+// workload, an ECS service, or a host — in the AI-Sandbox (AI-SPM) feature.
+// Every field here is a STORED column: exactly what the aggregator upserts and
+// postgres-connector persists in the ai_sandboxes serving table. Row-lifecycle
+// timestamps (created/updated/deleted) live on the gorm model, not here.
 //
-// Only STORED serving fields appear here. Counters (instance_count,
-// models_count, connectors_count) are computed at serving time, policy
-// state and row-lifecycle timestamps (created/updated/deleted) are not
-// part of the serving contract, and live-join fields (risk_factors,
-// is_internet_facing, entity_type, ...) are resolved at serving time and
-// are intentionally absent.
+// The UI does not consume AiSandboxInfo directly — it consumes AiSandboxView,
+// which embeds this record and adds the fields produced at serving time
+// (counters, risk_factors, is_internet_facing, entity_type, ai_*_providers).
+// Splitting the two keeps the write contract (what we store) distinct from the
+// read contract (what we serve).
 type AiSandboxInfo struct {
 	CustomerGUID string `json:"customerGUID"`
 	ResourceHash string `json:"resourceHash"`
@@ -40,6 +40,39 @@ type AiSandboxInfo struct {
 	EnablementState string    `json:"enablementState"`
 	FirstSeen       time.Time `json:"firstSeen"`
 	LastSeen        time.Time `json:"lastSeen"`
+}
+
+// AiSandboxView is the READ model for the AI-Sandbox UI: one row in the sandbox
+// list (and the source for the header). It composes the persisted AiSandboxInfo
+// record with the fields that are NOT stored but produced at serving time, so
+// the UI binds to one complete shape regardless of each field's provenance.
+//
+// Provenance of the added fields:
+//   - Counters are computed at serving time by COUNTing the per-subject detail
+//     tables — there are no stored counter columns, which avoids drift:
+//     instanceCount   ← COUNT(ai_sandbox_instances)              [available now]
+//     modelsCount     ← COUNT(distinct models)                   [R-L7; 0 until]
+//     connectorsCount ← COUNT(mcp_servers)+COUNT(external_svcs)  [R-L7; 0 until]
+//   - The remaining fields are joined live from workload_statuses on
+//     (customer_guid, resource_hash); they are display-only header/badge inputs
+//     the platform already owns.
+//
+// The aggregator never populates these; the serving query (cadashboardbe) does.
+// On the write path they are simply absent.
+type AiSandboxView struct {
+	AiSandboxInfo `json:",inline"`
+
+	// Computed at serving time (COUNT over the per-subject detail tables).
+	InstanceCount   int `json:"instanceCount"`
+	ModelsCount     int `json:"modelsCount"`
+	ConnectorsCount int `json:"connectorsCount"`
+
+	// Joined live from workload_statuses on (customer_guid, resource_hash).
+	AIClientProviders []string `json:"aiClientProviders"`
+	AIServerProviders []string `json:"aiServerProviders"`
+	RiskFactors       []string `json:"riskFactors"`
+	IsInternetFacing  bool     `json:"isInternetFacing"`
+	EntityType        string   `json:"entityType"`
 }
 
 // AiSandboxInstanceInfo is the shared serving DTO for one running unit of

--- a/armotypes/ai_sandbox.go
+++ b/armotypes/ai_sandbox.go
@@ -17,8 +17,11 @@ type AiSandboxInfo struct {
 	CustomerGUID string `json:"customerGUID"`
 	ResourceHash string `json:"resourceHash"`
 
-	// HostType is the kind of host running the subject:
-	// kubernetes|ecs-ec2|ecs-fargate|ec2.
+	// HostType is the kind of host running the subject. Values are the
+	// platform's canonical HostType constants (this package):
+	// HostTypeKubernetes|HostTypeEcsEc2|HostTypeEcsFargate|HostTypeEc2 — never a
+	// hand-written literal. Kept as string here to match the stored column type;
+	// producers must assign string(armotypes.HostType*) values.
 	HostType string `json:"hostType"`
 	WLID     string `json:"wlid"`
 	Name     string `json:"name"`

--- a/armotypes/ai_sandbox.go
+++ b/armotypes/ai_sandbox.go
@@ -1,0 +1,58 @@
+package armotypes
+
+import "time"
+
+// AiSandboxInfo is the shared serving DTO for one sandboxed subject — a
+// Kubernetes workload, an ECS service, or a host — in the AI-Sandbox
+// (AI-SPM) feature. It crosses repos: postgres-connector maps it to/from
+// the ai_sandboxes serving row and cadashboardbe serves it to the UI.
+//
+// Only STORED serving fields appear here. Counters (instance_count,
+// models_count, connectors_count) are computed at serving time, policy
+// state and row-lifecycle timestamps (created/updated/deleted) are not
+// part of the serving contract, and live-join fields (risk_factors,
+// is_internet_facing, entity_type, ...) are resolved at serving time and
+// are intentionally absent.
+type AiSandboxInfo struct {
+	CustomerGUID string `json:"customerGUID"`
+	ResourceHash string `json:"resourceHash"`
+
+	// HostType is the kind of host running the subject:
+	// kubernetes|ecs-ec2|ecs-fargate|ec2.
+	HostType string `json:"hostType"`
+	WLID     string `json:"wlid"`
+	Name     string `json:"name"`
+
+	Account       string `json:"account"`
+	Region        string `json:"region"`
+	CloudProvider string `json:"cloudProvider"`
+
+	Cluster      string `json:"cluster"`
+	Namespace    string `json:"namespace"`
+	Kind         string `json:"kind"`
+	WorkloadName string `json:"workloadName"`
+
+	HostID string `json:"hostID"`
+
+	// EnablementState is observing|active.
+	EnablementState string    `json:"enablementState"`
+	FirstSeen       time.Time `json:"firstSeen"`
+	LastSeen        time.Time `json:"lastSeen"`
+}
+
+// AiSandboxInstanceInfo is the shared serving DTO for one running unit of
+// a sandboxed subject — a Kubernetes pod or an ECS task.
+type AiSandboxInstanceInfo struct {
+	CustomerGUID string `json:"customerGUID"`
+	InstanceRef  string `json:"instanceRef"`
+
+	WLID         string `json:"wlid"`
+	ResourceHash string `json:"resourceHash"`
+
+	Status  string `json:"status"`
+	Node    string `json:"node"`
+	PodName string `json:"podName"`
+
+	FirstSeen time.Time `json:"firstSeen"`
+	LastSeen  time.Time `json:"lastSeen"`
+}


### PR DESCRIPTION
Add the shared serving DTOs for the AI-Sandbox (AI-SPM) feature to the shared types repo so they cross postgres-connector → cadashboardbe.

## What

- `armotypes/ai_sandbox.go` with two structs (camelCase json tags):
  - `AiSandboxInfo` — stored serving fields only: CustomerGUID, ResourceHash, HostType (kubernetes|ecs-ec2|ecs-fargate|ec2), WLID, Name, Account, Region, CloudProvider, Cluster, Namespace, Kind, WorkloadName, HostID, EnablementState, FirstSeen, LastSeen.
  - `AiSandboxInstanceInfo` — CustomerGUID, InstanceRef, WLID, ResourceHash, Status, Node, PodName, FirstSeen, LastSeen.

## Notes

- No counters, no policy_mode, no created/updated/deleted timestamps, no join-live fields (resolved at serving time).
- Consumed by postgres-connector PR #1426 (`feat/ai-sandbox-serving-tables`), which drops its local DTO copies and points go.mod at this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AI Sandbox support for tracking and managing sandboxed workloads and instances across Kubernetes, ECS, and host environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->