### PR TITLE
feat(notifications): integration token-health attributes + degraded status

### DIFF
--- a/docs/features/integration-token-health.md
+++ b/docs/features/integration-token-health.md
@@ -1,0 +1,55 @@
+---
+type: feature
+status: in-progress
+owner: alonliwsky
+scope: repo
+related_code:
+  - notifications/integrationhealth.go
+  - notifications/collaborationconfig.go
+---
+
+# Integration Token Health — shared model
+
+Part of the cross-service integration-token-health project: OAuth ticketing
+integrations (Linear, Jira Cloud, GitHub) silently break when refresh tokens
+expire while the platform keeps reporting "connected". This library change
+defines the shared health contract; detection, cron, UI, and notifications
+live in the consuming services.
+
+## What this adds
+
+1. **`Degraded` value** on `IntegrationConnectionStatus` (`connected | disconnected | degraded`).
+   `degraded` = the integration is configured but its credentials are unusable;
+   user action (OAuth reconnect) is required.
+2. **Health attributes contract** on `CollaborationConfig.Attributes`
+   (`notifications/integrationhealth.go`):
+
+   | Attribute key | Meaning |
+   |---|---|
+   | `healthStatus` | `"degraded"`; **absence = healthy** |
+   | `healthLastChecked` | RFC3339 time of last health evaluation |
+   | `healthLastError` | reason for the last failed evaluation |
+   | `healthDegradedSince` | RFC3339 time of first transition into degraded |
+
+3. **Typed helpers** so consumers never touch raw keys: `GetHealth()`,
+   `SetHealthDegraded(reason)` (idempotent — keeps the original
+   `healthDegradedSince` on re-mark), `SetHealthChecked()`, `ClearHealth()`.
+
+## Why Attributes instead of typed struct fields
+
+`CollaborationConfig` is read-modify-written by several services
+(cadashboardbe, config-service, users-notification-service). A service built
+against an older armoapi-go silently drops unknown *typed* fields when it
+deserializes and re-serializes the record — a typed degraded flag would
+flicker back to healthy whenever any lagging writer rewrote the config.
+Attributes-map entries survive those round-trips with zero version
+coordination, and remain queryable in Mongo (`attributes.healthStatus`).
+
+## Consumers
+
+- **cadashboardbe** — writes health on `RefreshTokenError` (reactive) and from
+  the daily health check (proactive); reads it in the integrations status +
+  configV2 endpoints. Clears on OAuth reconnect.
+- **users-notification-service** — reads the 424 `integration_token_expired`
+  contract derived from this state (does not write health itself).
+- **armo-ui** — renders `degraded` badge/banner from the status endpoints.

--- a/docs/repo/architecture.md
+++ b/docs/repo/architecture.md
@@ -42,6 +42,7 @@ armoapi-go/
 ├── notifications/           # Alert & collaboration configuration
 │   ├── alertchannelapi.go   # AlertChannelAPI, AlertConfig
 │   ├── collaborationconfig.go # CollaborationConfig (Jira, Linear, etc.)
+│   ├── integrationhealth.go # Integration token-health attributes + helpers
 │   └── runtimeincidents.go  # Runtime incident notification types
 ├── broadcastevents/         # Platform event types for analytics pipeline
 │   ├── events.go            # EventBase, LoginEvent, HelmInstalledEvent

