### PR TITLE
feat(httpcapture): sensor<->backend HTTP capture wire contract (spec §5.2)

### DIFF
--- a/armotypes/httpcapture/httpcapture.go
+++ b/armotypes/httpcapture/httpcapture.go
@@ -1,0 +1,90 @@
+// Package httpcapture is the sensor↔backend wire contract for HTTP(S) capture
+// (cloud-agent-sandbox spec §5). A sensor (the eBPF node-agent in Phase 1, an
+// in-line proxy later) uploads captured HTTP transactions to the backend as a
+// stream of message Fragments; the backend reassembles them. Both the sensor and
+// the backend import THIS package so the wire shape is defined exactly once — the
+// sensor never derives it from a backend/ingester package, and vice-versa.
+//
+// The sensor forwards raw bytes and does no content interpretation; everything
+// semantic (parsing, redaction, dedup, token/usage derivation, reassembly) is the
+// backend's. See spec §5.2 (wire unit) and §5.1 (capture fidelity).
+package httpcapture
+
+import "fmt"
+
+// Direction identifies which half of a transaction a fragment belongs to
+// (spec §5.2). It mirrors the capture-side direction: a request is what the
+// workload sent (SSL_write), a response is what it received (SSL_read).
+type Direction string
+
+const (
+	DirectionRequest  Direction = "request"
+	DirectionResponse Direction = "response"
+)
+
+// CaptureFidelity marks how much of a record the sensor actually saw (spec §5.1),
+// so the backend and UI never mistake a capture gap for an absence of activity.
+type CaptureFidelity string
+
+const (
+	FidelityComplete     CaptureFidelity = "complete"      // whole transaction captured
+	FidelityTruncated    CaptureFidelity = "truncated"     // body cut at a capture/size bound
+	FidelityTupleMissing CaptureFidelity = "tuple-missing" // destination 5-tuple unrecoverable
+	FidelityPartial      CaptureFidelity = "partial"       // a fragment was lost / reassembly timed out
+)
+
+// DefaultMaxFragmentBytes is the default per-fragment payload cap. It sits well
+// under the ~4 MB OTLP/gRPC message ceiling to leave headroom for the record
+// envelope and for the ~33% base64 expansion a bytes value incurs when a LogRecord
+// is JSON-encoded; 1 MiB of raw payload encodes to well under 4 MB.
+const DefaultMaxFragmentBytes = 1 << 20 // 1 MiB
+
+// Attribute keys carried on each fragment LogRecord (spec §5.2). Defined here so
+// the sensor that writes them and the backend that reads them share one source of
+// truth for the key strings.
+const (
+	AttrTransactionID   = "http.capture.transaction_id"
+	AttrSequenceNumber  = "http.capture.sequence_number"
+	AttrDirection       = "http.capture.direction"
+	AttrEndOfStream     = "http.capture.end_of_stream"
+	AttrCaptureFidelity = "http.capture.fidelity"
+	AttrFidelityReason  = "http.capture.fidelity_reason"
+)
+
+// Fragment is one unit on the wire (spec §5.2): a slice of one direction of one
+// logical HTTP transaction. It is smaller than a whole request/response — a sensor
+// only ever sees limited slices (one SSL_write unit, one proxy read buffer), and
+// long/streamed bodies exceed the OTLP message ceiling — so a transaction is a
+// STREAM of fragments, not one record.
+//
+// The backend reassembles per (TransactionID, Direction) ordered by SequenceNumber
+// until EndOfStream. Completeness requires the terminal marker AND contiguous
+// SequenceNumber coverage 0..N; a gap resolves to FidelityPartial.
+type Fragment struct {
+	// TransactionID correlates all fragments of one logical HTTP transaction —
+	// BOTH directions (request + response) share it. It MUST be globally unique
+	// across every sensor instance and tenant (see NewTransactionID); the backend
+	// treats it as opaque and only requires uniqueness.
+	TransactionID string `json:"transactionId"`
+	// Direction is request or response.
+	Direction Direction `json:"direction"`
+	// SequenceNumber orders fragments within a direction, contiguous from 0.
+	SequenceNumber uint32 `json:"sequenceNumber"`
+	// EndOfStream is set only on the final fragment of a direction, so the backend
+	// knows the direction is done without a known total size.
+	EndOfStream bool `json:"endOfStream"`
+	// Data is the raw captured payload slice (headers-block bytes or a body chunk),
+	// verbatim — never parsed, masked, or reassembled by the sensor. Bounded by
+	// DefaultMaxFragmentBytes.
+	Data []byte `json:"data"`
+}
+
+// NewTransactionID composes a globally-unique transaction id from readily-available
+// capture-side parts (spec §5.2 "Global uniqueness (required)"). A raw ssl_ptr is a
+// process-local pointer reused after SSL_free, so it collides within an instance
+// over time and across instances immediately; namespacing it by the sensor-instance
+// identity + process start time and disambiguating with a per-connection nonce makes
+// a collision vanishingly unlikely. The backend does not parse the result.
+func NewTransactionID(instanceID string, pid uint32, procStartNS, sslPtr, nonce uint64) string {
+	return fmt.Sprintf("%s:%x:%x:%x:%x", instanceID, pid, procStartNS, sslPtr, nonce)
+}

