### PR TITLE
feat(cdr): add Azure Activity Log types to the CDR contract

### DIFF
--- a/armotypes/cdr/azure.go
+++ b/armotypes/cdr/azure.go
@@ -1,0 +1,67 @@
+package cdr
+
+import "time"
+
+const (
+	// CdrEventAzureSubscriptionIDJsonPath is the JSON path to the subscription ID
+	// (the Azure equivalent of the AWS account ID) on an Azure Activity Log event.
+	CdrEventAzureSubscriptionIDJsonPath = "cdrevent.eventData.azureActivityLog.subscriptionId"
+	// CdrEventAzureTenantIDJsonPath is the JSON path to the tenant ID
+	// (the Azure equivalent of the AWS org ID) on an Azure Activity Log event.
+	CdrEventAzureTenantIDJsonPath = "cdrevent.eventData.azureActivityLog.tenantId"
+)
+
+// AzureActivityLogBatch is the envelope Azure Monitor delivers to Event Hub: one
+// Event Hub message carries many Activity Log records. The in-account collector
+// unwraps this and embeds each AzureActivityLogEvent into a CdrAlert's EventData.
+type AzureActivityLogBatch struct {
+	Records []AzureActivityLogEvent `json:"records"`
+}
+
+// AzureActivityLogEvent is a single Azure Activity Log record — the control-plane
+// audit event that is the Azure equivalent of an AWS CloudTrail management event
+// (see CloudTrailEvent in aws.go).
+//
+// The field set below covers the common Activity Log fields observed in the POC.
+// NOTE: the exact shape differs slightly between the two delivery paths — the
+// Event Hub stream vs. the Azure Monitor REST API (e.g. some callers nest
+// authorization/claims under an "identity" object, and the Event Hub body adds
+// wrapper fields). Reconcile/extend against real samples of both; the
+// marshal/unmarshal round-trip test is the guard (see the POC FINDINGS.md for a
+// captured sample).
+type AzureActivityLogEvent struct {
+	Time            time.Time `json:"time"`
+	ResourceID      string    `json:"resourceId,omitempty"`
+	OperationName   string    `json:"operationName,omitempty"`
+	Category        string    `json:"category,omitempty"`
+	ResultType      string    `json:"resultType,omitempty"`
+	ResultSignature string    `json:"resultSignature,omitempty"`
+	CorrelationID   string    `json:"correlationId,omitempty"`
+	CallerIPAddress string    `json:"callerIpAddress,omitempty"`
+	// Caller is the identity that performed the operation (UPN or object ID).
+	Caller string `json:"caller,omitempty"`
+	Level  string `json:"level,omitempty"`
+	// Channels is the Activity Log channel (e.g. "Operation").
+	Channels string `json:"channels,omitempty"`
+	// SubscriptionID / TenantID / ResourceGroupName are the account identifiers
+	// (Azure's equivalents of the AWS accountId/orgId). Present on the
+	// management/REST shape; on the Event Hub shape SubscriptionID may need to be
+	// derived from ResourceID.
+	SubscriptionID    string `json:"subscriptionId,omitempty"`
+	TenantID          string `json:"tenantId,omitempty"`
+	ResourceGroupName string `json:"resourceGroupName,omitempty"`
+	// Authorization is the RBAC context of the operation.
+	Authorization *AzureAuthorization `json:"authorization,omitempty"`
+	// Claims is the caller's token claims (objectId, appid, ipaddr, tenantid, ...).
+	Claims map[string]string `json:"claims,omitempty"`
+	// Properties is the operation-specific bag (eventCategory, entity, message,
+	// hierarchy, statusCode, responseBody, ...); shape varies by operation.
+	Properties map[string]interface{} `json:"properties,omitempty"`
+}
+
+// AzureAuthorization is the RBAC authorization context of an Activity Log operation.
+type AzureAuthorization struct {
+	Scope    string                 `json:"scope,omitempty"`
+	Action   string                 `json:"action,omitempty"`
+	Evidence map[string]interface{} `json:"evidence,omitempty"`
+}

