### PR TITLE
feat(ai-sandbox): drop the failed state from SandboxStatus (SUB-7442)

### DIFF
--- a/armotypes/inventory.go
+++ b/armotypes/inventory.go
@@ -32,14 +32,20 @@ type Inventory struct {
 	// working regardless of the ai_sandboxes agentic-verdict migration state.
 	IsAgentic bool `json:"isAgentic,omitempty"`
 	// SandboxStatus is the AI-sandbox "add to sandbox" lifecycle status of the
-	// workload: "pending", "in_sandbox", or "failed" (empty = not-in-sandbox). It
-	// is DERIVED in the inventory query, not stored: "in_sandbox" from the live
-	// pod-template label (kubescape.io/sandbox on the synced workload), else
-	// "failed"/"pending" from the control-plane ai_sandbox_statuses event
-	// timestamps (LEFT JOIN on (customer_guid, resource_hash)). Independent of the
-	// observed ai_sandboxes telemetry tables. Host coverage tracks resource_hash
-	// availability on the inventory row — k8s and ECS carry one; cloud-host rows do
-	// not yet project one, so they read empty until the platform surfaces a host
-	// resource_hash.
+	// workload: "pending" or "in_sandbox" (empty = not-in-sandbox). It is DERIVED
+	// in the inventory query, not stored: "in_sandbox" from the live pod-template
+	// label (kubescape.io/sandbox on the synced workload), else "pending" from the
+	// control-plane ai_sandbox_statuses event timestamps (LEFT JOIN on
+	// (customer_guid, resource_hash)). Independent of the observed ai_sandboxes
+	// telemetry tables.
+	//
+	// There is intentionally NO "failed" state (product decision, SUB-7442): the
+	// lifecycle is not-in-sandbox -> pending -> in_sandbox. Deterministic enable
+	// errors are handled in the write-path (unsupported kinds / not-found are
+	// logged, not surfaced) rather than exposed as a status.
+	//
+	// Host coverage tracks resource_hash availability on the inventory row - k8s
+	// and ECS carry one; cloud-host rows do not yet project one, so they read
+	// empty until the platform surfaces a host resource_hash.
 	SandboxStatus string `json:"sandboxStatus,omitempty"`
 }

--- a/armotypes/inventory.go
+++ b/armotypes/inventory.go
@@ -35,7 +35,7 @@ type Inventory struct {
 	// workload: "pending" or "in_sandbox" (empty = not-in-sandbox). It is DERIVED
 	// in the inventory query, not stored: "in_sandbox" from the live pod-template
 	// label (kubescape.io/sandbox on the synced workload), else "pending" from the
-	// control-plane ai_sandbox_statuses event timestamps (LEFT JOIN on
+	// control-plane ai_sandbox_statuses request timestamp (LEFT JOIN on
 	// (customer_guid, resource_hash)). Independent of the observed ai_sandboxes
 	// telemetry tables.
 	//

--- a/docs/services/armoapi-go/service.md
+++ b/docs/services/armoapi-go/service.md
@@ -116,16 +116,18 @@ The inventory (`/api/v1/inventory`) is the discovery surface that carries the ba
 
 The discovery DTO also carries `Inventory.SandboxStatus` (`string`,
 `json:"sandboxStatus,omitempty"`) — the AI-Sandbox "add to sandbox" apply-lifecycle
-status: `pending` | `in_sandbox` | `failed` (an empty/absent value means
-not-in-sandbox). Unlike the telemetry-owned `ai_sandboxes` tables, this is the
-**write-path control-plane** status (owned by cadashboardbe `/enable` →
-event-ingester apply). It is **derived** in the inventory query, not stored:
-`in_sandbox` from the live pod-template label (`kubescape.io/sandbox` on the synced
-workload), else `failed`/`pending` from the `ai_sandbox_statuses` event timestamps,
-LEFT-JOINed on `(customer_guid, resource_hash)` — the table stores no status column
-and there are no status constants. Host coverage tracks
-`resource_hash` availability on the inventory row (k8s + ECS today; cloud-host
-rows carry none yet).
+status: `pending` | `in_sandbox` (an empty/absent value means not-in-sandbox).
+There is intentionally **no `failed` state** (product decision, SUB-7442): the
+lifecycle is `not-in-sandbox → pending → in_sandbox`, and deterministic enable
+errors are handled in the write-path (logged, not surfaced). Unlike the
+telemetry-owned `ai_sandboxes` tables, this is the **write-path control-plane**
+status (owned by cadashboardbe `/enable` → event-ingester apply). It is
+**derived** in the inventory query, not stored: `in_sandbox` from the live
+pod-template label (`kubescape.io/sandbox` on the synced workload), else `pending`
+from the `ai_sandbox_statuses` request timestamp, LEFT-JOINed on
+`(customer_guid, resource_hash)` — the table stores no status column and there are
+no status constants. Host coverage tracks `resource_hash` availability on the
+inventory row (k8s + ECS today; cloud-host rows carry none yet).
 
 > **Deprecated:** the **entire `WorkloadViews`** type/view is deprecated, superseded
 > by `Inventory` (the discovery surface at `/api/v1/inventory`). Use `armotypes.Inventory`


### PR DESCRIPTION
## What

`Inventory.SandboxStatus` now documents its values as `pending` / `in_sandbox` (empty = not-in-sandbox) only — no `failed`. Updates the type comment and `docs/services/armoapi-go/service.md`.

## Why

Product decision (SUB-7442, shared-designs-and-docs #112, Slack thread): the add-to-sandbox lifecycle is `not-in-sandbox → pending → in_sandbox`. Deterministic enable errors are handled in the write-path (logged, not surfaced) instead of exposed as a `failed` badge.

## Notes

- Comment/doc-only change; the field type (`string`) is unchanged, so this is non-breaking.
- Paired with postgres-connector (removes the `failed` derivation) and event-ingester (stops stamping failure) — those carry the behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI-skills: plan,pr_comments | cmds: /review_plan,/compact,/model,/design-consent,/design