### PR TITLE
feat(notifications): add WorkloadNames to AggregatedVulnerability for workload-scope matching

### DIFF
--- a/notifications/vulnerability.go
+++ b/notifications/vulnerability.go
@@ -16,6 +16,7 @@ type AggregatedVulnerability struct {
 	Namespace        string                `json:"namespace,omitempty" bson:"namespace,omitempty"`
 	WorkloadHashes   []string              `json:"workloadHashes,omitempty" bson:"workloadHashes,omitempty"`
 	Workloads        []string              `json:"workloads,omitempty" bson:"workloads,omitempty"`
+	WorkloadNames    []string              `json:"workloadNames,omitempty" bson:"workloadNames,omitempty"`
 	Images           []string              `json:"images,omitempty" bson:"images,omitempty"`
 	ImagesHashes     []string              `json:"imagesHashes,omitempty" bson:"imagesHashes,omitempty"`
 	Kinds            []string              `json:"kinds,omitempty" bson:"kinds,omitempty"`
@@ -36,11 +37,3 @@ type AggregatedVulnerability struct {
 	CisaKevInfo      armotypes.CisaKevInfo `json:"cisaKevInfo,omitempty" bson:"cisaKevInfo,omitempty"`
 	RiskFactors			 []string              `json:"riskFactors,omitempty" bson:"riskFactors,omitempty"`
 }
-
-// type VulnerabilitiesComponentShort struct {
-// 	Name        string `json:"name"`
-// 	Version     string `json:"version"`
-// 	PackageType string `json:"packageType"`
-// 	FixVersion  string `json:"fixVersion"`
-// 	IsRelevant  string `json:"isRelevant"` // in use
-// }


### PR DESCRIPTION
## Why

Vulnerability workflows scoped to a specific **Workload** deliver zero Slack/Jira alerts (silently), even though the vulnerabilities are detected and stored correctly.

Root cause is a workload-identifier representation mismatch:
- A workflow's `Workload` scope — and the onStart matcher (`WorkflowScope.InScope`) — identify a workload by its **bare name** (e.g. `vuln-gate-test`, from the `name` designator).
- The stored `AggregatedVulnerability` record represents the same workload in `Workloads` as **`<kind>-<name>`** (e.g. `deployment-vuln-gate-test`, from `GetWorkload()`).

So the delivery-stage CVE query filters on the bare name against records that only hold `kind-name` → 0 matches → no notification.

## Change

Add a dedicated `WorkloadNames []string` field (bare names) as a queryable match target. `Workloads` (`kind-name`) is left untouched — it's still used for notification display.

Consumers will populate `WorkloadNames` from the **same `name` designator the scope matcher reads**, so the detection-stage (`InScope`) and delivery-stage (CVE query) filters agree on the same value and cannot silently diverge — an exact match with no format coupling across repos.

Also removes a long-commented-out `VulnerabilitiesComponentShort` type (dead code; verified no live references in any consumer).

## Part of a 4-repo fix (Option 2)

1. **armoapi-go: this PR** — add the field
2. config-service — add `workloadNames` to the vuln route's queryable array paths (**deploys first**)
3. users-notification-service — populate `WorkloadNames` from the bare name; bump armoapi-go
4. armosec-infra — emit `workloadNames` for the config-service backend scope filter, + a contract test asserting every emitted config-service filter key exists as a queryable record field

Additive and backward-compatible; no consumer breaks by taking this version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)