### PR TITLE
feat(ai-sandbox): AiSandboxInstanceView DTO for instance-primary list

### DIFF
--- a/armotypes/ai_sandbox.go
+++ b/armotypes/ai_sandbox.go
@@ -186,6 +186,33 @@ type AiSandboxInstanceInfo struct {
 	LastSeen  time.Time `json:"lastSeen"`
 }
 
+// AiSandboxInstanceView is the READ model for the instance-primary Sandboxes
+// list: one row per running unit (a Kubernetes pod or an ECS task), carrying a
+// compact summary of its parent workload — the subject that owns
+// identity/inventory/rollups. The list defaults to this instance axis; the
+// existing workload rows (AiSandboxView) are served under the groupBy=workload
+// toggle. Per-subject detail (identities/cloud/events) still resolves via the
+// instance's parent ResourceHash (already carried on the embedded
+// AiSandboxInstanceInfo), so the resolver is reused unchanged.
+//
+// The instance fields are persisted on ai_sandbox_instances; the parent-workload
+// summary is joined at serving time from the parent ai_sandboxes row (name/kind/
+// cluster/namespace) and the live workload_statuses join (AIClientProviders, the
+// AI badge) plus identity resolution (IdentityAdmin). Producers never populate
+// the summary; the serving query does. Every summary field is omitempty so a
+// bare instance row stays compact.
+type AiSandboxInstanceView struct {
+	AiSandboxInstanceInfo `json:",inline"` // instanceRef, resourceHash(parent), podName, status, node, first/lastSeen
+
+	// Parent-workload summary (the group this instance rolls up to):
+	WorkloadName      string   `json:"workloadName,omitempty"`
+	Kind              string   `json:"kind,omitempty"`
+	Cluster           string   `json:"cluster,omitempty"`
+	Namespace         string   `json:"namespace,omitempty"`
+	AIClientProviders []string `json:"aiClientProviders,omitempty"` // the AI badge, from the subject's workload_statuses
+	IdentityAdmin     bool     `json:"identityAdmin,omitempty"`     // any workload identity is admin (k8s or cloud)
+}
+
 // AiSandboxEvent.EventLayer — UI grouping of an activity event by protocol/kind.
 // Derived at serving time from the agent's event_type (exec→proc, network→net,
 // open→file, …); the UI groups/filters the Activity feed by these.


### PR DESCRIPTION
## What

Adds `AiSandboxInstanceView` — the read row for the **instance-primary** Sandboxes list (D-LIST-1): one row per running unit (pod / ECS task). It embeds the existing `AiSandboxInstanceInfo` (instanceRef, parent resourceHash, podName, status, node, first/last seen) and adds a compact **parent-workload summary** (`workloadName`, `kind`, `cluster`, `namespace`, `aiClientProviders`, `identityAdmin`), all `omitempty`.

## Why

The visual design's list shows instances, not workloads. Ratified as a U6 reversal (**D-LIST-1**, 2026-06-16). The workload stays the subject that owns identity/inventory; an instance row carries a summary of its parent. See `specs/2026-06-16-ai-sandbox-instance-list-impact.md`.

## Notes

Purely additive — no change to any existing type, so the `groupBy=workload` (workload-view) wire shape (`AiSandboxView`) is byte-identical. `identityAdmin` is a Phase-1 placeholder (resolved later cadashboardbe-side; absent/false until then).

## Stack (base → top)

1. **this PR** — DTO
2. armosec/postgres-connector#1434 — getter
3. armosec/cadashboardbe#2880 — /list toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)