### PR TITLE
feat(common): add SourceIP to NetworkEntity

### DIFF
--- a/armotypes/common/runtime_common.go
+++ b/armotypes/common/runtime_common.go
@@ -20,6 +20,7 @@ type NetworkEntity struct {
 	DstIP    string `json:"dstIP,omitempty" bson:"dstIP,omitempty"`
 	DstPort  int    `json:"dstPort,omitempty" bson:"dstPort,omitempty"`
 	Protocol string `json:"protocol,omitempty" bson:"protocol,omitempty"`
+	SourceIP string `json:"sourceIP,omitempty" bson:"sourceIP,omitempty"`
 }
 
 type HttpEntity struct {
@@ -102,6 +103,9 @@ func (identifiers *Identifiers) Flatten() map[string]string {
 		}
 		if identifiers.Network.Protocol != "" {
 			identifiers_map["network.protocol"] = identifiers.Network.Protocol
+		}
+		if identifiers.Network.SourceIP != "" {
+			identifiers_map["network.sourceIP"] = identifiers.Network.SourceIP
 		}
 	}
 	if identifiers.Http != nil {

--- a/armotypes/common/runtime_common_test.go
+++ b/armotypes/common/runtime_common_test.go
@@ -54,6 +54,7 @@ func TestIdentifiersFlatten(t *testing.T) {
 					DstIP:    "1.1.1.1",
 					DstPort:  8080,
 					Protocol: "TCP",
+					SourceIP: "2.2.2.2",
 				},
 				Http: &HttpEntity{
 					Method:    "POST",


### PR DESCRIPTION
## What

Adds a `SourceIP` field to the runtime-incident `NetworkEntity` (`armotypes/common/runtime_common.go`), so network identifiers on HTTP-based alerts can carry *who initiated the connection*, not just the destination.

- New field `SourceIP string \`json:"sourceIP,omitempty" bson:"sourceIP,omitempty"\``
- `Flatten()` emits `network.sourceIP`
- Test fixture updated (self-validating `Flatten` test covers it)

## Why

Part of a cross-repo effort to surface a proxy-aware source IP on runtime incidents. This repo is the root of the dependency chain — the field is **populated** by the private node agent's HTTP adapter and **surfaced** via cadashboardbe filters and the armo-ng-app risk-acceptance form (separate PRs).

Scope is deliberately narrow: `SourceIP` only (no `SourcePort`), populated only from the private-node-agent HTTP path. See the design spec: `docs/superpowers/specs/2026-07-08-network-entity-source-ip-design.md`.

## Downstream (follow-up PRs, gated on a new tag of this repo)

- `private-node-agent` — populate `SourceIP` (X-Forwarded-For → X-Real-IP → socket source)
- `cadashboardbe` — add `identifiers.network.sourceIP` to the search-filter allow-list
- `armo-ng-app` — add the `SourceIP` enum + "Source IP" label

## Test

`go build ./armotypes/...` and `go test ./armotypes/common/` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI-skills: superpowers:brainstorming,armosec-shared-rules:docs_find