### PR TITLE
feat(notifications): nest GitHub ticket content under fields map (mirror Jira/Linear)

### DIFF
--- a/notifications/github_ticket_identifiers_test.go
+++ b/notifications/github_ticket_identifiers_test.go
@@ -7,15 +7,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// GitHubTicketIdentifiers carries routing identifiers at the top level and all
+// issue content under a generic `fields` map, mirroring JiraTicketIdentifiers
+// and LinearTicketIdentifiers. Content keys match the field schema's fieldId
+// (labels, assignees, milestone), and select values may be bare or the UI's
+// option-object shape — coercion happens downstream in cadashboardbe, so the
+// map carries whatever was submitted verbatim.
+
 func TestGitHubTicketIdentifiers_Serialization(t *testing.T) {
-	milestoneID := 7
 	identifiers := GitHubTicketIdentifiers{
 		CollaborationGUID: "collab-guid-123",
 		OrganizationName:  "my-org",
 		RepositoryName:    "my-repo",
-		Labels:            []string{"bug", "priority:high"},
-		Assignees:         []string{"alice"},
-		MilestoneID:       &milestoneID,
+		Fields: map[string]interface{}{
+			"labels":    []interface{}{"bug", "priority:high"},
+			"assignees": []interface{}{"alice"},
+			"milestone": "7",
+		},
 	}
 
 	data, err := json.Marshal(identifiers)
@@ -26,19 +34,19 @@ func TestGitHubTicketIdentifiers_Serialization(t *testing.T) {
 	require.Contains(t, raw, "collaborationGUID")
 	require.Contains(t, raw, "organizationName")
 	require.Contains(t, raw, "repositoryName")
-	require.Contains(t, raw, "labels")
-	require.Contains(t, raw, "assignees")
-	require.Contains(t, raw, "milestoneId")
+	require.Contains(t, raw, "fields")
+	// Content lives under `fields`, not at the top level — matches Jira/Linear.
+	require.NotContains(t, raw, "labels")
+	require.NotContains(t, raw, "assignees")
+	require.NotContains(t, raw, "milestoneId")
+	require.NotContains(t, raw, "milestone")
 
 	var decoded GitHubTicketIdentifiers
 	require.NoError(t, json.Unmarshal(data, &decoded))
-
-	require.Equal(t, identifiers.CollaborationGUID, decoded.CollaborationGUID)
-	require.Equal(t, identifiers.OrganizationName, decoded.OrganizationName)
-	require.Equal(t, identifiers.RepositoryName, decoded.RepositoryName)
-	require.Equal(t, identifiers.Labels, decoded.Labels)
-	require.Equal(t, identifiers.Assignees, decoded.Assignees)
-	require.Equal(t, *identifiers.MilestoneID, *decoded.MilestoneID)
+	require.Equal(t, "collab-guid-123", decoded.CollaborationGUID)
+	require.Equal(t, "my-org", decoded.OrganizationName)
+	require.Equal(t, "my-repo", decoded.RepositoryName)
+	require.Equal(t, identifiers.Fields, decoded.Fields)
 }
 
 func TestGitHubTicketIdentifiers_OmitsEmptyOptionals(t *testing.T) {
@@ -51,6 +59,72 @@ func TestGitHubTicketIdentifiers_OmitsEmptyOptionals(t *testing.T) {
 	require.NoError(t, json.Unmarshal(data, &raw))
 
 	require.Empty(t, raw, "empty GitHubTicketIdentifiers should serialize to {}")
+}
+
+// The map carries the UI's select-option shape verbatim — the workflow path no
+// longer needs a special milestoneId key; everything rides `fields` keyed by
+// the schema fieldId (labels, assignees, milestone), and cadashboardbe coerces
+// option objects downstream.
+func TestGitHubTicketIdentifiers_PreservesSelectOptionShape(t *testing.T) {
+	in := `{
+		"collaborationGUID": "c1",
+		"organizationName": "org",
+		"repositoryName": "repo",
+		"fields": {
+			"labels": [{"id": "bug"}, {"id": "priority:high"}],
+			"assignees": [{"id": "alice"}],
+			"milestone": {"id": "12"}
+		}
+	}`
+
+	var got GitHubTicketIdentifiers
+	require.NoError(t, json.Unmarshal([]byte(in), &got))
+
+	require.Equal(t, "c1", got.CollaborationGUID)
+	require.Equal(t, "org", got.OrganizationName)
+	require.Equal(t, "repo", got.RepositoryName)
+	require.NotNil(t, got.Fields)
+
+	milestone, ok := got.Fields["milestone"].(map[string]interface{})
+	require.True(t, ok, "milestone option object preserved in fields")
+	require.Equal(t, "12", milestone["id"])
+
+	labels, ok := got.Fields["labels"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, labels, 2)
+}
+
+func TestGitHubTicketIdentifiers_RoutingOnly(t *testing.T) {
+	in := `{"collaborationGUID": "c1", "organizationName": "org", "repositoryName": "repo"}`
+
+	var got GitHubTicketIdentifiers
+	require.NoError(t, json.Unmarshal([]byte(in), &got))
+
+	require.Equal(t, "c1", got.CollaborationGUID)
+	require.Equal(t, "org", got.OrganizationName)
+	require.Equal(t, "repo", got.RepositoryName)
+	require.Nil(t, got.Fields)
+}
+
+// Structural parity: GitHub now nests content under `fields` just like Jira.
+func TestGitHubTicketIdentifiers_MirrorsJiraFieldsShape(t *testing.T) {
+	gh, err := json.Marshal(GitHubTicketIdentifiers{
+		CollaborationGUID: "c1",
+		Fields:            map[string]interface{}{"labels": []interface{}{"bug"}},
+	})
+	require.NoError(t, err)
+	jira, err := json.Marshal(JiraTicketIdentifiers{
+		CollaborationGUID: "c1",
+		Fields:            map[string]interface{}{"labels": []interface{}{"bug"}},
+	})
+	require.NoError(t, err)
+
+	var ghRaw, jiraRaw map[string]interface{}
+	require.NoError(t, json.Unmarshal(gh, &ghRaw))
+	require.NoError(t, json.Unmarshal(jira, &jiraRaw))
+	require.Contains(t, ghRaw, "fields")
+	require.Contains(t, jiraRaw, "fields")
+	require.Equal(t, ghRaw["fields"], jiraRaw["fields"])
 }
 
 func TestAlertChannel_GitHubTicketIdentifiers(t *testing.T) {

--- a/notifications/usernotificationreporttypes.go
+++ b/notifications/usernotificationreporttypes.go
@@ -74,13 +74,17 @@ type LinearTicketIdentifiers struct {
 	Fields      map[string]interface{} `json:"fields,omitempty" bson:"fields,omitempty"`
 }
 
+// GitHubTicketIdentifiers carries the GitHub routing identifiers (org/repo) at
+// the top level and all issue content under a generic `fields` map, mirroring
+// JiraTicketIdentifiers and LinearTicketIdentifiers. Content keys match the
+// field schema's fieldId (e.g. labels, assignees, milestone); select values may
+// be bare or the UI's option-object shape ({"id": …}) — they ride the map
+// verbatim and are coerced downstream by cadashboardbe when the issue is built.
 type GitHubTicketIdentifiers struct {
-	CollaborationGUID string   `json:"collaborationGUID,omitempty" bson:"collaborationGUID,omitempty"`
-	OrganizationName  string   `json:"organizationName,omitempty" bson:"organizationName,omitempty"`
-	RepositoryName    string   `json:"repositoryName,omitempty" bson:"repositoryName,omitempty"`
-	Labels            []string `json:"labels,omitempty" bson:"labels,omitempty"`
-	Assignees         []string `json:"assignees,omitempty" bson:"assignees,omitempty"`
-	MilestoneID       *int     `json:"milestoneId,omitempty" bson:"milestoneId,omitempty"`
+	CollaborationGUID string                 `json:"collaborationGUID,omitempty" bson:"collaborationGUID,omitempty"`
+	OrganizationName  string                 `json:"organizationName,omitempty" bson:"organizationName,omitempty"`
+	RepositoryName    string                 `json:"repositoryName,omitempty" bson:"repositoryName,omitempty"`
+	Fields            map[string]interface{} `json:"fields,omitempty" bson:"fields,omitempty"`
 }
 
 type AlertChannel struct {


### PR DESCRIPTION
<!-- armosec-pr: v=1 via=manual -->

## Summary

Aligns the GitHub workflow / runtime-incident notification identifier with Jira/Linear: content moves from flat top-level fields into a generic `fields` map. **Breaking change** to the shared type (callers reading `.Labels`/`.Assignees`/`.MilestoneID` switch to `.Fields`).

```go
// after — mirrors JiraTicketIdentifiers / LinearTicketIdentifiers
type GitHubTicketIdentifiers struct {
    CollaborationGUID, OrganizationName, RepositoryName string
    Fields map[string]interface{}   // json: "fields"
}
```

## Why

- **Structural consistency** — workflow/runtime GitHub notifications now match Jira/Linear (content under `fields`) *and* GitHub's own manual-create path. One shape per provider; the GET round-trip returns `fields` for GitHub too.
- **Fixes the milestone bug** — content is keyed by the schema's `fieldId` (`labels`, `assignees`, `milestone`). The flat struct used `milestoneId`, but the field schema publishes `fieldId: "milestone"`, so a schema-driven UI's `milestone` value was silently dropped. Under `fields` it just works.
- **Select-option shape rides the map verbatim** — `{"id": …}` objects are carried through and coerced downstream by cadashboardbe (same `toStringSlice`/`toMilestoneNumber` the manual path uses). No decode logic here — **supersedes #668**.

## Breaking change

Only consumer reading the typed content fields is `users-notification-service` `buildGitHubIssuePayload` (companion PR; it simplifies to a `fields` pass-through). Feature is behind a flag and not released to customers, so **no stored-config migration**.

## Tests (TDD)

`github_ticket_identifiers_test.go` rewritten failing-first then implemented: routing top-level + content under `fields`; select-option shape preserved verbatim; routing-only decode; empty → `{}`; structural parity with `JiraTicketIdentifiers.fields`. `go test ./...` passes module-wide; `go vet` clean.

## Rollout (after merge + tag)

| Repo | Change |
|---|---|
| users-notification-service | `buildGitHubIssuePayload` → pass `Fields` through (code) + bump |
| cadashboardbe | bump + fix `github-workflow-notifications.md` (`fields.milestone`) |
| config-service | bump (typed-binds — required to persist `fields`) |
| event-ingester-service | bump |
| system-tests | add `fields` content coverage before GA |

## AI Context
| Category | Used |
|----------|------|
| Skills | `test-driven-development` |
| MCP Servers | `github` |
| Rules/Commands | `worktree_new`, `open_pr` |