--- a/notifications/collaborationconfig.go
+++ b/notifications/collaborationconfig.go
@@ -90,6 +90,11 @@ type IntegrationConnectionStatus string
 const (
 	Connected    IntegrationConnectionStatus = "connected"
 	Disconnected IntegrationConnectionStatus = "disconnected"
+	// Degraded means the integration is configured but its credentials are no
+	// longer usable (e.g. expired/revoked OAuth refresh token) and user action
+	// (reconnect) is required. Derived from the persisted health attributes on
+	// the CollaborationConfig — never from a live provider call.
+	Degraded IntegrationConnectionStatus = "degraded"
 )
 
 type IntegrationsConnectionStatus struct {

--- a/notifications/integrationhealth.go
+++ b/notifications/integrationhealth.go
@@ -1,0 +1,99 @@
+package notifications
+
+import "time"
+
+// Integration health is persisted as entries in CollaborationConfig.Attributes
+// (map[string]interface{}) rather than as typed struct fields. Attributes
+// entries survive read-modify-write round-trips through services built against
+// older versions of this library, while unknown typed fields would be silently
+// dropped on re-serialization. Absence of the health keys means healthy.
+const (
+	AttributeHealthStatus        = "healthStatus"
+	AttributeHealthLastChecked   = "healthLastChecked"
+	AttributeHealthLastError     = "healthLastError"
+	AttributeHealthDegradedSince = "healthDegradedSince"
+)
+
+type IntegrationHealthStatus string
+
+const (
+	IntegrationHealthStatusHealthy  IntegrationHealthStatus = "healthy"
+	IntegrationHealthStatusDegraded IntegrationHealthStatus = "degraded"
+)
+
+// IntegrationHealth is the typed view over the health attributes of a
+// CollaborationConfig. Timestamps are RFC3339 strings, consistent with
+// PortalBase.UpdatedTime and CollaborationConfig.CreationTime.
+// swagger:model IntegrationHealth
+type IntegrationHealth struct {
+	Status IntegrationHealthStatus `json:"status"`
+	// LastChecked is the time of the last health evaluation (successful or not)
+	LastChecked string `json:"lastChecked,omitempty"`
+	// LastError is the reason for the last failed health evaluation
+	LastError string `json:"lastError,omitempty"`
+	// DegradedSince is when the integration first transitioned into degraded
+	DegradedSince string `json:"degradedSince,omitempty"`
+}
+
+// GetHealth returns the health recorded on the config's attributes.
+// Missing/nil attributes mean the integration is considered healthy.
+func (c *CollaborationConfig) GetHealth() IntegrationHealth {
+	health := IntegrationHealth{Status: IntegrationHealthStatusHealthy}
+	if c == nil || c.Attributes == nil {
+		return health
+	}
+	if attributeString(c.Attributes, AttributeHealthStatus) == string(IntegrationHealthStatusDegraded) {
+		health.Status = IntegrationHealthStatusDegraded
+	}
+	health.LastChecked = attributeString(c.Attributes, AttributeHealthLastChecked)
+	health.LastError = attributeString(c.Attributes, AttributeHealthLastError)
+	health.DegradedSince = attributeString(c.Attributes, AttributeHealthDegradedSince)
+	return health
+}
+
+// SetHealthDegraded marks the integration as degraded with the given reason.
+// Idempotent with respect to DegradedSince: re-marking an already-degraded
+// config refreshes LastChecked/LastError but keeps the original transition time.
+func (c *CollaborationConfig) SetHealthDegraded(reason string) {
+	if c.Attributes == nil {
+		c.Attributes = map[string]interface{}{}
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	if attributeString(c.Attributes, AttributeHealthStatus) != string(IntegrationHealthStatusDegraded) {
+		c.Attributes[AttributeHealthDegradedSince] = now
+	}
+	c.Attributes[AttributeHealthStatus] = string(IntegrationHealthStatusDegraded)
+	c.Attributes[AttributeHealthLastChecked] = now
+	c.Attributes[AttributeHealthLastError] = reason
+}
+
+// SetHealthChecked records a successful health evaluation, clearing any
+// degraded state.
+func (c *CollaborationConfig) SetHealthChecked() {
+	if c.Attributes == nil {
+		c.Attributes = map[string]interface{}{}
+	}
+	c.ClearHealth()
+	c.Attributes[AttributeHealthLastChecked] = time.Now().UTC().Format(time.RFC3339)
+}
+
+// ClearHealth removes all health attributes (e.g. after a successful
+// reconnect), returning the config to the implicit healthy state.
+func (c *CollaborationConfig) ClearHealth() {
+	if c == nil || c.Attributes == nil {
+		return
+	}
+	delete(c.Attributes, AttributeHealthStatus)
+	delete(c.Attributes, AttributeHealthLastChecked)
+	delete(c.Attributes, AttributeHealthLastError)
+	delete(c.Attributes, AttributeHealthDegradedSince)
+}
+
+// attributeString reads a string attribute, tolerating the
+// map[string]interface{} shapes produced by JSON/BSON round-trips.
+func attributeString(attributes map[string]interface{}, key string) string {
+	if v, ok := attributes[key].(string); ok {
+		return v
+	}
+	return ""
+}

--- a/notifications/integrationhealth.go
+++ b/notifications/integrationhealth.go
@@ -55,6 +55,9 @@ func (c *CollaborationConfig) GetHealth() IntegrationHealth {
 // Idempotent with respect to DegradedSince: re-marking an already-degraded
 // config refreshes LastChecked/LastError but keeps the original transition time.
 func (c *CollaborationConfig) SetHealthDegraded(reason string) {
+	if c == nil {
+		return
+	}
 	if c.Attributes == nil {
 		c.Attributes = map[string]interface{}{}
 	}
@@ -70,6 +73,9 @@ func (c *CollaborationConfig) SetHealthDegraded(reason string) {
 // SetHealthChecked records a successful health evaluation, clearing any
 // degraded state.
 func (c *CollaborationConfig) SetHealthChecked() {
+	if c == nil {
+		return
+	}
 	if c.Attributes == nil {
 		c.Attributes = map[string]interface{}{}
 	}

--- a/notifications/integrationhealth_test.go
+++ b/notifications/integrationhealth_test.go
@@ -1,0 +1,122 @@
+package notifications
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetHealthDefaultsToHealthy(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		config *CollaborationConfig
+	}{
+		{name: "nil config", config: nil},
+		{name: "nil attributes", config: &CollaborationConfig{}},
+		{name: "unrelated attributes", config: configWithAttributes(map[string]interface{}{"workspaceId": "w-1"})},
+		{name: "non-string health attribute", config: configWithAttributes(map[string]interface{}{AttributeHealthStatus: 42})},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			health := tt.config.GetHealth()
+			assert.Equal(t, IntegrationHealthStatusHealthy, health.Status)
+			assert.Empty(t, health.LastChecked)
+			assert.Empty(t, health.LastError)
+			assert.Empty(t, health.DegradedSince)
+		})
+	}
+}
+
+func TestSetHealthDegraded(t *testing.T) {
+	t.Parallel()
+	config := &CollaborationConfig{}
+	config.SetHealthDegraded("token_refresh_failed: invalid_grant")
+
+	health := config.GetHealth()
+	assert.Equal(t, IntegrationHealthStatusDegraded, health.Status)
+	assert.Equal(t, "token_refresh_failed: invalid_grant", health.LastError)
+	assertRFC3339(t, health.LastChecked)
+	assertRFC3339(t, health.DegradedSince)
+}
+
+func TestSetHealthDegradedKeepsDegradedSince(t *testing.T) {
+	t.Parallel()
+	config := &CollaborationConfig{}
+	config.SetHealthDegraded("first failure")
+	firstSince := config.GetHealth().DegradedSince
+
+	config.SetHealthDegraded("second failure")
+	health := config.GetHealth()
+	assert.Equal(t, firstSince, health.DegradedSince, "re-marking must not reset the transition time")
+	assert.Equal(t, "second failure", health.LastError)
+}
+
+func TestSetHealthDegradedPreservesOtherAttributes(t *testing.T) {
+	t.Parallel()
+	config := configWithAttributes(map[string]interface{}{"workspaceId": "w-1"})
+	config.SetHealthDegraded("boom")
+	assert.Equal(t, "w-1", config.Attributes["workspaceId"])
+}
+
+func TestSetHealthChecked(t *testing.T) {
+	t.Parallel()
+	config := &CollaborationConfig{}
+	config.SetHealthDegraded("boom")
+
+	config.SetHealthChecked()
+	health := config.GetHealth()
+	assert.Equal(t, IntegrationHealthStatusHealthy, health.Status)
+	assert.Empty(t, health.LastError)
+	assert.Empty(t, health.DegradedSince)
+	assertRFC3339(t, health.LastChecked)
+}
+
+func TestClearHealth(t *testing.T) {
+	t.Parallel()
+	config := configWithAttributes(map[string]interface{}{"workspaceId": "w-1"})
+	config.SetHealthDegraded("boom")
+
+	config.ClearHealth()
+	for _, key := range []string{AttributeHealthStatus, AttributeHealthLastChecked, AttributeHealthLastError, AttributeHealthDegradedSince} {
+		assert.NotContains(t, config.Attributes, key)
+	}
+	assert.Equal(t, "w-1", config.Attributes["workspaceId"], "unrelated attributes must survive")
+	assert.NotPanics(t, func() { (&CollaborationConfig{}).ClearHealth() })
+}
+
+// Simulates the config-service round-trip: the config is marshalled to JSON
+// and back (Attributes become map[string]interface{} with plain strings) and
+// the helpers must still read the health correctly.
+func TestHealthSurvivesJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+	config := configWithAttributes(map[string]interface{}{"workspaceId": "w-1"})
+	config.SetHealthDegraded("token_refresh_failed")
+
+	raw, err := json.Marshal(config)
+	require.NoError(t, err)
+	var roundTripped CollaborationConfig
+	require.NoError(t, json.Unmarshal(raw, &roundTripped))
+
+	health := roundTripped.GetHealth()
+	assert.Equal(t, IntegrationHealthStatusDegraded, health.Status)
+	assert.Equal(t, "token_refresh_failed", health.LastError)
+	assertRFC3339(t, health.DegradedSince)
+	assert.Equal(t, "w-1", roundTripped.Attributes["workspaceId"])
+}
+
+func configWithAttributes(attributes map[string]interface{}) *CollaborationConfig {
+	config := &CollaborationConfig{}
+	config.Attributes = attributes
+	return config
+}
+
+func assertRFC3339(t *testing.T, value string) {
+	t.Helper()
+	_, err := time.Parse(time.RFC3339, value)
+	assert.NoError(t, err, "expected RFC3339 timestamp, got %q", value)
+}


### PR DESCRIPTION
## What

Shared model for the **integration-token-health** project: OAuth ticketing integrations (Linear, Jira Cloud, GitHub) silently break when refresh tokens expire while the platform keeps reporting "connected".

- New `Degraded` value on `IntegrationConnectionStatus` (`connected | disconnected | degraded`)
- Health attribute keys + typed helpers on `CollaborationConfig` (`GetHealth`/`SetHealthDegraded`/`SetHealthChecked`/`ClearHealth`) over the `Attributes` map

## Why Attributes instead of typed fields

`CollaborationConfig` is read-modify-written by several services. A service on an older armoapi-go silently drops unknown **typed** fields on deserialize→reserialize — a typed degraded flag would flicker back to healthy whenever a lagging writer rewrote the record. Attributes entries survive those round-trips with zero version coordination and stay Mongo-queryable (`attributes.healthStatus`). Absence of keys = healthy.

## Context

Found via the `linear_notifications_workflows` dev failure (2026-05-25): expired Linear refresh token, every call returned 500 "Refresh token expired", integration still showed "connected", UNS retried for 20 minutes.

## Dependencies / merge order

1. **This PR** (no dependencies) — tag after merge
2. armosec/cadashboardbe `feature/integration-token-health` — reactive degraded marking + 424 (pins this branch by commit; retag before merge)
3. armosec/users-notification-service `feature/integration-token-health` — 424 classifiers (no code dependency on this PR)

## Tests

Table-driven unit tests incl. JSON round-trip (simulating the config-service PUT cycle), idempotent re-mark, nil-attribute safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)