### PR TITLE
feat(notifications): tolerate UI select-option shape in GitHub workflow identifiers

### DIFF
--- a/notifications/github_ticket_identifiers_test.go
+++ b/notifications/github_ticket_identifiers_test.go
@@ -75,3 +75,119 @@ func TestAlertChannel_GitHubTicketIdentifiers(t *testing.T) {
 	require.Equal(t, "my-org", decoded.GitHubTicketIdentifiers[0].OrganizationName)
 	require.Equal(t, "my-repo", decoded.GitHubTicketIdentifiers[0].RepositoryName)
 }
+
+// The workflow/runtime payload historically accepted only the bare forms
+// (labels: ["bug"], milestoneId: 7). The UI submits the same select-option
+// shape it uses for every provider — {"id": ...} / {"name": ...} objects —
+// so decoding must tolerate both, normalizing to the typed fields.
+
+func TestGitHubTicketIdentifiers_DecodesBareForm(t *testing.T) {
+	in := `{
+		"collaborationGUID": "c1",
+		"organizationName": "org",
+		"repositoryName": "repo",
+		"labels": ["bug", "priority:high"],
+		"assignees": ["alice"],
+		"milestoneId": 7
+	}`
+
+	var got GitHubTicketIdentifiers
+	require.NoError(t, json.Unmarshal([]byte(in), &got))
+
+	require.Equal(t, "c1", got.CollaborationGUID)
+	require.Equal(t, "org", got.OrganizationName)
+	require.Equal(t, "repo", got.RepositoryName)
+	require.Equal(t, []string{"bug", "priority:high"}, got.Labels)
+	require.Equal(t, []string{"alice"}, got.Assignees)
+	require.NotNil(t, got.MilestoneID)
+	require.Equal(t, 7, *got.MilestoneID)
+}
+
+func TestGitHubTicketIdentifiers_DecodesSelectOptionShape(t *testing.T) {
+	// The UI's shape: option objects for labels/assignees, a milestone object.
+	in := `{
+		"collaborationGUID": "c1",
+		"organizationName": "org",
+		"repositoryName": "repo",
+		"labels": [{"id": "bug"}, {"id": "priority:high"}],
+		"assignees": [{"id": "alice"}],
+		"milestone": {"id": "12"}
+	}`
+
+	var got GitHubTicketIdentifiers
+	require.NoError(t, json.Unmarshal([]byte(in), &got))
+
+	require.Equal(t, []string{"bug", "priority:high"}, got.Labels)
+	require.Equal(t, []string{"alice"}, got.Assignees)
+	require.NotNil(t, got.MilestoneID)
+	require.Equal(t, 12, *got.MilestoneID)
+}
+
+func TestGitHubTicketIdentifiers_NameFallbackAndNumericMilestone(t *testing.T) {
+	in := `{
+		"labels": [{"name": "bug"}],
+		"milestone": {"id": 3}
+	}`
+
+	var got GitHubTicketIdentifiers
+	require.NoError(t, json.Unmarshal([]byte(in), &got))
+
+	require.Equal(t, []string{"bug"}, got.Labels)
+	require.NotNil(t, got.MilestoneID)
+	require.Equal(t, 3, *got.MilestoneID)
+}
+
+func TestGitHubTicketIdentifiers_MilestoneIdWinsOverMilestone(t *testing.T) {
+	in := `{"milestoneId": 7, "milestone": {"id": "12"}}`
+
+	var got GitHubTicketIdentifiers
+	require.NoError(t, json.Unmarshal([]byte(in), &got))
+
+	require.NotNil(t, got.MilestoneID)
+	require.Equal(t, 7, *got.MilestoneID)
+}
+
+func TestGitHubTicketIdentifiers_MixedAndEmptyOptionsSkipped(t *testing.T) {
+	// Mixed bare + object elements; empty/malformed options are dropped.
+	in := `{
+		"labels": ["bug", {"id": "enhancement"}, {"id": ""}, {}],
+		"assignees": []
+	}`
+
+	var got GitHubTicketIdentifiers
+	require.NoError(t, json.Unmarshal([]byte(in), &got))
+
+	require.Equal(t, []string{"bug", "enhancement"}, got.Labels)
+	require.Empty(t, got.Assignees)
+	require.Nil(t, got.MilestoneID)
+}
+
+func TestGitHubTicketIdentifiers_NullsAndAbsentAreNil(t *testing.T) {
+	in := `{"collaborationGUID": "c1", "labels": null}`
+
+	var got GitHubTicketIdentifiers
+	require.NoError(t, json.Unmarshal([]byte(in), &got))
+
+	require.Equal(t, "c1", got.CollaborationGUID)
+	require.Nil(t, got.Labels)
+	require.Nil(t, got.Assignees)
+	require.Nil(t, got.MilestoneID)
+}
+
+func TestGitHubTicketIdentifiers_RoundTripMarshalsBareForm(t *testing.T) {
+	// After decoding the option shape, re-marshaling produces the bare,
+	// typed form (what stored configs and UNS expect).
+	in := `{"labels": [{"id": "bug"}], "milestone": {"id": "12"}}`
+
+	var got GitHubTicketIdentifiers
+	require.NoError(t, json.Unmarshal([]byte(in), &got))
+
+	out, err := json.Marshal(got)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &raw))
+	require.Equal(t, []interface{}{"bug"}, raw["labels"])
+	require.Equal(t, float64(12), raw["milestoneId"])
+	require.NotContains(t, raw, "milestone")
+}

