### PR TITLE
chore(tickets): remove unused Severity field from Ticket

### DIFF
--- a/armotypes/integrationtypes.go
+++ b/armotypes/integrationtypes.go
@@ -19,7 +19,6 @@ type Ticket struct {
 	Link           string              `json:"link,omitempty"`           //link to the ticket
 	Status         string              `json:"status,omitempty"`         //status of the ticket
 	LinkTitle      string              `json:"linkTitle,omitempty"`      //title of the ticket
-	Severity       string              `json:"severity,omitempty"`       //severity of the ticket
 	Error          string              `json:"error,omitempty"`          //error message if any
 	ErrorCode      int                 `json:"errorCode,omitempty"`      //error code if any (e.g. http status code like 401)
 	ProviderData   map[string]string   `json:"providerData,omitempty"`   //provider specific data


### PR DESCRIPTION
## What

Removes the `Severity` field from the `armotypes.Ticket` struct (`armotypes/integrationtypes.go`).

## Why

The field was written (from the provider's priority, or `"unknown"`) but **never read for any logic, never persisted, and never consumed by the frontend** (`ITicket` has no `severity` field). Confirmed unused org-wide via code search across every repo importing `armotypes.Ticket`:

- cadashboardbe (only writes/emptiness-checks — removed separately)
- postgres-connector, event-ingester-service, config-service, armosec-infra
- armo-ng-app, users-notification-service

Part of **SUB-7420**. The companion cadashboardbe PR removes all usage; once this merges and releases, cadashboardbe bumps to the field-less version.

## Risk

Low. `severity` was serialized in ticket JSON but no known consumer reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)