--- a/armotypes/cdr/azure_test.go
+++ b/armotypes/cdr/azure_test.go
@@ -1,0 +1,107 @@
+package cdr
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// azureActivityLogSample is a trimmed real Azure Activity Log record captured in
+// the POC (Event Hub `records[]` envelope; identity claims abbreviated). See the
+// azure-cdr-poc FINDINGS.md for the full sample.
+const azureActivityLogSample = `{
+  "records": [
+    {
+      "time": "2026-07-19T14:14:22Z",
+      "resourceId": "/SUBSCRIPTIONS/8FC00071/RESOURCEGROUPS/CDR-POC-RG",
+      "operationName": "Microsoft.Resources/subscriptions/resourcegroups/write",
+      "category": "Administrative",
+      "resultType": "Success",
+      "resultSignature": "Succeeded.Created",
+      "correlationId": "abc-123",
+      "caller": "benm@armosec.io",
+      "level": "Information",
+      "channels": "Operation",
+      "tenantId": "50a70646-52e3-4e46-911e-6ca1b46afba3",
+      "authorization": {
+        "action": "Microsoft.Resources/subscriptions/resourcegroups/write",
+        "scope": "/subscriptions/8fc00071/resourcegroups/cdr-poc-rg"
+      },
+      "claims": {
+        "idtyp": "user",
+        "appid": "04b07795-8ddb-461a-bbee-02f9e1bf7b46",
+        "ipaddr": "199.203.132.136",
+        "http://schemas.microsoft.com/identity/claims/objectidentifier": "0dfe9580"
+      },
+      "properties": {
+        "statusCode": "Created",
+        "eventCategory": "Administrative",
+        "entity": "/subscriptions/8fc00071/resourcegroups/cdr-poc-rg",
+        "message": "Microsoft.Resources/subscriptions/resourcegroups/write"
+      }
+    }
+  ]
+}`
+
+func TestAzureActivityLogRoundTrip(t *testing.T) {
+	var batch AzureActivityLogBatch
+	if err := json.Unmarshal([]byte(azureActivityLogSample), &batch); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(batch.Records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(batch.Records))
+	}
+
+	e := batch.Records[0]
+	if e.OperationName != "Microsoft.Resources/subscriptions/resourcegroups/write" {
+		t.Errorf("operationName = %q", e.OperationName)
+	}
+	if e.Category != "Administrative" {
+		t.Errorf("category = %q", e.Category)
+	}
+	if e.Caller != "benm@armosec.io" {
+		t.Errorf("caller = %q", e.Caller)
+	}
+	if e.TenantID != "50a70646-52e3-4e46-911e-6ca1b46afba3" {
+		t.Errorf("tenantId = %q", e.TenantID)
+	}
+	if e.Authorization == nil || e.Authorization.Action == "" {
+		t.Fatalf("authorization not parsed: %+v", e.Authorization)
+	}
+	if e.Claims["idtyp"] != "user" {
+		t.Errorf("claims.idtyp = %q", e.Claims["idtyp"])
+	}
+	if e.Properties["message"] != "Microsoft.Resources/subscriptions/resourcegroups/write" {
+		t.Errorf("properties.message = %v", e.Properties["message"])
+	}
+
+	// Round-trip back to JSON.
+	if _, err := json.Marshal(e); err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+}
+
+// TestAzureEventDataEmbedding verifies the Azure event embeds in the shared
+// CdrAlert contract without disturbing the AWS path.
+func TestAzureEventDataEmbedding(t *testing.T) {
+	alert := CdrAlert{
+		CloudMetadata: CloudMetadata{Provider: Azure, SourceService: ActivityLogs},
+		EventData:     EventData{AzureActivityLog: &AzureActivityLogEvent{OperationName: "test"}},
+	}
+	b, err := json.Marshal(alert)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got CdrAlert
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Provider != Azure || got.SourceService != ActivityLogs {
+		t.Errorf("cloud metadata = %+v", got.CloudMetadata)
+	}
+	if got.AzureActivityLog == nil || got.AzureActivityLog.OperationName != "test" {
+		t.Errorf("azure event data = %+v", got.AzureActivityLog)
+	}
+	if got.AWSCloudTrail != nil {
+		t.Errorf("AWS path should be nil, got %+v", got.AWSCloudTrail)
+	}
+}