--- a/notifications/usernotificationreporttypes.go
+++ b/notifications/usernotificationreporttypes.go
@@ -1,6 +1,9 @@
 package notifications
 
 import (
+	"encoding/json"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/armosec/armoapi-go/containerscan"
@@ -81,6 +84,132 @@ type GitHubTicketIdentifiers struct {
 	Labels            []string `json:"labels,omitempty" bson:"labels,omitempty"`
 	Assignees         []string `json:"assignees,omitempty" bson:"assignees,omitempty"`
 	MilestoneID       *int     `json:"milestoneId,omitempty" bson:"milestoneId,omitempty"`
+}
+
+// UnmarshalJSON decodes GitHubTicketIdentifiers tolerantly so the workflow /
+// runtime-incident payload accepts the same select-option shape the UI submits
+// for every provider, in addition to the historical bare forms:
+//   - labels / assignees: bare strings (["bug"]) OR option objects
+//     ([{"id":"bug"}] / [{"name":"bug"}]).
+//   - milestone: the bare "milestoneId" integer (preferred) OR a "milestone"
+//     select option ({"id":"12"} / {"id":12} / "12").
+//
+// Everything normalizes into the typed fields, so existing readers (e.g. the
+// notification senders) and re-marshaling — which always emits the bare form —
+// are unaffected. For GitHub the option id IS the value the API consumes (label
+// name, assignee login, milestone number), mirroring the manual create path.
+func (g *GitHubTicketIdentifiers) UnmarshalJSON(data []byte) error {
+	var shadow struct {
+		CollaborationGUID string          `json:"collaborationGUID"`
+		OrganizationName  string          `json:"organizationName"`
+		RepositoryName    string          `json:"repositoryName"`
+		Labels            json.RawMessage `json:"labels"`
+		Assignees         json.RawMessage `json:"assignees"`
+		MilestoneID       json.RawMessage `json:"milestoneId"`
+		Milestone         json.RawMessage `json:"milestone"`
+	}
+	if err := json.Unmarshal(data, &shadow); err != nil {
+		return err
+	}
+
+	g.CollaborationGUID = shadow.CollaborationGUID
+	g.OrganizationName = shadow.OrganizationName
+	g.RepositoryName = shadow.RepositoryName
+	g.Labels = githubSelectStrings(shadow.Labels)
+	g.Assignees = githubSelectStrings(shadow.Assignees)
+
+	g.MilestoneID = nil
+	if n, ok := githubMilestoneNumber(shadow.MilestoneID); ok {
+		g.MilestoneID = &n
+	} else if n, ok := githubMilestoneNumber(shadow.Milestone); ok {
+		g.MilestoneID = &n
+	}
+	return nil
+}
+
+// githubSelectStrings coerces a labels/assignees JSON value into []string,
+// accepting bare strings and option objects ({"id":...} / {"name":...}).
+// Elements that resolve to "" are skipped; null/absent/empty input yields nil.
+func githubSelectStrings(raw json.RawMessage) []string {
+	if isEmptyJSON(raw) {
+		return nil
+	}
+	var items []json.RawMessage
+	if err := json.Unmarshal(raw, &items); err != nil || len(items) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if s := githubOptionString(item); s != "" {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// githubOptionString extracts the string value of a single select-field option,
+// reading "id" first then "name" for object options. The option id is the value
+// GitHub consumes. Returns "" when nothing usable is found.
+func githubOptionString(raw json.RawMessage) string {
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return ""
+	}
+	for _, key := range []string{"id", "name"} {
+		v, ok := obj[key]
+		if !ok {
+			continue
+		}
+		var str string
+		if err := json.Unmarshal(v, &str); err == nil && str != "" {
+			return str
+		}
+		var num float64
+		if err := json.Unmarshal(v, &num); err == nil { // numeric id, e.g. {"id": 1}
+			return strconv.Itoa(int(num))
+		}
+	}
+	return ""
+}
+
+// githubMilestoneNumber coerces a milestone value into the integer milestone
+// number GitHub requires. Accepts a JSON number, a numeric string, or an option
+// object ({"id": ...}). Returns ok=false for null/absent/non-numeric input.
+func githubMilestoneNumber(raw json.RawMessage) (int, bool) {
+	if isEmptyJSON(raw) {
+		return 0, false
+	}
+	var num float64
+	if err := json.Unmarshal(raw, &num); err == nil {
+		return int(num), true
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		if t := strings.TrimSpace(s); t != "" {
+			if i, err := strconv.Atoi(t); err == nil {
+				return i, true
+			}
+		}
+		return 0, false
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err == nil {
+		if v, ok := obj["id"]; ok {
+			return githubMilestoneNumber(v)
+		}
+	}
+	return 0, false
+}
+
+func isEmptyJSON(raw json.RawMessage) bool {
+	return len(raw) == 0 || string(raw) == "null"
 }
 
 type AlertChannel struct {


### PR DESCRIPTION
<!-- armosec-pr: v=1 via=manual -->

## Summary

Makes the **workflow / runtime-incident** GitHub notification payload accept the same select-option shape the UI already submits for every other provider, instead of only the bare forms.

`GitHubTicketIdentifiers` was a plain struct decoded by stdlib `json`, so:
- `labels` / `assignees` accepted only `["bug"]` — the UI's `[{"id":"bug"}]` shape failed with a **400** (`cannot unmarshal object into ... of type string`).
- milestone accepted only top-level `milestoneId` (int) — the UI's `milestone: {"id":"12"}` was **silently dropped**.

Meanwhile the **manual create** path (`POST issueV2/create`) already coerces the `{id}`/`{name}` option shape. This divergence forced the UI to build a GitHub-workflow-specific serializer. This PR closes that gap at the type's decode boundary.

## Change

A tolerant `UnmarshalJSON` on `GitHubTicketIdentifiers` that accepts **both** shapes and normalizes to the existing typed fields:

| Field | Accepted input | Normalized to |
|---|---|---|
| `labels` / `assignees` | `["bug"]` **or** `[{"id":"bug"}]` / `[{"name":"bug"}]` | `[]string` |
| milestone | `milestoneId: 7` (preferred) **or** `milestone: {"id":"12"}` / `{"id":12}` / `"12"` | `*int` |

- **Backward compatible** — bare forms still decode unchanged.
- **Marshaling untouched** — always emits the bare form, so persisted workflow configs and the notification senders (users-notification-service) are unaffected.
- Mirrors the coercion the manual path already does in `cadashboardbe/integrations/tickets/github/github_client.go` (`toStringSlice` / `toMilestoneNumber`, id-then-name precedence).

## Tests (TDD)

Added to `notifications/github_ticket_identifiers_test.go` — written failing first, then implemented:
- bare form still decodes; select-option shape decodes; `{name}` fallback; numeric `{id}`; `milestoneId` wins over `milestone`; mixed/empty options skipped; null/absent → nil; round-trip re-marshals to bare form.

`go test ./...` passes across the whole module; `go vet` clean; build OK.

## Rollout (follow-ups, after merge + tag)

1. Bump `armoapi-go` in **cadashboardbe** → workflow endpoint starts accepting the `{id}` shape.
2. Bump `armoapi-go` in **users-notification-service** (no behavior change — reads normalized fields).
3. Update **cadashboardbe** `docs/features/github-workflow-notifications.md` to document the now-accepted select-option shape (this PR is `Docs-exempt` since the payload contract doc lives in the consumer repo).

This is the "min fix" from the design discussion; full `fields`-nesting alignment (matching Jira/Linear structurally) remains a separate, larger follow-up.

## AI Context
| Category | Used |
|----------|------|
| Skills | `test-driven-development` |
| MCP Servers | `github` |
| Rules/Commands | `worktree_new`, `open_pr` |
