### PR TITLE
[LFX 2026] feat(armotypes): add ObjectSelector label selector to PostureExceptionPolicy

### DIFF
--- a/armotypes/postureexceptionpolicytypes.go
+++ b/armotypes/postureexceptionpolicytypes.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/armosec/armoapi-go/identifiers"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type PostureExceptionPolicyActions string
@@ -31,6 +32,11 @@ type PostureExceptionPolicy struct {
 	CreationTime    string                          `json:"creationTime,omitempty" bson:"creationTime,omitempty"`
 	Actions         []PostureExceptionPolicyActions `json:"actions,omitempty" bson:"actions,omitempty"`
 	Resources       []identifiers.PortalDesignator  `json:"resources" bson:"resources,omitempty"`
+	// ObjectSelector carries a full Kubernetes label selector (matchLabels + matchExpressions)
+	// for the exception's workload-matching axis. Unlike Resources (which encodes per-key regex
+	// designators), this is evaluated with labels.Selector semantics by the exception processor.
+	// A nil selector imposes no label constraint; it is never treated as match-all.
+	ObjectSelector  *metav1.LabelSelector           `json:"objectSelector,omitempty" bson:"objectSelector,omitempty"`
 	PosturePolicies []PosturePolicy                 `json:"posturePolicies,omitempty" bson:"posturePolicies,omitempty"`
 	Reason          *string                         `json:"reason,omitempty" bson:"reason,omitempty"`
 	ExpirationDate  *time.Time                      `json:"expirationDate,omitempty" bson:"expirationDate"`

--- a/armotypes/postureexceptionpolicytypes.go
+++ b/armotypes/postureexceptionpolicytypes.go
@@ -41,12 +41,50 @@ type PostureExceptionPolicy struct {
 	// entirely in those cases. Do NOT pass either straight to metav1.LabelSelectorAsSelector,
 	// whose conversion disagrees with that intent — nil yields labels.Nothing() (matches nothing)
 	// and an empty selector yields labels.Everything() (matches every workload). Guard for
-	// nil/empty before converting.
-	ObjectSelector  *metav1.LabelSelector           `json:"objectSelector,omitempty" bson:"objectSelector,omitempty"`
+	// nil/empty before converting; ObjectSelector.ToMetaV1() returns nil for a nil receiver.
+	ObjectSelector  *LabelSelector                  `json:"objectSelector,omitempty" bson:"objectSelector,omitempty"`
 	PosturePolicies []PosturePolicy                 `json:"posturePolicies,omitempty" bson:"posturePolicies,omitempty"`
 	Reason          *string                         `json:"reason,omitempty" bson:"reason,omitempty"`
 	ExpirationDate  *time.Time                      `json:"expirationDate,omitempty" bson:"expirationDate"`
 	CreatedBy       string                          `json:"createdBy,omitempty" bson:"createdBy,omitempty"`
+}
+
+// LabelSelector mirrors metav1.LabelSelector but carries explicit bson tags so the
+// persisted (Mongo) document keeps the same camelCase keys the JSON/API and CRD shapes
+// expose (matchLabels / matchExpressions). The upstream metav1 type declares json tags
+// only; the mongo-driver default encoder would otherwise lowercase the nested keys to
+// matchlabels / matchexpressions and diverge from the API contract.
+type LabelSelector struct {
+	MatchLabels      map[string]string          `json:"matchLabels,omitempty" bson:"matchLabels,omitempty"`
+	MatchExpressions []LabelSelectorRequirement `json:"matchExpressions,omitempty" bson:"matchExpressions,omitempty"`
+}
+
+// LabelSelectorRequirement mirrors metav1.LabelSelectorRequirement with explicit bson tags.
+type LabelSelectorRequirement struct {
+	Key      string                       `json:"key" bson:"key"`
+	Operator metav1.LabelSelectorOperator `json:"operator" bson:"operator"`
+	Values   []string                     `json:"values,omitempty" bson:"values,omitempty"`
+}
+
+// ToMetaV1 converts the selector to a metav1.LabelSelector for evaluation via
+// metav1.LabelSelectorAsSelector. It returns nil for a nil receiver; callers must still
+// treat a nil or empty result as "no label constraint" (see ObjectSelector).
+func (s *LabelSelector) ToMetaV1() *metav1.LabelSelector {
+	if s == nil {
+		return nil
+	}
+	out := &metav1.LabelSelector{MatchLabels: s.MatchLabels}
+	if len(s.MatchExpressions) > 0 {
+		out.MatchExpressions = make([]metav1.LabelSelectorRequirement, len(s.MatchExpressions))
+		for i, r := range s.MatchExpressions {
+			out.MatchExpressions[i] = metav1.LabelSelectorRequirement{
+				Key:      r.Key,
+				Operator: r.Operator,
+				Values:   r.Values,
+			}
+		}
+	}
+	return out
 }
 
 type PosturePolicy struct {

--- a/armotypes/postureexceptionpolicytypes.go
+++ b/armotypes/postureexceptionpolicytypes.go
@@ -35,7 +35,13 @@ type PostureExceptionPolicy struct {
 	// ObjectSelector carries a full Kubernetes label selector (matchLabels + matchExpressions)
 	// for the exception's workload-matching axis. Unlike Resources (which encodes per-key regex
 	// designators), this is evaluated with labels.Selector semantics by the exception processor.
-	// A nil selector imposes no label constraint; it is never treated as match-all.
+	//
+	// Both a nil selector and a non-nil but empty selector ({} / no matchLabels and no
+	// matchExpressions) mean "no label constraint": the consumer must skip the label axis
+	// entirely in those cases. Do NOT pass either straight to metav1.LabelSelectorAsSelector,
+	// whose conversion disagrees with that intent — nil yields labels.Nothing() (matches nothing)
+	// and an empty selector yields labels.Everything() (matches every workload). Guard for
+	// nil/empty before converting.
 	ObjectSelector  *metav1.LabelSelector           `json:"objectSelector,omitempty" bson:"objectSelector,omitempty"`
 	PosturePolicies []PosturePolicy                 `json:"posturePolicies,omitempty" bson:"posturePolicies,omitempty"`
 	Reason          *string                         `json:"reason,omitempty" bson:"reason,omitempty"`

--- a/armotypes/postureexceptionpolicytypes_test.go
+++ b/armotypes/postureexceptionpolicytypes_test.go
@@ -6,25 +6,33 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// TestPostureExceptionPolicyObjectSelectorRoundTrip verifies that a full label
-// selector (matchLabels + matchExpressions) survives a JSON marshal/unmarshal
-// round-trip on the ObjectSelector field.
-func TestPostureExceptionPolicyObjectSelectorRoundTrip(t *testing.T) {
-	policy := PostureExceptionPolicy{
-		ObjectSelector: &metav1.LabelSelector{
-			MatchLabels: map[string]string{"app": "nginx"},
-			MatchExpressions: []metav1.LabelSelectorRequirement{
-				{
-					Key:      "tier",
-					Operator: metav1.LabelSelectorOpIn,
-					Values:   []string{"frontend", "backend"},
-				},
+func objectSelectorFixture() *metav1.LabelSelector {
+	return &metav1.LabelSelector{
+		MatchLabels: map[string]string{"app": "nginx"},
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      "tier",
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"frontend", "backend"},
+			},
+			{
+				Key:      "track",
+				Operator: metav1.LabelSelectorOpNotIn,
+				Values:   []string{"canary"},
 			},
 		},
 	}
+}
+
+// TestPostureExceptionPolicyObjectSelectorRoundTrip verifies that a full label
+// selector (matchLabels + matchExpressions with multiple operators) survives a
+// JSON marshal/unmarshal round-trip on the ObjectSelector field.
+func TestPostureExceptionPolicyObjectSelectorRoundTrip(t *testing.T) {
+	policy := PostureExceptionPolicy{ObjectSelector: objectSelectorFixture()}
 
 	raw, err := json.Marshal(policy)
 	require.NoError(t, err)
@@ -36,11 +44,34 @@ func TestPostureExceptionPolicyObjectSelectorRoundTrip(t *testing.T) {
 	assert.Equal(t, policy.ObjectSelector, decoded.ObjectSelector)
 }
 
+// TestPostureExceptionPolicyObjectSelectorBSONRoundTrip pins the same selector
+// contract for the bson tag, since the field is persisted via mongo-driver too.
+func TestPostureExceptionPolicyObjectSelectorBSONRoundTrip(t *testing.T) {
+	policy := PostureExceptionPolicy{ObjectSelector: objectSelectorFixture()}
+
+	raw, err := bson.Marshal(policy)
+	require.NoError(t, err)
+
+	var decoded PostureExceptionPolicy
+	require.NoError(t, bson.Unmarshal(raw, &decoded))
+
+	require.NotNil(t, decoded.ObjectSelector)
+	assert.Equal(t, policy.ObjectSelector, decoded.ObjectSelector)
+}
+
 // TestPostureExceptionPolicyObjectSelectorOmitEmpty pins the contract that a nil
-// ObjectSelector is omitted from the serialized form (no label constraint), so a
+// ObjectSelector is absent from both serialized forms (no label constraint), so a
 // selector-less exception is never persisted as a match-all selector.
 func TestPostureExceptionPolicyObjectSelectorOmitEmpty(t *testing.T) {
-	raw, err := json.Marshal(PostureExceptionPolicy{})
+	jsonRaw, err := json.Marshal(PostureExceptionPolicy{})
 	require.NoError(t, err)
-	assert.NotContains(t, string(raw), "objectSelector")
+	var jsonFields map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(jsonRaw, &jsonFields))
+	assert.NotContains(t, jsonFields, "objectSelector")
+
+	bsonRaw, err := bson.Marshal(PostureExceptionPolicy{})
+	require.NoError(t, err)
+	var bsonFields map[string]bson.RawValue
+	require.NoError(t, bson.Unmarshal(bsonRaw, &bsonFields))
+	assert.NotContains(t, bsonFields, "objectSelector")
 }

--- a/armotypes/postureexceptionpolicytypes_test.go
+++ b/armotypes/postureexceptionpolicytypes_test.go
@@ -10,10 +10,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func objectSelectorFixture() *metav1.LabelSelector {
-	return &metav1.LabelSelector{
+func objectSelectorFixture() *LabelSelector {
+	return &LabelSelector{
 		MatchLabels: map[string]string{"app": "nginx"},
-		MatchExpressions: []metav1.LabelSelectorRequirement{
+		MatchExpressions: []LabelSelectorRequirement{
 			{
 				Key:      "tier",
 				Operator: metav1.LabelSelectorOpIn,
@@ -44,19 +44,47 @@ func TestPostureExceptionPolicyObjectSelectorRoundTrip(t *testing.T) {
 	assert.Equal(t, policy.ObjectSelector, decoded.ObjectSelector)
 }
 
-// TestPostureExceptionPolicyObjectSelectorBSONRoundTrip pins the same selector
-// contract for the bson tag, since the field is persisted via mongo-driver too.
+// TestPostureExceptionPolicyObjectSelectorBSONRoundTrip pins the selector contract for
+// the bson tag, since the field is persisted via mongo-driver too. It also asserts the
+// nested keys are stored as camelCase (matchLabels / matchExpressions) rather than the
+// lowercased fallback the metav1 type would produce, so persisted documents match the
+// JSON/API/CRD shape.
 func TestPostureExceptionPolicyObjectSelectorBSONRoundTrip(t *testing.T) {
 	policy := PostureExceptionPolicy{ObjectSelector: objectSelectorFixture()}
 
 	raw, err := bson.Marshal(policy)
 	require.NoError(t, err)
 
+	// Inspect the raw document keys, not just the symmetric round-trip.
+	var doc bson.M
+	require.NoError(t, bson.Unmarshal(raw, &doc))
+	selector, ok := doc["objectSelector"].(bson.M)
+	require.True(t, ok, "objectSelector must persist as a nested document")
+	assert.Contains(t, selector, "matchLabels")
+	assert.Contains(t, selector, "matchExpressions")
+	assert.NotContains(t, selector, "matchlabels")
+	assert.NotContains(t, selector, "matchexpressions")
+
 	var decoded PostureExceptionPolicy
 	require.NoError(t, bson.Unmarshal(raw, &decoded))
-
 	require.NotNil(t, decoded.ObjectSelector)
 	assert.Equal(t, policy.ObjectSelector, decoded.ObjectSelector)
+}
+
+// TestLabelSelectorToMetaV1 verifies the conversion to metav1.LabelSelector used by the
+// downstream exception comparator, including the nil-receiver guard.
+func TestLabelSelectorToMetaV1(t *testing.T) {
+	assert.Nil(t, (*LabelSelector)(nil).ToMetaV1())
+
+	got := objectSelectorFixture().ToMetaV1()
+	want := &metav1.LabelSelector{
+		MatchLabels: map[string]string{"app": "nginx"},
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{Key: "tier", Operator: metav1.LabelSelectorOpIn, Values: []string{"frontend", "backend"}},
+			{Key: "track", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"canary"}},
+		},
+	}
+	assert.Equal(t, want, got)
 }
 
 // TestPostureExceptionPolicyObjectSelectorOmitEmpty pins the contract that a nil

--- a/armotypes/postureexceptionpolicytypes_test.go
+++ b/armotypes/postureexceptionpolicytypes_test.go
@@ -1,0 +1,46 @@
+package armotypes
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestPostureExceptionPolicyObjectSelectorRoundTrip verifies that a full label
+// selector (matchLabels + matchExpressions) survives a JSON marshal/unmarshal
+// round-trip on the ObjectSelector field.
+func TestPostureExceptionPolicyObjectSelectorRoundTrip(t *testing.T) {
+	policy := PostureExceptionPolicy{
+		ObjectSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{"app": "nginx"},
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      "tier",
+					Operator: metav1.LabelSelectorOpIn,
+					Values:   []string{"frontend", "backend"},
+				},
+			},
+		},
+	}
+
+	raw, err := json.Marshal(policy)
+	require.NoError(t, err)
+
+	var decoded PostureExceptionPolicy
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+
+	require.NotNil(t, decoded.ObjectSelector)
+	assert.Equal(t, policy.ObjectSelector, decoded.ObjectSelector)
+}
+
+// TestPostureExceptionPolicyObjectSelectorOmitEmpty pins the contract that a nil
+// ObjectSelector is omitted from the serialized form (no label constraint), so a
+// selector-less exception is never persisted as a match-all selector.
+func TestPostureExceptionPolicyObjectSelectorOmitEmpty(t *testing.T) {
+	raw, err := json.Marshal(PostureExceptionPolicy{})
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "objectSelector")
+}

--- a/go.mod
+++ b/go.mod
@@ -20,8 +20,10 @@ require (
 	github.com/masahiro331/go-mvn-version v0.0.0-20250131095131-f4974fa13b8a
 	github.com/stretchr/testify v1.11.1
 	github.com/stripe/stripe-go/v74 v74.30.0
+	go.mongodb.org/mongo-driver v1.17.1
 	golang.org/x/exp v0.0.0-20250711185948-6ae5c78190dc
 	golang.org/x/oauth2 v0.30.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.32.0
 	k8s.io/apimachinery v0.32.0
 	k8s.io/apiserver v0.32.0
@@ -277,7 +279,6 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/zclconf/go-cty v1.16.3 // indirect
 	github.com/zeebo/errs v1.4.0 // indirect
-	go.mongodb.org/mongo-driver v1.17.1 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.37.0 // indirect
@@ -311,7 +312,6 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/client-go v0.32.0 // indirect
 	k8s.io/component-base v0.32.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect


### PR DESCRIPTION
## Overview

`PostureExceptionPolicy` (`armotypes/postureexceptionpolicytypes.go`) is the type the
Kubescape scanners consume to suppress posture/vulnerability findings. Its only
workload-matching axis today is `Resources []identifiers.PortalDesignator`, where each
designator encodes match values as **per-key regexes** (evaluated by opa-utils
`compareLabels` via `regexCompare`).

The SecurityException CRD exposes a native Kubernetes `spec.match.objectSelector`
(`metav1.LabelSelector` , `matchLabels` **and** `matchExpressions`). Because there is no
field on `PostureExceptionPolicy` that can carry a full label selector, the getter in
kubescape currently flattens `objectSelector.matchLabels` into regex designators and
**logs-and-skips `matchExpressions`** (best-effort for `v1beta1`, established in
`kubescape/kubescape#2366`). Set-based requirements (`In`/`NotIn`/`Exists`/`DoesNotExist`)
simply cannot be expressed as key→value designator attributes.

This PR adds the data-model foundation to fix that:

```go
// ObjectSelector carries a full Kubernetes label selector (matchLabels + matchExpressions)
// for the exception's workload-matching axis. Unlike Resources (which encodes per-key regex
// designators), this is evaluated with labels.Selector semantics by the exception processor.
// A nil selector imposes no label constraint; it is never treated as match-all.
ObjectSelector *metav1.LabelSelector `json:"objectSelector,omitempty" bson:"objectSelector,omitempty"`
```

## Why this is a type-only change (and why it lands first)

This is the **head of a three-PR chain** that replaces the regex-designator path for
`objectSelector` with one selector evaluated by `labels.Selector.Matches(...)`:

1. **this PR — `armoapi-go`:** add the `ObjectSelector` field, then **tag a release**.
2. **`opa-utils`:** bump to that tag and evaluate the field via
   `labels.Selector.Matches(labels.Set(workload.GetLabels()))` in the exception
   comparator (retiring the regex path *for objectSelector* only). Tag a release.
3. **`kubescape`:** bump both tags and populate `ObjectSelector` from the full CRD
   `objectSelector`, dropping the `matchExpressions` best-effort skip. Closes
   `kubescape/kubescape#2363`.

armoapi-go has no consumer of the field yet **by construction** — the downstream repos
(`opa-utils v0.0.330` → kubescape `v0.0.693`) can only `go get` it after it ships in a
tagged release, so the type has to land first. The field shape and semantics are fixed
by the SecurityException design doc, so the contract is stable ahead of its consumers.

## Additional Information

- **Nil contract (the empty-selector trap):** a `nil`/absent `ObjectSelector` imposes
  **no** label constraint and must **never** be promoted to a match-all
  `labels.Everything()` selector — otherwise an exception with no `objectSelector` would
  silently suppress findings on *every* workload. The doc comment states this, and the
  consumer (PR 2 above) is responsible for guarding `nil`/empty before calling
  `.Matches`. The `omitempty`/nil serialization is pinned by a test here so the absent
  case stays absent across the wire and in BSON.
- **Additive only.** New optional field; existing marshaled `PostureExceptionPolicy`
  documents are unaffected. `k8s.io/apimachinery` (`metav1`) is already a direct
  dependency of the module (`v0.32.0`), so no new dependency is introduced.

## How to Test

Two focused unit tests added in `armotypes/postureexceptionpolicytypes_test.go`:

```bash
go test ./armotypes/ -run PostureExceptionPolicyObjectSelector -v
# === RUN   TestPostureExceptionPolicyObjectSelectorRoundTrip   --- PASS
#   marshal/unmarshal preserves matchLabels + matchExpressions (In/NotIn requirement)
# === RUN   TestPostureExceptionPolicyObjectSelectorOmitEmpty   --- PASS
#   a nil ObjectSelector is omitted from JSON (never serialized as match-all)

go build ./... && go vet ./armotypes/
```

## Related issues/PRs

- Part of `kubescape/kubescape#1982` — SecurityException CRD implementation (epic).
- Builds on `kubescape/kubescape#2366` — which honors `objectSelector.matchLabels` today
  and ships `matchExpressions` as a logged best-effort no-op; this field is the typed
  surface that lets the next PRs evaluate `matchExpressions` for real.
- Design reference: `kubescape/kubevuln` →
  `docs/security-exception-design.md` (`v1beta1`).

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] I have added tests covering the new field (round-trip + omitempty contract)
- [x] New and existing unit tests pass locally with my changes


