### PR TITLE
feat(ai-sandbox): AiSandboxEvent DTO + AIReachableEndpoints field

### DIFF
--- a/armotypes/ai_sandbox.go
+++ b/armotypes/ai_sandbox.go
@@ -108,24 +108,28 @@ type AiSandboxInstanceInfo struct {
 
 // AiSandboxEvent is the shared READ DTO for one row of the per-sandbox Activity
 // & Events surface (UI Track D). It mirrors the lake-backed ai_sandbox_events
-// serving table (a hot, short-TTL table) — every json tag is the stored column
-// name the aggregator/SILVER writes and cadashboardbe reads. This is a clean
-// read model: producers project rows into it, the UI binds to it; there is no
-// separate write split because events are append-only and never upserted.
+// serving table (a hot, short-TTL table). The json tags are the armoapi DTO
+// (camelCase) convention shared with the sibling AiSandbox* types; the stored
+// BRONZE/serving columns are the snake_case envelope keys (event_time,
+// instance_ref, exe_path, …) the aggregator/SILVER writes and cadashboardbe
+// reads, mapped to these fields. This is a clean read model: producers project
+// rows into it, the UI binds to it; there is no separate write split because
+// events are append-only and never upserted.
 //
 // Envelope keys identify the sandboxed subject and the running unit that emitted
 // the event, joining back to ai_sandboxes / ai_sandbox_instances on
 // (customer_guid, resource_hash) and instance_ref.
 //
 // The typed process fields (ExePath, Argv, Cwd, Pid, Ppid, ParentExePath) are
-// populated NOW for R-PROC process-exec events; other event layers
-// (net/dns/http/file/syscall) carry their type-specific payload in Detail until
-// they get first-class fields. Verdict/Rule/PolicyRef are enforcement stubs
-// reserved per the policies-descoped decision — always empty for now.
+// populated NOW for R-PROC-1 (process-exec, EventType == EventTypeExec) events;
+// other event families (network/dns/http/file/syscall) carry their type-specific
+// payload in Detail until they get first-class fields. Verdict/Rule/PolicyRef are
+// enforcement stubs reserved per the policies-descoped decision — always empty
+// for now.
 //
 // NOTE: the contract keeps a generic `detail` jsonb column for not-yet-typed
-// event layers; it is surfaced here as a raw json.RawMessage so the read model
-// stays lossless without committing to a schema for those layers yet.
+// event families; it is surfaced here as a raw json.RawMessage so the read model
+// stays lossless without committing to a schema for those families yet.
 type AiSandboxEvent struct {
 	CustomerGUID string `json:"customerGUID"`
 	ResourceHash string `json:"resourceHash"`
@@ -134,14 +138,22 @@ type AiSandboxEvent struct {
 
 	EventTime time.Time `json:"eventTime"`
 
-	// EventLayer is the event family/discriminator: net|dns|http|proc|file|syscall.
-	EventLayer string `json:"eventLayer"`
-	// EventType is the specific event within the layer (e.g. "process-exec").
-	EventType string `json:"eventType"`
+	// EventFamily is the node-agent's `event.family` envelope value — the R-*
+	// family the agent emits (R-PROC-1, R-NET-1, R-NET-2/DNS, R-L7-1/HTTP,
+	// R-FILE-1, R-SYSCALL-1). Kept as string to mirror the stored column; it is
+	// NOT a new net|proc|file vocabulary.
+	EventFamily string `json:"eventFamily"`
+	// EventType is the specific event within the family, using the shared
+	// armotypes.EventType vocabulary (EventTypeExec=="exec", EventTypeDNS=="dns",
+	// EventTypeHTTP=="http", …) — the same string values the node-agent emits in
+	// the `event_type` envelope key. Process-exec events carry EventTypeExec.
+	EventType EventType `json:"eventType"`
 	// Summary is a short human-readable description for the activity feed.
 	Summary string `json:"summary,omitempty"`
 
-	// R-PROC process-exec typed fields (populated NOW for proc events).
+	// R-PROC-1 process-exec typed fields (populated NOW for EventTypeExec events).
+	// Field names mirror the agent's structured attrs / BRONZE columns:
+	// exe_path, argv, cwd, pid, ppid, parent_exe_path.
 	ExePath       string   `json:"exePath,omitempty"`
 	Argv          []string `json:"argv,omitempty"`
 	Cwd           string   `json:"cwd,omitempty"`

--- a/armotypes/ai_sandbox.go
+++ b/armotypes/ai_sandbox.go
@@ -5,6 +5,35 @@ import (
 	"time"
 )
 
+// AiSandboxAIEndpoint observation source: how the endpoint was detected.
+const (
+	AiSandboxEndpointSourceDNS = "dns" // DNS resolution — reachability, NOT confirmed usage
+	AiSandboxEndpointSourceL7  = "l7"  // R-L7 structured payload — confirmed usage
+)
+
+// AiSandboxAIEndpoint plane/kind: which face of the provider the endpoint is.
+const (
+	AiSandboxEndpointKindInference    = "inference"     // model data-plane (bedrock-runtime, api.openai.com)
+	AiSandboxEndpointKindControlPlane = "control-plane" // management API (bedrock.<region>)
+	AiSandboxEndpointKindModelHost    = "model-host"    // model hosting (sagemaker)
+)
+
+// AiSandboxAIEndpoint is one AI-provider endpoint a sandboxed workload is
+// observed contacting. v1 entries are DNS-derived (Source="dns" → reachability,
+// not confirmed usage); the R-L7 payload later adds confirmed-usage entries
+// (Source="l7"). It is the lightweight precursor of the
+// ai_sandbox_external_services detail model — same host/provider keying, ready
+// to merge when typed L7 lands.
+type AiSandboxAIEndpoint struct {
+	Host      string     `json:"host"`                // e.g. bedrock-runtime.us-east-1.amazonaws.com
+	Provider  string     `json:"provider,omitempty"`  // aligns to workload_statuses ai_client_providers vocab, e.g. "AWS Bedrock"
+	Kind      string     `json:"kind,omitempty"`      // one of AiSandboxEndpointKind*
+	Region    string     `json:"region,omitempty"`    // e.g. us-east-1 (when derivable from the host)
+	Source    string     `json:"source"`              // one of AiSandboxEndpointSource*
+	FirstSeen *time.Time `json:"firstSeen,omitempty"` // first observation in the rollup window
+	LastSeen  *time.Time `json:"lastSeen,omitempty"`  // most recent observation
+}
+
 // AiSandboxInfo is the WRITE model for one sandboxed subject — a Kubernetes
 // workload, an ECS service, or a host — in the AI-Sandbox (AI-SPM) feature.
 // Every field here is a STORED column: exactly what the aggregator upserts and
@@ -42,13 +71,14 @@ type AiSandboxInfo struct {
 
 	ExposureFlags []string `json:"exposureFlags"`
 
-	// AIReachableEndpoints is the set of AI-provider hosts the workload's DNS
-	// resolution shows it can contact — e.g. bedrock-runtime, *.openai.com,
-	// *.anthropic.com, generativelanguage.googleapis.com. This is DNS-derived
-	// REACHABILITY (the workload resolved/can reach these hosts), NOT confirmed
-	// usage: presence here does not imply the workload actually issued an AI call.
-	// Stored on the subject row so it flows into AiSandboxView via the embed.
-	AIReachableEndpoints []string `json:"aiReachableEndpoints,omitempty"`
+	// AIEndpoints is the set of AI-provider endpoints the workload is observed
+	// contacting (e.g. bedrock-runtime.us-east-1, api.openai.com), each with its
+	// provider/plane/region. v1 entries are DNS-derived (Source="dns" →
+	// REACHABILITY, not confirmed usage); the R-L7 payload later adds confirmed
+	// rows (Source="l7") with model/token detail. This is the lightweight
+	// precursor of the ai_sandbox_external_services detail model. Stored on the
+	// subject row so it flows into AiSandboxView via the embed.
+	AIEndpoints []AiSandboxAIEndpoint `json:"aiEndpoints,omitempty"`
 
 	// EnablementState is observing|active.
 	EnablementState string    `json:"enablementState"`

--- a/armotypes/ai_sandbox.go
+++ b/armotypes/ai_sandbox.go
@@ -200,9 +200,18 @@ type AiSandboxEvent struct {
 	// Summary is a short human-readable description for the activity feed.
 	Summary string `json:"summary,omitempty"`
 
+	// LogRecordUID carries the OTel log.record.uid — the agent's globally-unique
+	// per-event id — and is the canonical dedup key for the ai_sandbox_events
+	// serving table (the lake already dedups on it; PG should too, instead of a
+	// fragile composite key).
+	LogRecordUID string `json:"logRecordUID,omitempty"`
+
 	// SessionID and Turn are stamped during SILVER sessionization (R-L7).
+	// Turn is a pointer so that nil means "not yet sessionized" and a stamped
+	// first-turn value of 0 is preserved (plain int + omitempty would silently
+	// drop a real zero, making turn 0 indistinguishable from "unsessionized").
 	SessionID string `json:"sessionID,omitempty"`
-	Turn      int    `json:"turn,omitempty"`
+	Turn      *int   `json:"turn,omitempty"`
 
 	// Detail carries the type-specific payload for event layers that do not yet
 	// have first-class fields (the contract's `detail` jsonb column).

--- a/armotypes/ai_sandbox.go
+++ b/armotypes/ai_sandbox.go
@@ -136,6 +136,24 @@ type AiSandboxInstanceInfo struct {
 	LastSeen  time.Time `json:"lastSeen"`
 }
 
+// AiSandboxEvent.EventLayer — UI grouping of an activity event by protocol/kind.
+// Derived at serving time from the agent's event_type (exec→proc, network→net,
+// open→file, …); the UI groups/filters the Activity feed by these.
+const (
+	AiSandboxEventLayerNetwork = "net"
+	AiSandboxEventLayerDNS     = "dns"
+	AiSandboxEventLayerHTTP    = "http"
+	AiSandboxEventLayerProcess = "proc"
+	AiSandboxEventLayerFile    = "file"
+	AiSandboxEventLayerSyscall = "syscall"
+)
+
+// AiSandboxEvent.Direction — for the network/L7 layers (egress vs ingress, audit R5).
+const (
+	AiSandboxEventDirectionIngress = "ingress"
+	AiSandboxEventDirectionEgress  = "egress"
+)
+
 // AiSandboxEvent is the shared READ DTO for one row of the per-sandbox Activity
 // & Events surface (UI Track D). It mirrors the lake-backed ai_sandbox_events
 // serving table (a hot, short-TTL table). The json tags are the armoapi DTO
@@ -150,12 +168,11 @@ type AiSandboxInstanceInfo struct {
 // the event, joining back to ai_sandboxes / ai_sandbox_instances on
 // (customer_guid, resource_hash) and instance_ref.
 //
-// The typed process fields (ExePath, Argv, Cwd, Pid, Ppid, ParentExePath) are
-// populated NOW for R-PROC-1 (process-exec, EventType == EventTypeExec) events;
-// other event families (network/dns/http/file/syscall) carry their type-specific
-// payload in Detail until they get first-class fields. Verdict/Rule/PolicyRef are
-// enforcement stubs reserved per the policies-descoped decision — always empty
-// for now.
+// Type-specific payload (R-PROC-1 exe_path/argv/cwd/pid/ppid/parent_exe_path now;
+// host/method/model for L7 later) lives in the generic Detail jsonb — so the
+// hot-table column set stays STABLE as network/dns/http/file/syscall layers come
+// online, no column-per-type sprawl. Verdict/Rule/PolicyRef are enforcement stubs
+// reserved per the policies-descoped decision — always empty for now.
 //
 // NOTE: the contract keeps a generic `detail` jsonb column for not-yet-typed
 // event families; it is surfaced here as a raw json.RawMessage so the read model
@@ -168,28 +185,20 @@ type AiSandboxEvent struct {
 
 	EventTime time.Time `json:"eventTime"`
 
-	// EventFamily is the node-agent's `event.family` envelope value — the R-*
-	// family the agent emits (R-PROC-1, R-NET-1, R-NET-2/DNS, R-L7-1/HTTP,
-	// R-FILE-1, R-SYSCALL-1). Kept as string to mirror the stored column; it is
-	// NOT a new net|proc|file vocabulary.
-	EventFamily string `json:"eventFamily"`
-	// EventType is the specific event within the family, using the shared
+	// EventLayer is the UI grouping of the event by protocol/kind — one of
+	// AiSandboxEventLayer* (net/dns/http/proc/file/syscall). Derived at serving
+	// time from EventType (exec→proc, network→net, open→file, …).
+	EventLayer string `json:"eventLayer,omitempty"`
+	// Direction applies to the network/L7 layers — AiSandboxEventDirection*
+	// (ingress/egress). Empty for proc/file/syscall.
+	Direction string `json:"direction,omitempty"`
+	// EventType is the specific event, using the shared
 	// armotypes.EventType vocabulary (EventTypeExec=="exec", EventTypeDNS=="dns",
 	// EventTypeHTTP=="http", …) — the same string values the node-agent emits in
 	// the `event_type` envelope key. Process-exec events carry EventTypeExec.
 	EventType EventType `json:"eventType"`
 	// Summary is a short human-readable description for the activity feed.
 	Summary string `json:"summary,omitempty"`
-
-	// R-PROC-1 process-exec typed fields (populated NOW for EventTypeExec events).
-	// Field names mirror the agent's structured attrs / BRONZE columns:
-	// exe_path, argv, cwd, pid, ppid, parent_exe_path.
-	ExePath       string   `json:"exePath,omitempty"`
-	Argv          []string `json:"argv,omitempty"`
-	Cwd           string   `json:"cwd,omitempty"`
-	Pid           int      `json:"pid,omitempty"`
-	Ppid          int      `json:"ppid,omitempty"`
-	ParentExePath string   `json:"parentExePath,omitempty"`
 
 	// SessionID and Turn are stamped during SILVER sessionization (R-L7).
 	SessionID string `json:"sessionID,omitempty"`

--- a/armotypes/ai_sandbox.go
+++ b/armotypes/ai_sandbox.go
@@ -1,6 +1,9 @@
 package armotypes
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // AiSandboxInfo is the WRITE model for one sandboxed subject — a Kubernetes
 // workload, an ECS service, or a host — in the AI-Sandbox (AI-SPM) feature.
@@ -38,6 +41,14 @@ type AiSandboxInfo struct {
 	HostID string `json:"hostID"`
 
 	ExposureFlags []string `json:"exposureFlags"`
+
+	// AIReachableEndpoints is the set of AI-provider hosts the workload's DNS
+	// resolution shows it can contact — e.g. bedrock-runtime, *.openai.com,
+	// *.anthropic.com, generativelanguage.googleapis.com. This is DNS-derived
+	// REACHABILITY (the workload resolved/can reach these hosts), NOT confirmed
+	// usage: presence here does not imply the workload actually issued an AI call.
+	// Stored on the subject row so it flows into AiSandboxView via the embed.
+	AIReachableEndpoints []string `json:"aiReachableEndpoints,omitempty"`
 
 	// EnablementState is observing|active.
 	EnablementState string    `json:"enablementState"`
@@ -93,4 +104,61 @@ type AiSandboxInstanceInfo struct {
 
 	FirstSeen time.Time `json:"firstSeen"`
 	LastSeen  time.Time `json:"lastSeen"`
+}
+
+// AiSandboxEvent is the shared READ DTO for one row of the per-sandbox Activity
+// & Events surface (UI Track D). It mirrors the lake-backed ai_sandbox_events
+// serving table (a hot, short-TTL table) — every json tag is the stored column
+// name the aggregator/SILVER writes and cadashboardbe reads. This is a clean
+// read model: producers project rows into it, the UI binds to it; there is no
+// separate write split because events are append-only and never upserted.
+//
+// Envelope keys identify the sandboxed subject and the running unit that emitted
+// the event, joining back to ai_sandboxes / ai_sandbox_instances on
+// (customer_guid, resource_hash) and instance_ref.
+//
+// The typed process fields (ExePath, Argv, Cwd, Pid, Ppid, ParentExePath) are
+// populated NOW for R-PROC process-exec events; other event layers
+// (net/dns/http/file/syscall) carry their type-specific payload in Detail until
+// they get first-class fields. Verdict/Rule/PolicyRef are enforcement stubs
+// reserved per the policies-descoped decision — always empty for now.
+//
+// NOTE: the contract keeps a generic `detail` jsonb column for not-yet-typed
+// event layers; it is surfaced here as a raw json.RawMessage so the read model
+// stays lossless without committing to a schema for those layers yet.
+type AiSandboxEvent struct {
+	CustomerGUID string `json:"customerGUID"`
+	ResourceHash string `json:"resourceHash"`
+	WLID         string `json:"wlid"`
+	InstanceRef  string `json:"instanceRef"`
+
+	EventTime time.Time `json:"eventTime"`
+
+	// EventLayer is the event family/discriminator: net|dns|http|proc|file|syscall.
+	EventLayer string `json:"eventLayer"`
+	// EventType is the specific event within the layer (e.g. "process-exec").
+	EventType string `json:"eventType"`
+	// Summary is a short human-readable description for the activity feed.
+	Summary string `json:"summary,omitempty"`
+
+	// R-PROC process-exec typed fields (populated NOW for proc events).
+	ExePath       string   `json:"exePath,omitempty"`
+	Argv          []string `json:"argv,omitempty"`
+	Cwd           string   `json:"cwd,omitempty"`
+	Pid           int      `json:"pid,omitempty"`
+	Ppid          int      `json:"ppid,omitempty"`
+	ParentExePath string   `json:"parentExePath,omitempty"`
+
+	// SessionID and Turn are stamped during SILVER sessionization (R-L7).
+	SessionID string `json:"sessionID,omitempty"`
+	Turn      int    `json:"turn,omitempty"`
+
+	// Detail carries the type-specific payload for event layers that do not yet
+	// have first-class fields (the contract's `detail` jsonb column).
+	Detail json.RawMessage `json:"detail,omitempty"`
+
+	// Enforcement stubs — descoped (policies). Always empty for now.
+	Verdict   string `json:"verdict,omitempty"`
+	Rule      string `json:"rule,omitempty"`
+	PolicyRef string `json:"policyRef,omitempty"`
 }


### PR DESCRIPTION
## What

Two shared DTO additions in `armotypes/ai_sandbox.go` for the AI Sandbox (AI-SPM) feature.

### 1. `AiSandboxEvent` — read DTO for the Activity & Events surface (UI Track D)
Mirrors the lake-backed `ai_sandbox_events` serving table (hot, short-TTL). Clean read model — append-only events, no write/read split. Shape sourced from `specs/ai-sandbox-serving-contract.md` (`ai_sandbox_events` [PARTIAL-NOW]):
- Envelope keys: `customerGUID`, `resourceHash`, `wlid`, `instanceRef`
- `eventTime`, `eventLayer` (net/dns/http/proc/file/syscall discriminator), `eventType`, `summary`
- R-PROC process-exec typed fields populated NOW: `exePath`, `argv`, `cwd`, `pid`, `ppid`, `parentExePath`
- `sessionID` + `turn` (stamped in SILVER sessionization, R-L7)
- `detail` (raw `json.RawMessage`) for not-yet-typed event layers
- Nullable enforcement stubs `verdict`/`rule`/`policyRef` — descoped per the policies decision, always empty for now

### 2. `AIReachableEndpoints []string` on `AiSandboxInfo`
DNS-derived set of AI-provider hosts the workload can reach (e.g. bedrock-runtime, `*.openai.com`, `*.anthropic.com`, generativelanguage.googleapis.com). It is **reachability (not confirmed usage)** — a DNS-derived signal. Stored on the subject row so it flows into `AiSandboxView` via the embed. `json:"aiReachableEndpoints,omitempty"`.

## Notes
- Types-only repo; `go build ./...` + `go test ./armotypes/...` green (150 passed).
- Downstream (postgres-connector, event-ingester, cadashboardbe) will re-pin armoapi-go after this releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced AI sandbox event tracking with timestamped activity records and detailed event information
  * Improved monitoring of AI provider endpoint reachability for better visibility into sandbox operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->