### PR TITLE
feat(cdr): managed rule-delivery wire types (CdrRuleBundle/CdrRule)

### DIFF
--- a/armotypes/cdr/rules.go
+++ b/armotypes/cdr/rules.go
@@ -4,7 +4,8 @@ import "time"
 
 // CdrRuleOrigin distinguishes centrally-managed rules from customer-authored ones. Customer
 // authoring is not yet supported; the field exists so the delivery contract can carry custom rules
-// in future without a wire change. An empty value means managed.
+// in future without a wire change. The server always sets it (managed or custom); a consumer should
+// treat an absent value as managed.
 type CdrRuleOrigin string
 
 const (

--- a/armotypes/cdr/rules.go
+++ b/armotypes/cdr/rules.go
@@ -41,6 +41,8 @@ type CdrRule struct {
 	Tags []string `json:"tags,omitempty"`
 	// Message is the alert-message template emitted on a match.
 	Message string `json:"message,omitempty"`
+	// UniqueID is the templated dedup key for a match.
+	UniqueID string `json:"uniqueID,omitempty"`
 	// Origin is managed (default) or custom.
 	Origin CdrRuleOrigin `json:"origin,omitempty"`
 }

--- a/armotypes/cdr/rules.go
+++ b/armotypes/cdr/rules.go
@@ -1,0 +1,62 @@
+package cdr
+
+import "time"
+
+// CdrRuleOrigin distinguishes centrally-managed rules from customer-authored ones. Customer
+// authoring is not yet supported; the field exists so the delivery contract can carry custom rules
+// in future without a wire change. An empty value means managed.
+type CdrRuleOrigin string
+
+const (
+	// CdrRuleOriginManaged is a rule maintained centrally by ARMO.
+	CdrRuleOriginManaged CdrRuleOrigin = "managed"
+	// CdrRuleOriginCustom is a customer-authored rule.
+	CdrRuleOriginCustom CdrRuleOrigin = "custom"
+)
+
+// CdrRule is the sensor-facing projection of a CDR detection rule served to the in-account
+// collector over the managed rule-delivery endpoint. It is deliberately slim and decoupled from the
+// internal runtime-rule storage model so the wire contract stays stable as that storage evolves.
+// Its fields align with the alert a match produces, so rule metadata passes straight through to the
+// emitted CdrAlert.
+type CdrRule struct {
+	// RuleID is the unique identifier of the rule.
+	RuleID string `json:"ruleID"`
+	// Name is the human-readable rule name.
+	Name string `json:"name"`
+	// Description is the rule description.
+	Description string `json:"description,omitempty"`
+	// Service is the target log stream the rule evaluates (e.g. activitylogs, cloudtrail).
+	Service CloudService `json:"service"`
+	// Expression is the CEL rule text the collector compiles and evaluates.
+	Expression string `json:"expression"`
+	// Priority is the severity of the rule (matches CdrAlert.Priority for pass-through).
+	Priority string `json:"priority,omitempty"`
+	// MitreTactic is the MITRE ATT&CK tactic.
+	MitreTactic string `json:"mitreTactic,omitempty"`
+	// MitreTechnique is the MITRE ATT&CK technique.
+	MitreTechnique string `json:"mitreTechnique,omitempty"`
+	// Tags is the rule tags.
+	Tags []string `json:"tags,omitempty"`
+	// Message is the alert-message template emitted on a match.
+	Message string `json:"message,omitempty"`
+	// Origin is managed (default) or custom.
+	Origin CdrRuleOrigin `json:"origin,omitempty"`
+}
+
+// CdrRuleBundle is the response body of the managed rule-delivery endpoint: the provider-scoped CEL
+// rule set for a tenant plus an opaque content version for change detection. The collector
+// downloads it, authenticated with its per-tenant access key, instead of shipping rules baked into
+// the deployed image. Version is emitted as the response ETag; the collector echoes it via
+// If-None-Match to get a cheap 304 when the set is unchanged.
+type CdrRuleBundle struct {
+	// Version is an opaque content hash of the served rule set; it changes if and only if the set
+	// changes. Clients must treat it as opaque.
+	Version string `json:"version"`
+	// Provider is the cloud provider the bundle is scoped to.
+	Provider CloudProvider `json:"provider"`
+	// GeneratedAt is when the bundle was assembled (informational; not part of Version).
+	GeneratedAt time.Time `json:"generatedAt"`
+	// Rules is the enabled, provider-scoped CDR rule set for the tenant.
+	Rules []CdrRule `json:"rules"`
+}

--- a/armotypes/cdr/rules_test.go
+++ b/armotypes/cdr/rules_test.go
@@ -1,0 +1,66 @@
+package cdr
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestCdrRuleBundleRoundTrip verifies the rule-delivery response survives a JSON round-trip
+// unchanged — the collector must decode exactly what the endpoint encodes.
+func TestCdrRuleBundleRoundTrip(t *testing.T) {
+	original := CdrRuleBundle{
+		Version:     "sha256:abc123",
+		Provider:    Azure,
+		GeneratedAt: time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC),
+		Rules: []CdrRule{
+			{
+				RuleID:         "azure-role-assignment-created",
+				Name:           "Privileged role assignment created",
+				Service:        ActivityLogs,
+				Expression:     `event.operationName == "Microsoft.Authorization/roleAssignments/write"`,
+				Priority:       "high",
+				MitreTactic:    "Privilege Escalation",
+				MitreTechnique: "T1098",
+				Tags:           []string{"iam", "azure"},
+				Message:        "Role assignment created",
+				Origin:         CdrRuleOriginManaged,
+			},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded CdrRuleBundle
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.Version != original.Version || decoded.Provider != original.Provider ||
+		!decoded.GeneratedAt.Equal(original.GeneratedAt) || len(decoded.Rules) != 1 {
+		t.Fatalf("bundle mismatch: %+v", decoded)
+	}
+	got, want := decoded.Rules[0], original.Rules[0]
+	if got.RuleID != want.RuleID || got.Service != want.Service || got.Expression != want.Expression ||
+		got.Priority != want.Priority || got.Origin != want.Origin || len(got.Tags) != len(want.Tags) {
+		t.Errorf("rule mismatch:\n got  %+v\n want %+v", got, want)
+	}
+}
+
+// TestOmitEmptyOptionalFields verifies empty optional fields drop off the wire.
+func TestOmitEmptyOptionalFields(t *testing.T) {
+	data, err := json.Marshal(CdrRule{RuleID: "r1", Name: "n", Service: CloudTrail, Expression: "true"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, k := range []string{"origin", "priority", "tags", "message", "description"} {
+		if _, present := m[k]; present {
+			t.Errorf("expected %q omitted when empty, got: %s", k, data)
+		}
+	}
+}

--- a/armotypes/cdr/rules_test.go
+++ b/armotypes/cdr/rules_test.go
@@ -2,6 +2,7 @@ package cdr
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -38,13 +39,13 @@ func TestCdrRuleBundleRoundTrip(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if decoded.Version != original.Version || decoded.Provider != original.Provider ||
-		!decoded.GeneratedAt.Equal(original.GeneratedAt) || len(decoded.Rules) != 1 {
-		t.Fatalf("bundle mismatch: %+v", decoded)
+		!decoded.GeneratedAt.Equal(original.GeneratedAt) {
+		t.Fatalf("bundle header mismatch: %+v", decoded)
 	}
-	got, want := decoded.Rules[0], original.Rules[0]
-	if got.RuleID != want.RuleID || got.Service != want.Service || got.Expression != want.Expression ||
-		got.Priority != want.Priority || got.Origin != want.Origin || len(got.Tags) != len(want.Tags) {
-		t.Errorf("rule mismatch:\n got  %+v\n want %+v", got, want)
+	// Full-fidelity check: every rule field (incl. Name, MitreTechnique, Message, and tag values)
+	// must round-trip unchanged — this test locks the wire contract.
+	if !reflect.DeepEqual(decoded.Rules, original.Rules) {
+		t.Errorf("rules did not round-trip:\n got  %+v\n want %+v", decoded.Rules, original.Rules)
 	}
 }
 

--- a/armotypes/cdr/rules_test.go
+++ b/armotypes/cdr/rules_test.go
@@ -25,6 +25,7 @@ func TestCdrRuleBundleRoundTrip(t *testing.T) {
 				MitreTechnique: "T1098",
 				Tags:           []string{"iam", "azure"},
 				Message:        "Role assignment created",
+				UniqueID:       "event.subscriptionId + event.caller",
 				Origin:         CdrRuleOriginManaged,
 			},
 		},


### PR DESCRIPTION
<!-- armosec-pr: v=1 via=manual -->

## Summary

Adds the shared wire types for **CDR managed rule-delivery** in `armotypes/cdr`:

- `CdrRuleBundle` — the endpoint response: `{version, provider, generatedAt, rules[]}`.
- `CdrRule` — a slim, sensor-facing projection of a CDR detection rule (id, name, service, CEL expression, severity, MITRE, tags, message, origin).
- `CdrRuleOrigin` — `managed` (default) | `custom`, forward-compat for the future custom-rules epic.

These sit alongside the existing `CdrAlert`/`CdrAlertBatch` wire types: the in-account CDR collector downloads its provider-scoped CEL rule set as a `CdrRuleBundle`. `Version` is an opaque content hash for change detection (served as the endpoint's ETag). JSON round-trip + omitempty tests included; additive only, no behavioral change.

Wire contract of record: `shared-designs-and-docs/cdr/cdr-rule-delivery-contract.md`. Consumed by the cadashboardbe rule-delivery endpoint (separate PR, pins to the tag cut from this).

## Ticket

[SUB-7653](https://cyberarmor-io.atlassian.net/browse/SUB-7653)


[SUB-7653]: https://cyberarmor-io.atlassian.net/browse/SUB-7653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