### PR TITLE
feat(ai-sandbox): shared agentic classification rule + WorkloadViews.IsAgentic

### DIFF
--- a/armotypes/agentic_test.go
+++ b/armotypes/agentic_test.go
@@ -1,0 +1,87 @@
+package armotypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAgenticEntityType(t *testing.T) {
+	tests := []struct {
+		name            string
+		clientProviders []string
+		serverProviders []string
+		want            string
+	}{
+		{
+			name:            "client only -> AI Agent",
+			clientProviders: []string{"AWS Bedrock"},
+			serverProviders: nil,
+			want:            EntityTypeAIAgent,
+		},
+		{
+			name:            "server only -> MCP Server",
+			clientProviders: nil,
+			serverProviders: []string{"OpenAI"},
+			want:            EntityTypeMCPServer,
+		},
+		{
+			name:            "both -> MCP Server (server wins)",
+			clientProviders: []string{"AWS Bedrock"},
+			serverProviders: []string{"OpenAI"},
+			want:            EntityTypeMCPServer,
+		},
+		{
+			name:            "neither -> empty",
+			clientProviders: nil,
+			serverProviders: nil,
+			want:            "",
+		},
+		{
+			name:            "empty (non-nil) slices -> empty",
+			clientProviders: []string{},
+			serverProviders: []string{},
+			want:            "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, AgenticEntityType(tt.clientProviders, tt.serverProviders))
+		})
+	}
+}
+
+func TestIsAgentic(t *testing.T) {
+	tests := []struct {
+		name            string
+		clientProviders []string
+		serverProviders []string
+		want            bool
+	}{
+		{"client only", []string{"AWS Bedrock"}, nil, true},
+		{"server only", nil, []string{"OpenAI"}, true},
+		{"both", []string{"AWS Bedrock"}, []string{"OpenAI"}, true},
+		{"neither (nil)", nil, nil, false},
+		{"neither (empty)", []string{}, []string{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsAgentic(tt.clientProviders, tt.serverProviders))
+		})
+	}
+}
+
+// TestAgenticEntityType_matchesIsAgentic asserts the two helpers agree: a
+// non-empty entity type iff IsAgentic is true (single classification rule).
+func TestAgenticEntityType_matchesIsAgentic(t *testing.T) {
+	cases := [][2][]string{
+		{{"AWS Bedrock"}, nil},
+		{nil, {"OpenAI"}},
+		{{"AWS Bedrock"}, {"OpenAI"}},
+		{nil, nil},
+	}
+	for _, c := range cases {
+		entityType := AgenticEntityType(c[0], c[1])
+		assert.Equal(t, entityType != "", IsAgentic(c[0], c[1]))
+	}
+}

--- a/armotypes/common.go
+++ b/armotypes/common.go
@@ -30,7 +30,41 @@ const (
 	RepositoryPosture        ScanType = "repository"
 	ContainerVulnerabilities ScanType = "container"
 	RegistryVulnerabilities  ScanType = "registry"
+
+	// Agentic entity-type values — the SINGLE source of truth for the AI-Sandbox
+	// agentic classification, shared by the inventory/dashboard and the
+	// AI-Sandbox serving so both classify identical inputs identically (no
+	// duplicated deriveEntityType). The exact strings MUST stay in sync with the
+	// values served by postgres-connector services/aisandbox/view.go.
+	//
+	// EntityTypeMCPServer marks a subject that exposes/serves AI capability
+	// (ai_server_providers present) — it acts as an MCP server / model host.
+	EntityTypeMCPServer = "MCP Server"
+	// EntityTypeAIAgent marks a subject that consumes AI (ai_client_providers
+	// present, no server providers) — an AI agent / client workload.
+	EntityTypeAIAgent = "AI Agent"
 )