--- a/armotypes/cdr/azure_test.go
+++ b/armotypes/cdr/azure_test.go
@@ -2,7 +2,11 @@ package cdr
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // azureActivityLogSample is a trimmed real Azure Activity Log record captured in
@@ -103,5 +107,60 @@ func TestAzureEventDataEmbedding(t *testing.T) {
 	}
 	if got.AWSCloudTrail != nil {
 		t.Errorf("AWS path should be nil, got %+v", got.AWSCloudTrail)
+	}
+}
+
+// TestCdrAlertAzureJsonPath verifies the Azure subscription/tenant JSON-path
+// constants match the json tags on CdrAlert, so config-service lookups don't
+// drift from the wire contract (mirrors TestCdrAlertJsonPath for AWS).
+func TestCdrAlertAzureJsonPath(t *testing.T) {
+	tests := []struct {
+		Name          string
+		Path          string
+		CdrAlert      CdrAlert
+		ExpectedValue string
+	}{
+		{
+			Name: "Test CdrEventAzureSubscriptionIDJsonPath",
+			Path: CdrEventAzureSubscriptionIDJsonPath,
+			CdrAlert: CdrAlert{
+				EventData: EventData{
+					AzureActivityLog: &AzureActivityLogEvent{
+						SubscriptionID: "8fc00071-75e6-4b3f-82d4-844e7865bab3",
+					},
+				},
+			},
+			ExpectedValue: "8fc00071-75e6-4b3f-82d4-844e7865bab3",
+		},
+		{
+			Name: "Test CdrEventAzureTenantIDJsonPath",
+			Path: CdrEventAzureTenantIDJsonPath,
+			CdrAlert: CdrAlert{
+				EventData: EventData{
+					AzureActivityLog: &AzureActivityLogEvent{
+						TenantID: "50a70646-52e3-4e46-911e-6ca1b46afba3",
+					},
+				},
+			},
+			ExpectedValue: "50a70646-52e3-4e46-911e-6ca1b46afba3",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			// 1. Marshal to JSON
+			data, err := json.Marshal(test.CdrAlert)
+			require.NoError(t, err)
+
+			// 2. Unmarshal into a generic map
+			var genericCdrAlert map[string]interface{}
+			require.NoError(t, json.Unmarshal(data, &genericCdrAlert))
+
+			// 3. Traverse the path (shared helper lives in aws_test.go)
+			pathWithoutPrefix := strings.TrimPrefix(test.Path, "cdrevent.")
+			val, ok := getValueAtJsonPath(genericCdrAlert, pathWithoutPrefix)
+			require.True(t, ok)
+			assert.Equal(t, test.ExpectedValue, val)
+		})
 	}
 }

--- a/armotypes/cdr/cdr.go
+++ b/armotypes/cdr/cdr.go
@@ -15,6 +15,8 @@ type CloudService string
 const (
 	// CloudTrail is the cloudtrail service
 	CloudTrail CloudService = "cloudtrail"
+	// ActivityLogs is the Azure Activity Log service (control-plane audit log)
+	ActivityLogs CloudService = "activitylogs"
 	// Add more cloud services here
 )
 
@@ -24,6 +26,8 @@ type CloudProvider string
 const (
 	// AWS is the AWS cloud provider
 	AWS CloudProvider = "aws"
+	// Azure is the Microsoft Azure cloud provider
+	Azure CloudProvider = "azure"
 	// Add more cloud providers here
 )
 