--- a/armotypes/httpcapture/httpcapture.go
+++ b/armotypes/httpcapture/httpcapture.go
@@ -36,8 +36,14 @@ const (
 // DefaultMaxFragmentBytes is the default per-fragment payload cap. It sits well
 // under the ~4 MB OTLP/gRPC message ceiling to leave headroom for the record
 // envelope and for the ~33% base64 expansion a bytes value incurs when a LogRecord
-// is JSON-encoded; 1 MiB of raw payload encodes to well under 4 MB.
+// is JSON-encoded; 1 MiB of raw payload encodes to well under 4 MB (spec §5.10).
 const DefaultMaxFragmentBytes = 1 << 20 // 1 MiB
+
+// CurrentProtocolVersion is the wire-contract version stamped on every record and
+// every config response "from day one" (spec §5.10): with two sensor types and a
+// fidelity enum evolving independently, versioning the contract now is cheap
+// insurance against a breaking change later. Bump on a breaking wire change.
+const CurrentProtocolVersion = "1.0"
 
 // Attribute keys carried on each fragment LogRecord (spec §5.2). Defined here so
 // the sensor that writes them and the backend that reads them share one source of
@@ -49,6 +55,7 @@ const (
 	AttrEndOfStream     = "http.capture.end_of_stream"
 	AttrCaptureFidelity = "http.capture.fidelity"
 	AttrFidelityReason  = "http.capture.fidelity_reason"
+	AttrProtocolVersion = "http.capture.protocol_version"
 )
 
 // Fragment is one unit on the wire (spec §5.2): a slice of one direction of one
@@ -61,6 +68,10 @@ const (
 // until EndOfStream. Completeness requires the terminal marker AND contiguous
 // SequenceNumber coverage 0..N; a gap resolves to FidelityPartial.
 type Fragment struct {
+	// ProtocolVersion is the wire-contract version this record was produced under
+	// (spec §5.10) — carried on every record from day one so the two sensor types
+	// and the fidelity enum can evolve without a silent breaking change.
+	ProtocolVersion string `json:"protocolVersion"`
 	// TransactionID correlates all fragments of one logical HTTP transaction —
 	// BOTH directions (request + response) share it. It MUST be globally unique
 	// across every sensor instance and tenant (see NewTransactionID); the backend

--- a/armotypes/httpcapture/httpcapture.go
+++ b/armotypes/httpcapture/httpcapture.go
@@ -10,7 +10,11 @@
 // backend's. See spec §5.2 (wire unit) and §5.1 (capture fidelity).
 package httpcapture
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/armosec/armoapi-go/armotypes"
+)
 
 // Direction identifies which half of a transaction a fragment belongs to
 // (spec §5.2). It mirrors the capture-side direction: a request is what the
@@ -20,6 +24,19 @@ type Direction string
 const (
 	DirectionRequest  Direction = "request"
 	DirectionResponse Direction = "response"
+)
+
+// Part marks which section of a direction a fragment carries: the header block or
+// the body. It lets the backend split headers from body without re-parsing the
+// reassembled stream, and — with EndOfStream — tells it whether to expect a body:
+// a headers fragment with EndOfStream=true means the body was intentionally omitted
+// (e.g. a headers-only capture level), not lost. Headers are typically one fragment
+// (bounded ~4–16 KiB, captured in one shot); the body is streamed as many.
+type Part string
+
+const (
+	PartHeaders Part = "headers"
+	PartBody    Part = "body"
 )
 
 // CaptureFidelity marks how much of a record the sensor actually saw (spec §5.1),
@@ -56,6 +73,8 @@ const (
 	AttrCaptureFidelity = "http.capture.fidelity"
 	AttrFidelityReason  = "http.capture.fidelity_reason"
 	AttrProtocolVersion = "http.capture.protocol_version"
+	AttrPart            = "http.capture.part"
+	AttrCapturedAt      = "http.capture.captured_at"
 )
 
 // Fragment is one unit on the wire (spec §5.2): a slice of one direction of one
@@ -79,15 +98,65 @@ type Fragment struct {
 	TransactionID string `json:"transactionId"`
 	// Direction is request or response.
 	Direction Direction `json:"direction"`
-	// SequenceNumber orders fragments within a direction, contiguous from 0.
+	// Part is which section of the direction this fragment carries (headers | body).
+	// Headers fragment(s) come first (SequenceNumber 0…), body fragments after.
+	Part Part `json:"part"`
+	// SequenceNumber orders fragments within a direction, contiguous from 0
+	// (across both parts). The sensor produces it; the backend re-sorts by it.
 	SequenceNumber uint32 `json:"sequenceNumber"`
 	// EndOfStream is set only on the final fragment of a direction, so the backend
-	// knows the direction is done without a known total size.
+	// knows the direction is done without a known total size. The sensor decides it
+	// from transport framing (Content-Length satisfied / chunked terminator / close).
 	EndOfStream bool `json:"endOfStream"`
+	// CapturedAt is when this fragment was captured (unix nanoseconds). Per-fragment,
+	// because a streamed transaction spans time.
+	CapturedAt int64 `json:"capturedAt"`
 	// Data is the raw captured payload slice (headers-block bytes or a body chunk),
 	// verbatim — never parsed, masked, or reassembled by the sensor. Bounded by
 	// DefaultMaxFragmentBytes.
 	Data []byte `json:"data"`
+
+	// --- Lightweight identity, on EVERY fragment (placement "B") ---
+	// So the backend can attribute any fragment and query "in a sandbox" without a
+	// join. These REUSE the existing armotypes identity structs — the agent does not
+	// define its own process/cloud attribution. (The heavy process TREE is NOT here;
+	// it rides once per transaction on CaptureEnvelope — placement "A".)
+	//
+	// This identity may also be propagated to OTLP resource attributes to avoid
+	// repeating it per fragment; that is a later, easy-to-add optimization.
+	CustomerGUID string                            `json:"customerGuid,omitempty"`
+	SandboxID    string                            `json:"sandboxId,omitempty"`
+	K8s          *armotypes.RuntimeAlertK8sDetails `json:"k8s,omitempty"`   // pod / node / container / workload / cluster
+	Cloud        *armotypes.CloudMetadata          `json:"cloud,omitempty"` // account_id / region / provider / zone
+}
+
+// CaptureEnvelope is the per-transaction correlation envelope (spec §5.7): who the
+// transaction came from and where it went. It is sent ONCE per transaction (keyed
+// by TransactionID), not repeated on every body fragment, so a large multi-fragment
+// body doesn't re-ship the attribution. Attribution is populated to the sensor's
+// capability; consumers must treat individual fields as optional.
+type CaptureEnvelope struct {
+	ProtocolVersion string `json:"protocolVersion"`
+	// TransactionID links the envelope to its fragments.
+	TransactionID string `json:"transactionId"`
+	// CapturedAt is when the transaction was first observed (unix nanoseconds).
+	CapturedAt int64 `json:"capturedAt"`
+
+	// ProcessTree — WHICH PROCESS this transaction is from, with its FULL lineage
+	// (placement "A"): the process and every ancestor before it, so e.g. an HTTP
+	// call in P1 carries that P2 (the sandbox agent) spawned P1. It REUSES the
+	// existing armotypes.ProcessTree (the RuntimeAlert process tree) — the agent does
+	// NOT define its own process attribution. It rides ONCE per transaction, not on
+	// every fragment, because the tree can be large.
+	ProcessTree armotypes.ProcessTree `json:"processTree"`
+
+	// Destination — WHERE it went (recovered per transaction; absent when
+	// unrecoverable, reflected as FidelityTupleMissing on the fragments).
+	ServerAddress string `json:"serverAddress,omitempty"`
+	ServerPort    uint16 `json:"serverPort,omitempty"`
+
+	// SensorInstanceID identifies the emitting sensor (node-agent pod / gateway).
+	SensorInstanceID string `json:"sensorInstanceId,omitempty"`
 }
 
 // NewTransactionID composes a globally-unique transaction id from readily-available

--- a/armotypes/httpcapture/httpcapture.go
+++ b/armotypes/httpcapture/httpcapture.go
@@ -172,10 +172,19 @@ type CaptureConfig struct {
 	MaxFragmentBytes    int64 `json:"maxFragmentBytes,omitempty"`
 	MaxTransactionBytes int64 `json:"maxTransactionBytes,omitempty"`
 
-	// MaxTransactionsPerHour is the per-agent volume cap (0 ⇒ agent default). When it
-	// is exhausted the agent uploads NOTHING for further transactions this window and
-	// emits a "limit exhausted" signal to the backend.
-	MaxTransactionsPerHour int64 `json:"maxTransactionsPerHour,omitempty"`
+	// Transaction volume caps (0 ⇒ agent default). Both count whole transactions over a
+	// rolling window; when either is exhausted the agent uploads NOTHING for further
+	// transactions and emits a "limit exhausted" signal.
+	//   - MaxTransactionsPerHour: the global cap for the whole agent — every sandbox on
+	//     the node shares it.
+	//   - MaxTransactionsPerSandboxPerHour: a per-sandbox (container / pod / VM) fairness
+	//     cap the agent enforces with a per-sandbox_id counter, so one "bomber" sandbox
+	//     doing millions of requests cannot consume the global budget and starve the
+	//     other sandboxes. Agent-local (a sandbox instance lives on one node, so this
+	//     agent sees all of its traffic); a restart is a new sandbox_id with a fresh
+	//     budget, which is correct for a fairness cap.
+	MaxTransactionsPerHour           int64 `json:"maxTransactionsPerHour,omitempty"`
+	MaxTransactionsPerSandboxPerHour int64 `json:"maxTransactionsPerSandboxPerHour,omitempty"`
 
 	// Credential-header masking (§5.6). MaskKnownCredentialHeaders is a pointer so
 	// absent ⇒ default true (fail-safe: mask). ExtraCredentialHeaders adds names to

--- a/armotypes/httpcapture/httpcapture.go
+++ b/armotypes/httpcapture/httpcapture.go
@@ -65,6 +65,14 @@ const CurrentProtocolVersion = "1.0"
 // Attribute keys carried on each fragment LogRecord (spec §5.2). Defined here so
 // the sensor that writes them and the backend that reads them share one source of
 // truth for the key strings.
+//
+// These are the fragment-specific keys owned by this contract. Each Fragment is
+// emitted as one OTLP LogRecord whose Body is the raw Data bytes; the identity fields
+// below (K8s/Cloud/SandboxID/Server*/ProcessTree/…) are encoded with the shared
+// sandbox-event-schema keys, NOT http.capture.* keys, so capture fragments carry one
+// identity scheme with every other event family. The full LogRecord encoding
+// (resource attrs + record attrs + Body + a worked example) is documented in
+// private-node-agent docs/features/http-capture.md §3.1 "OTEL LogRecord encoding".
 const (
 	AttrTransactionID   = "http.capture.transaction_id"
 	AttrSequenceNumber  = "http.capture.sequence_number"
@@ -124,20 +132,20 @@ type Fragment struct {
 	//
 	// This identity may also be propagated to OTLP resource attributes to avoid
 	// repeating it per fragment; that is a later, easy-to-add optimization.
-	CustomerGUID string                            `json:"customerGuid,omitempty"`
-	SandboxID    string                            `json:"sandboxId,omitempty"`
-	K8s          *armotypes.RuntimeAlertK8sDetails `json:"k8s,omitempty"`   // pod / node / container / workload / cluster
-	Cloud        *armotypes.CloudMetadata          `json:"cloud,omitempty"` // account_id / region / provider / zone
+	CustomerGUID string                            `json:"customerGuid,omitempty"` // OTEL: customer_guid (resource attr)
+	SandboxID    string                            `json:"sandboxId,omitempty"`    // OTEL: sandbox_id / instance_ref
+	K8s          *armotypes.RuntimeAlertK8sDetails `json:"k8s,omitempty"`          // OTEL: wlid / pod_name / namespace / container.id / container_name
+	Cloud        *armotypes.CloudMetadata          `json:"cloud,omitempty"`        // OTEL: cloud.account_id / cloud.region / cloud.provider
 
 	// --- Per-transaction attribution, on the FIRST fragment only (placement A) ---
 	// Carried once — on the request-headers fragment (SequenceNumber 0) — not a
 	// separate record and not repeated per fragment (the process tree can be large).
 	// nil/zero on every other fragment. Reuses armotypes.ProcessTree (RuntimeAlert
 	// tree) — the agent defines no process attribution of its own.
-	ProcessTree      *armotypes.ProcessTree `json:"processTree,omitempty"` // full process lineage (P1 spawned by P2)
-	ServerAddress    string                 `json:"serverAddress,omitempty"`
-	ServerPort       uint16                 `json:"serverPort,omitempty"`
-	SensorInstanceID string                 `json:"sensorInstanceId,omitempty"`
+	ProcessTree      *armotypes.ProcessTree `json:"processTree,omitempty"`      // OTEL: process_lineage (JSON, first fragment)
+	ServerAddress    string                 `json:"serverAddress,omitempty"`    // OTEL: server.address (every fragment)
+	ServerPort       uint16                 `json:"serverPort,omitempty"`       // OTEL: server.port (every fragment)
+	SensorInstanceID string                 `json:"sensorInstanceId,omitempty"` // OTEL: sensor_instance_id (first fragment)
 
 	// Fidelity marks a capture gap on this fragment (§5.1); empty ⇒ complete. On a
 	// per-transaction size-cap truncation the terminal fragment carries

--- a/armotypes/httpcapture/httpcapture.go
+++ b/armotypes/httpcapture/httpcapture.go
@@ -120,7 +120,7 @@ type Fragment struct {
 	// So the backend can attribute any fragment and query "in a sandbox" without a
 	// join. These REUSE the existing armotypes identity structs — the agent does not
 	// define its own process/cloud attribution. (The heavy process TREE is NOT here;
-	// it rides once per transaction on CaptureEnvelope — placement "A".)
+	// it rides once, on the first fragment — placement "A", see below.)
 	//
 	// This identity may also be propagated to OTLP resource attributes to avoid
 	// repeating it per fragment; that is a later, easy-to-add optimization.
@@ -128,35 +128,52 @@ type Fragment struct {
 	SandboxID    string                            `json:"sandboxId,omitempty"`
 	K8s          *armotypes.RuntimeAlertK8sDetails `json:"k8s,omitempty"`   // pod / node / container / workload / cluster
 	Cloud        *armotypes.CloudMetadata          `json:"cloud,omitempty"` // account_id / region / provider / zone
+
+	// --- Per-transaction attribution, on the FIRST fragment only (placement A) ---
+	// Carried once — on the request-headers fragment (SequenceNumber 0) — not a
+	// separate record and not repeated per fragment (the process tree can be large).
+	// nil/zero on every other fragment. Reuses armotypes.ProcessTree (RuntimeAlert
+	// tree) — the agent defines no process attribution of its own.
+	ProcessTree      *armotypes.ProcessTree `json:"processTree,omitempty"` // full process lineage (P1 spawned by P2)
+	ServerAddress    string                 `json:"serverAddress,omitempty"`
+	ServerPort       uint16                 `json:"serverPort,omitempty"`
+	SensorInstanceID string                 `json:"sensorInstanceId,omitempty"`
+
+	// Fidelity marks a capture gap on this fragment (§5.1); empty ⇒ complete. On a
+	// per-transaction size-cap truncation the terminal fragment carries
+	// EndOfStream=true AND Fidelity=FidelityTruncated.
+	Fidelity       CaptureFidelity `json:"fidelity,omitempty"`
+	FidelityReason string          `json:"fidelityReason,omitempty"`
 }
 
-// CaptureEnvelope is the per-transaction correlation envelope (spec §5.7): who the
-// transaction came from and where it went. It is sent ONCE per transaction (keyed
-// by TransactionID), not repeated on every body fragment, so a large multi-fragment
-// body doesn't re-ship the attribution. Attribution is populated to the sensor's
-// capability; consumers must treat individual fields as optional.
-type CaptureEnvelope struct {
+// CaptureConfig is the backend-supplied capture configuration the sensor polls
+// (spec §5.3/§5.4). It carries enablement, the caps, and the masking controls. The
+// sensor uses built-in defaults until a config is fetched (a 0 cap ⇒ agent default),
+// and fails closed (captures nothing) with no config. The per-target upload-policy
+// rules (host/path → full|headers|none) are the agent's uploadpolicy types today and
+// migrate into this package next.
+type CaptureConfig struct {
 	ProtocolVersion string `json:"protocolVersion"`
-	// TransactionID links the envelope to its fragments.
-	TransactionID string `json:"transactionId"`
-	// CapturedAt is when the transaction was first observed (unix nanoseconds).
-	CapturedAt int64 `json:"capturedAt"`
+	// Enabled is the master switch; false ⇒ the sensor captures nothing.
+	Enabled bool `json:"enabled"`
 
-	// ProcessTree — WHICH PROCESS this transaction is from, with its FULL lineage
-	// (placement "A"): the process and every ancestor before it, so e.g. an HTTP
-	// call in P1 carries that P2 (the sandbox agent) spawned P1. It REUSES the
-	// existing armotypes.ProcessTree (the RuntimeAlert process tree) — the agent does
-	// NOT define its own process attribution. It rides ONCE per transaction, not on
-	// every fragment, because the tree can be large.
-	ProcessTree armotypes.ProcessTree `json:"processTree"`
+	// Size caps in bytes (0 ⇒ use the agent default). MaxFragmentBytes bounds one
+	// fragment; MaxTransactionBytes bounds a whole transaction — on hit the body is
+	// truncated (headers are still sent) and the terminal fragment is marked
+	// EndOfStream + FidelityTruncated.
+	MaxFragmentBytes    int64 `json:"maxFragmentBytes,omitempty"`
+	MaxTransactionBytes int64 `json:"maxTransactionBytes,omitempty"`
 
-	// Destination — WHERE it went (recovered per transaction; absent when
-	// unrecoverable, reflected as FidelityTupleMissing on the fragments).
-	ServerAddress string `json:"serverAddress,omitempty"`
-	ServerPort    uint16 `json:"serverPort,omitempty"`
+	// MaxTransactionsPerHour is the per-agent volume cap (0 ⇒ agent default). When it
+	// is exhausted the agent uploads NOTHING for further transactions this window and
+	// emits a "limit exhausted" signal to the backend.
+	MaxTransactionsPerHour int64 `json:"maxTransactionsPerHour,omitempty"`
 
-	// SensorInstanceID identifies the emitting sensor (node-agent pod / gateway).
-	SensorInstanceID string `json:"sensorInstanceId,omitempty"`
+	// Credential-header masking (§5.6). MaskKnownCredentialHeaders is a pointer so
+	// absent ⇒ default true (fail-safe: mask). ExtraCredentialHeaders adds names to
+	// the masked set. Masking is a one-way (irreversible) fingerprint.
+	MaskKnownCredentialHeaders *bool    `json:"maskKnownCredentialHeaders,omitempty"`
+	ExtraCredentialHeaders     []string `json:"extraCredentialHeaders,omitempty"`
 }
 
 // NewTransactionID composes a globally-unique transaction id from readily-available

--- a/armotypes/httpcapture/httpcapture_test.go
+++ b/armotypes/httpcapture/httpcapture_test.go
@@ -45,11 +45,12 @@ func TestNewTransactionID(t *testing.T) {
 // (bytes) survives — this is the binary-safe carrier for raw captured payload.
 func TestFragmentJSONRoundTrip(t *testing.T) {
 	in := Fragment{
-		TransactionID:  "inst-1:2a:64:deadbeef:1",
-		Direction:      DirectionResponse,
-		SequenceNumber: 3,
-		EndOfStream:    true,
-		Data:           []byte{0x00, 0x01, 0xff, 'h', 'i'}, // non-UTF8: proves bytes carrier
+		ProtocolVersion: CurrentProtocolVersion,
+		TransactionID:   "inst-1:2a:64:deadbeef:1",
+		Direction:       DirectionResponse,
+		SequenceNumber:  3,
+		EndOfStream:     true,
+		Data:            []byte{0x00, 0x01, 0xff, 'h', 'i'}, // non-UTF8: proves bytes carrier
 	}
 	b, err := json.Marshal(in)
 	if err != nil {
@@ -59,9 +60,9 @@ func TestFragmentJSONRoundTrip(t *testing.T) {
 	if err := json.Unmarshal(b, &out); err != nil {
 		t.Fatal(err)
 	}
-	if out.TransactionID != in.TransactionID || out.Direction != in.Direction ||
-		out.SequenceNumber != in.SequenceNumber || out.EndOfStream != in.EndOfStream ||
-		string(out.Data) != string(in.Data) {
+	if out.ProtocolVersion != in.ProtocolVersion || out.TransactionID != in.TransactionID ||
+		out.Direction != in.Direction || out.SequenceNumber != in.SequenceNumber ||
+		out.EndOfStream != in.EndOfStream || string(out.Data) != string(in.Data) {
 		t.Errorf("round-trip mismatch:\n in=%+v\nout=%+v", in, out)
 	}
 }

--- a/armotypes/httpcapture/httpcapture_test.go
+++ b/armotypes/httpcapture/httpcapture_test.go
@@ -108,24 +108,52 @@ func TestReusedIdentityAndProcessTree(t *testing.T) {
 		t.Errorf("fragment identity did not round-trip: %+v", fo)
 	}
 
-	// Envelope carries the full process lineage (A): P1 spawned by P2.
-	env := CaptureEnvelope{
+	// The FIRST fragment (request headers, seq 0) carries the full process lineage
+	// (A): P1 spawned by P2. On other fragments ProcessTree is nil.
+	first := Fragment{
 		ProtocolVersion: CurrentProtocolVersion, TransactionID: "t1",
-		ProcessTree: armotypes.ProcessTree{ProcessTree: armotypes.Process{
+		Direction: DirectionRequest, Part: PartHeaders, SequenceNumber: 0,
+		ProcessTree: &armotypes.ProcessTree{ProcessTree: armotypes.Process{
 			PID: 200, Comm: "sandbox-agent",
 			ChildrenMap: map[armotypes.CommPID]*armotypes.Process{
 				{Comm: "python3", PID: 201}: {PID: 201, PPID: 200, Comm: "python3"},
 			},
 		}},
-		ServerAddress: "api.example.com", ServerPort: 443,
+		ServerAddress: "api.example.com", ServerPort: 443, SensorInstanceID: "node-7",
 	}
-	var eo CaptureEnvelope
-	if b, err := json.Marshal(env); err != nil {
+	var firstO Fragment
+	if b, err := json.Marshal(first); err != nil {
 		t.Fatal(err)
-	} else if err := json.Unmarshal(b, &eo); err != nil {
+	} else if err := json.Unmarshal(b, &firstO); err != nil {
 		t.Fatal(err)
 	}
-	if eo.ProcessTree.ProcessTree.PID != 200 || eo.ProcessTree.FindProcessByPID(201) == nil {
-		t.Errorf("process tree/lineage did not round-trip: %+v", eo.ProcessTree)
+	if firstO.ProcessTree == nil || firstO.ProcessTree.ProcessTree.PID != 200 || firstO.ProcessTree.FindProcessByPID(201) == nil {
+		t.Errorf("process tree/lineage did not round-trip on the first fragment: %+v", firstO.ProcessTree)
+	}
+	if fo.ProcessTree != nil {
+		t.Error("non-first fragment must not carry a process tree")
+	}
+}
+
+// CaptureConfig round-trips the caps + masking controls the backend delivers.
+func TestCaptureConfigRoundTrip(t *testing.T) {
+	mask := false
+	in := CaptureConfig{
+		ProtocolVersion: CurrentProtocolVersion, Enabled: true,
+		MaxFragmentBytes: 1 << 20, MaxTransactionBytes: 8 << 20, MaxTransactionsPerHour: 5000,
+		MaskKnownCredentialHeaders: &mask, ExtraCredentialHeaders: []string{"x-acme-signature"},
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out CaptureConfig
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	if !out.Enabled || out.MaxTransactionsPerHour != 5000 || out.MaxTransactionBytes != 8<<20 ||
+		out.MaskKnownCredentialHeaders == nil || *out.MaskKnownCredentialHeaders != false ||
+		len(out.ExtraCredentialHeaders) != 1 {
+		t.Errorf("config did not round-trip: %+v", out)
 	}
 }

--- a/armotypes/httpcapture/httpcapture_test.go
+++ b/armotypes/httpcapture/httpcapture_test.go
@@ -140,7 +140,8 @@ func TestCaptureConfigRoundTrip(t *testing.T) {
 	mask := false
 	in := CaptureConfig{
 		ProtocolVersion: CurrentProtocolVersion, Enabled: true,
-		MaxFragmentBytes: 1 << 20, MaxTransactionBytes: 8 << 20, MaxTransactionsPerHour: 5000,
+		MaxFragmentBytes: 1 << 20, MaxTransactionBytes: 8 << 20,
+		MaxTransactionsPerHour: 5000, MaxTransactionsPerSandboxPerHour: 500,
 		MaskKnownCredentialHeaders: &mask, ExtraCredentialHeaders: []string{"x-acme-signature"},
 	}
 	b, err := json.Marshal(in)
@@ -151,7 +152,8 @@ func TestCaptureConfigRoundTrip(t *testing.T) {
 	if err := json.Unmarshal(b, &out); err != nil {
 		t.Fatal(err)
 	}
-	if !out.Enabled || out.MaxTransactionsPerHour != 5000 || out.MaxTransactionBytes != 8<<20 ||
+	if !out.Enabled || out.MaxTransactionsPerHour != 5000 || out.MaxTransactionsPerSandboxPerHour != 500 ||
+		out.MaxTransactionBytes != 8<<20 ||
 		out.MaskKnownCredentialHeaders == nil || *out.MaskKnownCredentialHeaders != false ||
 		len(out.ExtraCredentialHeaders) != 1 {
 		t.Errorf("config did not round-trip: %+v", out)

--- a/armotypes/httpcapture/httpcapture_test.go
+++ b/armotypes/httpcapture/httpcapture_test.go
@@ -3,6 +3,8 @@ package httpcapture
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/armosec/armoapi-go/armotypes"
 )
 
 // The wire string values are part of the contract — both sensor and backend match
@@ -56,8 +58,10 @@ func TestFragmentJSONRoundTrip(t *testing.T) {
 		ProtocolVersion: CurrentProtocolVersion,
 		TransactionID:   "inst-1:2a:64:deadbeef:1",
 		Direction:       DirectionResponse,
+		Part:            PartBody,
 		SequenceNumber:  3,
 		EndOfStream:     true,
+		CapturedAt:      1700000000000000000,
 		Data:            []byte{0x00, 0x01, 0xff, 'h', 'i'}, // non-UTF8: proves bytes carrier
 	}
 	b, err := json.Marshal(in)
@@ -66,7 +70,7 @@ func TestFragmentJSONRoundTrip(t *testing.T) {
 	}
 	// Pin the exact wire shape (field names + order + base64 Data) so a JSON-tag
 	// regression is caught — round-tripping the same Go type alone would not.
-	const wantJSON = `{"protocolVersion":"1.0","transactionId":"inst-1:2a:64:deadbeef:1","direction":"response","sequenceNumber":3,"endOfStream":true,"data":"AAH/aGk="}`
+	const wantJSON = `{"protocolVersion":"1.0","transactionId":"inst-1:2a:64:deadbeef:1","direction":"response","part":"body","sequenceNumber":3,"endOfStream":true,"capturedAt":1700000000000000000,"data":"AAH/aGk="}`
 	if string(b) != wantJSON {
 		t.Fatalf("wire JSON =\n  %s\nwant\n  %s", b, wantJSON)
 	}
@@ -75,8 +79,53 @@ func TestFragmentJSONRoundTrip(t *testing.T) {
 		t.Fatal(err)
 	}
 	if out.ProtocolVersion != in.ProtocolVersion || out.TransactionID != in.TransactionID ||
-		out.Direction != in.Direction || out.SequenceNumber != in.SequenceNumber ||
-		out.EndOfStream != in.EndOfStream || string(out.Data) != string(in.Data) {
+		out.Direction != in.Direction || out.Part != in.Part ||
+		out.SequenceNumber != in.SequenceNumber || out.EndOfStream != in.EndOfStream ||
+		out.CapturedAt != in.CapturedAt || string(out.Data) != string(in.Data) {
 		t.Errorf("round-trip mismatch:\n in=%+v\nout=%+v", in, out)
+	}
+}
+
+// The reused identity (per fragment, "B") and the reused process tree (per
+// transaction, "A") round-trip — proving we compose the existing armotypes structs
+// rather than inventing our own process/cloud attribution.
+func TestReusedIdentityAndProcessTree(t *testing.T) {
+	// Fragment carries the lightweight identity (B).
+	f := Fragment{
+		ProtocolVersion: CurrentProtocolVersion,
+		TransactionID:   "t1", Direction: DirectionRequest, Part: PartHeaders,
+		CustomerGUID: "cust-abc", SandboxID: "sbx-1",
+		K8s:   &armotypes.RuntimeAlertK8sDetails{PodName: "orders-7c9", WorkloadName: "orders", NodeName: "node-7"},
+		Cloud: &armotypes.CloudMetadata{AccountID: "1234", Region: "eu-central-1"},
+	}
+	var fo Fragment
+	if b, err := json.Marshal(f); err != nil {
+		t.Fatal(err)
+	} else if err := json.Unmarshal(b, &fo); err != nil {
+		t.Fatal(err)
+	}
+	if fo.K8s == nil || fo.K8s.PodName != "orders-7c9" || fo.Cloud == nil || fo.Cloud.Region != "eu-central-1" || fo.CustomerGUID != "cust-abc" {
+		t.Errorf("fragment identity did not round-trip: %+v", fo)
+	}
+
+	// Envelope carries the full process lineage (A): P1 spawned by P2.
+	env := CaptureEnvelope{
+		ProtocolVersion: CurrentProtocolVersion, TransactionID: "t1",
+		ProcessTree: armotypes.ProcessTree{ProcessTree: armotypes.Process{
+			PID: 200, Comm: "sandbox-agent",
+			ChildrenMap: map[armotypes.CommPID]*armotypes.Process{
+				{Comm: "python3", PID: 201}: {PID: 201, PPID: 200, Comm: "python3"},
+			},
+		}},
+		ServerAddress: "api.example.com", ServerPort: 443,
+	}
+	var eo CaptureEnvelope
+	if b, err := json.Marshal(env); err != nil {
+		t.Fatal(err)
+	} else if err := json.Unmarshal(b, &eo); err != nil {
+		t.Fatal(err)
+	}
+	if eo.ProcessTree.ProcessTree.PID != 200 || eo.ProcessTree.FindProcessByPID(201) == nil {
+		t.Errorf("process tree/lineage did not round-trip: %+v", eo.ProcessTree)
 	}
 }

--- a/armotypes/httpcapture/httpcapture_test.go
+++ b/armotypes/httpcapture/httpcapture_test.go
@@ -31,13 +31,21 @@ func TestNewTransactionID(t *testing.T) {
 	if a != b {
 		t.Errorf("same inputs must yield same id: %q vs %q", a, b)
 	}
-	// identical except the nonce — must differ (reused ssl_ptr)
-	if c := NewTransactionID("inst-1", 42, 100, 0xdeadbeef, 2); c == a {
-		t.Errorf("nonce must disambiguate a reused ssl_ptr, got %q for both", a)
-	}
-	// different instance — must differ
-	if d := NewTransactionID("inst-2", 42, 100, 0xdeadbeef, 1); d == a {
-		t.Errorf("instance id must namespace the transaction id, got %q for both", a)
+	// Every input must independently affect the id — change exactly one from the
+	// baseline at a time, so the test fails if any part is dropped from the id.
+	for _, tc := range []struct {
+		name string
+		id   string
+	}{
+		{"nonce", NewTransactionID("inst-1", 42, 100, 0xdeadbeef, 2)},
+		{"instanceID", NewTransactionID("inst-2", 42, 100, 0xdeadbeef, 1)},
+		{"pid", NewTransactionID("inst-1", 43, 100, 0xdeadbeef, 1)},
+		{"procStartNS", NewTransactionID("inst-1", 42, 101, 0xdeadbeef, 1)},
+		{"sslPtr", NewTransactionID("inst-1", 42, 100, 0xdeadbee0, 1)},
+	} {
+		if tc.id == a {
+			t.Errorf("changing %s must change the transaction id, but both were %q", tc.name, a)
+		}
 	}
 }
 
@@ -55,6 +63,12 @@ func TestFragmentJSONRoundTrip(t *testing.T) {
 	b, err := json.Marshal(in)
 	if err != nil {
 		t.Fatal(err)
+	}
+	// Pin the exact wire shape (field names + order + base64 Data) so a JSON-tag
+	// regression is caught — round-tripping the same Go type alone would not.
+	const wantJSON = `{"protocolVersion":"1.0","transactionId":"inst-1:2a:64:deadbeef:1","direction":"response","sequenceNumber":3,"endOfStream":true,"data":"AAH/aGk="}`
+	if string(b) != wantJSON {
+		t.Fatalf("wire JSON =\n  %s\nwant\n  %s", b, wantJSON)
 	}
 	var out Fragment
 	if err := json.Unmarshal(b, &out); err != nil {

--- a/armotypes/httpcapture/httpcapture_test.go
+++ b/armotypes/httpcapture/httpcapture_test.go
@@ -1,0 +1,67 @@
+package httpcapture
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The wire string values are part of the contract — both sensor and backend match
+// on them, so a rename is a breaking change and must be caught here.
+func TestEnumWireValues(t *testing.T) {
+	if DirectionRequest != "request" || DirectionResponse != "response" {
+		t.Errorf("direction wire values changed: %q %q", DirectionRequest, DirectionResponse)
+	}
+	fid := map[CaptureFidelity]string{
+		FidelityComplete: "complete", FidelityTruncated: "truncated",
+		FidelityTupleMissing: "tuple-missing", FidelityPartial: "partial",
+	}
+	for got, want := range fid {
+		if string(got) != want {
+			t.Errorf("fidelity wire value = %q, want %q", got, want)
+		}
+	}
+}
+
+// NewTransactionID must be deterministic in its inputs (same parts → same id) and
+// distinguish connections by the nonce even when every other part repeats — the
+// ssl_ptr-reuse collision the id exists to defeat (spec §5.2).
+func TestNewTransactionID(t *testing.T) {
+	a := NewTransactionID("inst-1", 42, 100, 0xdeadbeef, 1)
+	b := NewTransactionID("inst-1", 42, 100, 0xdeadbeef, 1)
+	if a != b {
+		t.Errorf("same inputs must yield same id: %q vs %q", a, b)
+	}
+	// identical except the nonce — must differ (reused ssl_ptr)
+	if c := NewTransactionID("inst-1", 42, 100, 0xdeadbeef, 2); c == a {
+		t.Errorf("nonce must disambiguate a reused ssl_ptr, got %q for both", a)
+	}
+	// different instance — must differ
+	if d := NewTransactionID("inst-2", 42, 100, 0xdeadbeef, 1); d == a {
+		t.Errorf("instance id must namespace the transaction id, got %q for both", a)
+	}
+}
+
+// A Fragment round-trips through JSON with the contract field names, and Data
+// (bytes) survives — this is the binary-safe carrier for raw captured payload.
+func TestFragmentJSONRoundTrip(t *testing.T) {
+	in := Fragment{
+		TransactionID:  "inst-1:2a:64:deadbeef:1",
+		Direction:      DirectionResponse,
+		SequenceNumber: 3,
+		EndOfStream:    true,
+		Data:           []byte{0x00, 0x01, 0xff, 'h', 'i'}, // non-UTF8: proves bytes carrier
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out Fragment
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.TransactionID != in.TransactionID || out.Direction != in.Direction ||
+		out.SequenceNumber != in.SequenceNumber || out.EndOfStream != in.EndOfStream ||
+		string(out.Data) != string(in.Data) {
+		t.Errorf("round-trip mismatch:\n in=%+v\nout=%+v", in, out)
+	}
+}


### PR DESCRIPTION
## Summary

Adds the shared **sensor↔backend HTTP(S) capture wire contract** for cloud-agent-sandbox, per `shared-designs-and-docs` spec **§5** (PR #113). It lives here in `armoapi-go` so **both** the node-agent (sensor) and the backend (`event-ingester-service`) import one definition — neither derives the wire shape from the other's internals.

New package `armotypes/httpcapture`:

- **`Fragment`** (§5.2) — one `LogRecord` = one slice of one direction of one HTTP transaction: `ProtocolVersion`, `TransactionID`, `Direction`, `SequenceNumber`, `EndOfStream`, `Data`. `Data` is `[]byte` (binary-safe carrier — raw header-block bytes or a body chunk, verbatim; the sensor never parses/masks content). A transaction is a *stream* of fragments; the backend reassembles per `(TransactionID, Direction)` ordered by `SequenceNumber` until `EndOfStream`.
- **`Direction`** (`request|response`) and **`CaptureFidelity`** (`complete|truncated|tuple-missing|partial`, §5.1) as wire-stable string enums.
- **`CurrentProtocolVersion = "1.0"`** — stamped on every record from day one (§5.10).
- **Attribute-key constants** — one source of truth for the sensor writer and the backend reader.
- **`NewTransactionID`** — globally-unique id from `instanceID + pid + procStart + sslPtr + nonce` (§5.2; the nonce defeats `ssl_ptr` reuse after `SSL_free`).

Tests pin the wire enum values (a rename is a breaking change), the transaction-id uniqueness semantics, and a `Fragment` JSON round-trip including non-UTF8 `Data`.

The **upload-policy config schema** (§5.3) is the natural next addition to this package.

## Context
- Spec: `shared-designs-and-docs` §5.1 / §5.2 / §5.10.
- Consumers: `private-node-agent` (SUB-7588, PR #441) writes fragments; `event-ingester-service` reassembles them.

AI-skills: artifact-design | cmds: /loop