+
+// AgenticEntityType is the SINGLE agentic classification rule shared by the
+// inventory/dashboard and the AI-Sandbox serving. Precedence is server-wins: a
+// subject that serves AI (serverProviders non-empty) is an MCP Server;
+// otherwise one that consumes AI (clientProviders non-empty) is an AI Agent;
+// neither ⇒ "" (not agentic / unknown).
+func AgenticEntityType(clientProviders, serverProviders []string) string {
+	if len(serverProviders) > 0 {
+		return EntityTypeMCPServer
+	}
+	if len(clientProviders) > 0 {
+		return EntityTypeAIAgent
+	}
+	return ""
+}
+
+// IsAgentic is the binary (yes/no) agentic verdict used by the inventory badge.
+// A subject is agentic when it has any AI client OR any AI server provider.
+func IsAgentic(clientProviders, serverProviders []string) bool {
+	return len(clientProviders) > 0 || len(serverProviders) > 0
+}
 
 var RiskFactorMapping = map[string]RiskFactor{
 	"C-0256":        RiskFactorExternalFacing,

--- a/armotypes/workloadview.go
+++ b/armotypes/workloadview.go
@@ -18,4 +18,10 @@ type WorkloadViews struct {
 	RiskFactors        []string   `json:"riskFactors,omitempty"`
 	LearningPercentage *int       `json:"learningPercentage,omitempty"`
 	HostName           string     `json:"hostName,omitempty"`
+	// IsAgentic is the binary agentic-classification badge for the inventory.
+	// It is derived from workload_statuses (ai_client_providers /
+	// ai_server_providers) via armotypes.IsAgentic — it does NOT depend on the
+	// AI-Sandbox tables, so the dashboard badge keeps working regardless of the
+	// ai_sandboxes agentic-verdict migration state.
+	IsAgentic bool `json:"isAgentic,omitempty"`
 }

--- a/docs/services/armoapi-go/service.md
+++ b/docs/services/armoapi-go/service.md
@@ -107,11 +107,11 @@ entityType := armotypes.AgenticEntityType(clientProviders, serverProviders)
 agentic := armotypes.IsAgentic(clientProviders, serverProviders)
 ```
 
-`EntityTypeAIAgent` / `EntityTypeMCPServer` are the exact badge strings (kept in
-sync with postgres-connector `services/aisandbox/view.go`). The inventory DTO
-field `WorkloadViews.IsAgentic` (`json:"isAgentic"`) carries the badge; it is
-derived from `workload_statuses` providers via `armotypes.IsAgentic`, so it does
-**not** depend on the `ai_sandboxes` tables.
+`EntityTypeAIAgent` / `EntityTypeMCPServer` are the exact `entity_type` strings
+(kept in sync with postgres-connector `services/aisandbox/view.go`). The inventory
+DTO field `WorkloadViews.IsAgentic` (`bool`, `json:"isAgentic,omitempty"`) is the
+binary agentic verdict; it is derived from `workload_statuses` providers via
+`armotypes.IsAgentic`, so it does **not** depend on the `ai_sandboxes` tables.
 
 ## Versioning Strategy
 

--- a/docs/services/armoapi-go/service.md
+++ b/docs/services/armoapi-go/service.md
@@ -94,6 +94,25 @@ type MyEntity struct {
 }
 ```
 
+### AI-Sandbox Agentic Classification (single source of truth)
+
+`armotypes` owns the one shared rule for the AI-Sandbox "agentic" classification,
+so the inventory/dashboard and the AI-Sandbox serving classify identical inputs
+identically (no duplicated `deriveEntityType`):
+
+```go
+// server-wins precedence: server -> "MCP Server", else client -> "AI Agent", else ""
+entityType := armotypes.AgenticEntityType(clientProviders, serverProviders)
+// binary verdict: any client OR server provider
+agentic := armotypes.IsAgentic(clientProviders, serverProviders)
+```
+
+`EntityTypeAIAgent` / `EntityTypeMCPServer` are the exact badge strings (kept in
+sync with postgres-connector `services/aisandbox/view.go`). The inventory DTO
+field `WorkloadViews.IsAgentic` (`json:"isAgentic"`) carries the badge; it is
+derived from `workload_statuses` providers via `armotypes.IsAgentic`, so it does
+**not** depend on the `ai_sandboxes` tables.
+
 ## Versioning Strategy
 
 - **Module path**: `github.com/armosec/armoapi-go`


### PR DESCRIPTION
## What

Adds the **single source of truth** for the AI-Sandbox agentic classification in `armotypes`, so the inventory/dashboard and the AI-Sandbox serving share **one rule** (no duplicated `deriveEntityType`).

- `EntityTypeAIAgent` / `EntityTypeMCPServer` constants — exact badge strings, kept in sync with postgres-connector `services/aisandbox/view.go`.
- `AgenticEntityType(client, server) string` — server-wins precedence (server ⇒ MCP Server; else client ⇒ AI Agent; else "").
- `IsAgentic(client, server) bool` — binary verdict (any client OR server provider).
- `WorkloadViews.IsAgentic bool` (`json:"isAgentic,omitempty"`) — the inventory/dashboard badge DTO field.

## Why

The agentic badge must be served to the dashboard as a bool derived from `workload_statuses` only — so the inventory badge never depends on the `ai_sandboxes` tables. This PR is the shared home (imported by postgres-connector next).

## Tests

`go test ./armotypes/...` green — covers client→AI Agent, server→MCP Server precedence, both→MCP Server, neither→""/false, and helper agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)