### PR TITLE
feat: add profile-state MissingRuntimeInfoReason values

### DIFF
--- a/armotypes/networkpolicies.go
+++ b/armotypes/networkpolicies.go
@@ -17,6 +17,11 @@ const (
 	UnscheduledNodeAgentPods MissingRuntimeInfoReason = 2
 	IncompatibleKernel       MissingRuntimeInfoReason = 3
 	RuncNotFound             MissingRuntimeInfoReason = 4
+	// reasons 5-7 are derived from the state of the workload's own ApplicationProfile,
+	// complementing the node-agent (cluster-level) reasons above
+	ProfileStillLearning MissingRuntimeInfoReason = 5
+	AwaitingScanUpdate   MissingRuntimeInfoReason = 6
+	ProfileTooLarge      MissingRuntimeInfoReason = 7
 )
 
 // NetworkPoliciesWorkload is used store information about workloads


### PR DESCRIPTION
## What

Adds three `MissingRuntimeInfoReason` values derived from the state of the workload's own ApplicationProfile:

- `ProfileStillLearning = 5` — profile exists but the learning period hasn't finished
- `AwaitingScanUpdate = 6` — profile is complete and ready; relevancy data attaches on the next scan
- `ProfileTooLarge = 7` — profile exceeded the size limit and can't be used for relevancy

## Why

On the vulnerabilities Workloads page, the missing-runtime-info reason is currently computed once per **cluster** (from node-agent pod statuses) and applied to every flagged workload — any cluster with healthy agents shows "Workload requires a restart" on all of them. postgres-connector now resolves the reason per workload from its ApplicationProfile annotations (mirroring the kubevuln relevancy gate: `kubescape.io/completion == complete` and `kubescape.io/status` in {ready, completed}), and needs these values to express the profile-derived states.

Companion changes: postgres-connector (per-workload resolution, currently with local copies of these constants) and armo-ng-app (tooltip texts for 5-7).