### PR TITLE
feat(ai-sandbox): Inventory.SandboxStatus + apply-status constants

### DIFF
--- a/armotypes/inventory.go
+++ b/armotypes/inventory.go
@@ -31,4 +31,15 @@ type Inventory struct {
 	// — it does NOT depend on the ai_sandboxes tables, so the discovery badge keeps
 	// working regardless of the ai_sandboxes agentic-verdict migration state.
 	IsAgentic bool `json:"isAgentic,omitempty"`
+	// SandboxStatus is the AI-sandbox "add to sandbox" lifecycle status of the
+	// workload: "pending", "in_sandbox", or "failed" (empty = not-in-sandbox). It
+	// is DERIVED in the inventory query, not stored: "in_sandbox" from the live
+	// pod-template label (kubescape.io/sandbox on the synced workload), else
+	// "failed"/"pending" from the control-plane ai_sandbox_statuses event
+	// timestamps (LEFT JOIN on (customer_guid, resource_hash)). Independent of the
+	// observed ai_sandboxes telemetry tables. Host coverage tracks resource_hash
+	// availability on the inventory row — k8s and ECS carry one; cloud-host rows do
+	// not yet project one, so they read empty until the platform surfaces a host
+	// resource_hash.
+	SandboxStatus string `json:"sandboxStatus,omitempty"`
 }

--- a/docs/services/armoapi-go/service.md
+++ b/docs/services/armoapi-go/service.md
@@ -114,6 +114,19 @@ binary agentic verdict; it is derived from `workload_statuses` providers via
 `armotypes.IsAgentic`, so it does **not** depend on the `ai_sandboxes` tables.
 The inventory (`/api/v1/inventory`) is the discovery surface that carries the badge.
 
+The discovery DTO also carries `Inventory.SandboxStatus` (`string`,
+`json:"sandboxStatus,omitempty"`) — the AI-Sandbox "add to sandbox" apply-lifecycle
+status: `pending` | `in_sandbox` | `failed` (an empty/absent value means
+not-in-sandbox). Unlike the telemetry-owned `ai_sandboxes` tables, this is the
+**write-path control-plane** status (owned by cadashboardbe `/enable` →
+event-ingester apply). It is **derived** in the inventory query, not stored:
+`in_sandbox` from the live pod-template label (`kubescape.io/sandbox` on the synced
+workload), else `failed`/`pending` from the `ai_sandbox_statuses` event timestamps,
+LEFT-JOINed on `(customer_guid, resource_hash)` — the table stores no status column
+and there are no status constants. Host coverage tracks
+`resource_hash` availability on the inventory row (k8s + ECS today; cloud-host
+rows carry none yet).
+
 > **Deprecated:** the **entire `WorkloadViews`** type/view is deprecated, superseded
 > by `Inventory` (the discovery surface at `/api/v1/inventory`). Use `armotypes.Inventory`
 > for new work; do not add or extend fields on `WorkloadViews` (the agentic badge lives


### PR DESCRIPTION
## What

Adds the AI-sandbox "add to sandbox" apply-lifecycle status to the discovery DTO:

- `Inventory.SandboxStatus` (`json:"sandboxStatus,omitempty"`) — `"pending"` | `"in_sandbox"` | `"failed"` (empty = not-in-sandbox).

It is the **write-path control-plane** status, **derived** in the inventory query (not stored): `in_sandbox` from the live pod-template label (`kubescape.io/sandbox` on the synced workload), else `failed`/`pending` from postgres-connector's `ai_sandbox_statuses` event timestamps. There is **no stored status column and no status constants** — deliberately independent of the observed `ai_sandboxes` telemetry tables.

## Cross-repo

Base of the AI-sandbox status set — **merge first**:
1. **armoapi-go** (this PR)
2. postgres-connector — `ai_sandbox_statuses` table + derived-status inventory join (pins this)
3. event-ingester-service — write-path timestamp persistence (pins both)

Downstream PRs pin this commit via a branch pseudo-version; **re-pin to the released tag on merge**.

## Notes

Pure additive type change, no behavior. Docs updated (`docs/services/armoapi-go/service.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