@@ -38,6 +42,8 @@ type CloudMetadata struct {
 type EventData struct {
 	// AWSCloudTrail cloudtrail event
 	AWSCloudTrail *CloudTrailEvent `json:"awsCloudTrail,omitempty"`
+	// AzureActivityLog azure activity log event
+	AzureActivityLog *AzureActivityLogEvent `json:"azureActivityLog,omitempty"`
 	// Target resource
 	TargetResource string `json:"targetResource,omitempty"`
 	// Identifiers of the alert

--- a/docs/repo/architecture.md
+++ b/docs/repo/architecture.md
@@ -27,7 +27,8 @@ armoapi-go/
 │   ├── registrytypes.go     # RegistryInfo, RegistryJobParams
 │   ├── cdr/                 # Cloud Detection & Response types
 │   │   ├── cdr.go           # CdrAlert, CloudMetadata, CdrAlertBatch
-│   │   └── aws.go           # CloudTrailEvent, AWS-specific types
+│   │   ├── aws.go           # CloudTrailEvent, AWS-specific types
+│   │   └── azure.go         # AzureActivityLogEvent, Azure-specific types
 │   └── common/              # Shared runtime sub-types (ProcessEntity, FileEntity)
 ├── identifiers/             # Resource designator system
 │   ├── designators.go       # PortalDesignator, DesignatorType, constants

--- a/docs/services/armoapi-go/service.md
+++ b/docs/services/armoapi-go/service.md
@@ -20,7 +20,7 @@ This is a **pure type/utility library** with no runtime services (no HTTP server
 |---------|-------------|
 | `apis` | Command dispatch types, websocket scan commands, backend connector interfaces, and pagination helpers |
 | `armotypes` | Core platform domain types: clusters, configurations, policies, incidents, security risks, registries, vulnerability exceptions |
-| `armotypes/cdr` | Cloud Detection & Response alert types (CdrAlert, CloudTrailEvent, AWS-specific structures) |
+| `armotypes/cdr` | Cloud Detection & Response alert types (CdrAlert, CloudTrailEvent, AzureActivityLogEvent; AWS + Azure structures) |
 | `armotypes/common` | Shared runtime sub-types (ProcessEntity, FileEntity) used across detection features |
 | `identifiers` | Workload and resource designator system (WLID, SID, PortalDesignator) with parsing utilities |
 | `containerscan` | Container vulnerability scan report interfaces defining the contract between scanner and consumers |


### PR DESCRIPTION
<!-- armosec-pr: v=1 via=manual -->

## Summary

Story **SUB-7651** — extend the provider-agnostic CDR wire contract with Azure Activity Log types (first of the Azure CDR epic, [SUB-7650](https://cyberarmor-io.atlassian.net/browse/SUB-7650)). Additive and **non-breaking** — the AWS types are untouched.

## Changes
- **`armotypes/cdr/cdr.go`** — add `CloudProvider` `azure`, `CloudService` `activitylogs`, and an `AzureActivityLog` variant on `EventData`.
- **`armotypes/cdr/azure.go`** (new) — `AzureActivityLogEvent` (the Activity Log record, Azure's control-plane equivalent of a CloudTrail management event), an `AzureActivityLogBatch` envelope for the Event Hub `{"records":[…]}` payload, and subscription/tenant JSON-path constants (parallel to `aws.go`).
- **`armotypes/cdr/azure_test.go`** (new) — marshal/unmarshal round-trip on a captured sample + a test asserting the AWS path is unaffected.
- **Docs** — note `azure.go` in `docs/repo/architecture.md` and update the `armotypes/cdr` row in `docs/services/armoapi-go/service.md`.

## Notes
- Fields are modeled on the Azure CDR **POC's captured Activity Log events** (see `armosec/azure-cdr-poc`). The struct's doc comment marks it **provisional**: the Event Hub vs. REST shape nuances (field nesting, wrapper fields) are hardened in the collector work (SUB-7654). Additive, so later field refinement is a non-breaking follow-up.
- Design reference: `shared-designs-and-docs/cdr/cdr-azure-gcp-hld.md` §7.


[SUB-7650]: https://cyberarmor-io.atlassian.net/browse/SUB-7650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