### PR TITLE
feat(ai-sandbox): K8s RBAC permission DTOs

### DIFF
--- a/armotypes/ai_sandbox.go
+++ b/armotypes/ai_sandbox.go
@@ -222,3 +222,26 @@ type AiSandboxEvent struct {
 	Rule      string `json:"rule,omitempty"`
 	PolicyRef string `json:"policyRef,omitempty"`
 }
+
+// AiSandboxK8sPermission is one Kubescape RBAC/posture control finding attributed
+// to a K8s sandbox subject (read-time join over resource_control_results, scoped
+// to the latest cluster posture report). Severity is intentionally absent — it
+// lives in the Kubescape catalog, not Postgres. Status mirrors control_scan_results
+// ("passed"|"failed"|"skipped").
+type AiSandboxK8sPermission struct {
+	ControlID   string `json:"controlID"`             // e.g. "C-0267"
+	ControlName string `json:"controlName,omitempty"` // e.g. "Workload with cluster takeover roles"
+	Status      string `json:"status"`                // passed|failed|skipped
+	Framework   string `json:"framework,omitempty"`   // e.g. "AllControls"
+}
+
+// AiSandboxPermissionsSummary is the rolled-up RBAC posture of a subject: counts
+// by status plus the failed RBAC control names (the "permissions risk badges").
+type AiSandboxPermissionsSummary struct {
+	Section        string                   `json:"section"` // "k8s"
+	FailedCount    int                      `json:"failedCount"`
+	PassedCount    int                      `json:"passedCount"`
+	SkippedCount   int                      `json:"skippedCount"`
+	FailedControls []string                 `json:"failedControls,omitempty"` // human names, failed only
+	Findings       []AiSandboxK8sPermission `json:"findings,omitempty"`
+}


### PR DESCRIPTION
## What
Adds the DTOs for the H-K8S Kubernetes RBAC permissions read-model:
- `AiSandboxK8sPermission` — one Kubescape RBAC/posture control finding attributed to a K8s sandbox subject (controlID, controlName, status, framework). Severity omitted (Kubescape-catalog-only, not in PG).
- `AiSandboxPermissionsSummary` — rolled-up posture: counts by status + failed RBAC control names + findings.

## Why
Base of the H-K8S permissions stack (read-time, PG-native): surfaces each K8s AI-Sandbox subject's RBAC risk ("cluster takeover roles", "access to secrets", …) from existing posture data, no agent change.

## Stack (branch-pinned, reviewable in parallel)
- **armoapi-go (this PR)** → postgres-connector (getter) → cadashboardbe (endpoint).
- Downstream PRs pin go.mod to this PR's commit; re-pin to the released tag after merge.

Plan: `specs/2026-06-15-ai-sandbox-h-k8s-rbac-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)