### PR TITLE
feat(cdr): add GCP Admin Activity audit-log types (SUB-7810)

### DIFF
--- a/armotypes/cdr/cdr.go
+++ b/armotypes/cdr/cdr.go
@@ -17,6 +17,10 @@ const (
 	CloudTrail CloudService = "cloudtrail"
 	// ActivityLogs is the Azure Activity Log service (control-plane audit log)
 	ActivityLogs CloudService = "activitylogs"
+	// CloudAuditLogs is the GCP Cloud Audit Logs service; the CDR pipe consumes
+	// the Admin Activity control-plane audit log (the GCP equivalent of AWS
+	// CloudTrail management events / the Azure Activity Log).
+	CloudAuditLogs CloudService = "cloudauditlogs"
 	// Add more cloud services here
 )
 
@@ -28,6 +32,8 @@ const (
 	AWS CloudProvider = "aws"
 	// Azure is the Microsoft Azure cloud provider
 	Azure CloudProvider = "azure"
+	// GCP is the Google Cloud Platform cloud provider
+	GCP CloudProvider = "gcp"
 	// Add more cloud providers here
 )
 
@@ -44,6 +50,8 @@ type EventData struct {
 	AWSCloudTrail *CloudTrailEvent `json:"awsCloudTrail,omitempty"`
 	// AzureActivityLog azure activity log event
 	AzureActivityLog *AzureActivityLogEvent `json:"azureActivityLog,omitempty"`
+	// GcpAuditLog gcp cloud audit log (Admin Activity) event
+	GcpAuditLog *GcpAuditLogEvent `json:"gcpAuditLog,omitempty"`
 	// Target resource
 	TargetResource string `json:"targetResource,omitempty"`
 	// Identifiers of the alert

--- a/armotypes/cdr/gcp.go
+++ b/armotypes/cdr/gcp.go
@@ -126,11 +126,31 @@ type GcpAuditLogPayload struct {
 	// Status is the operation status. Present but EMPTY ({}) on success, so
 	// status.code is absent rather than 0 — guard with has() in CEL.
 	Status *GcpStatus `json:"status,omitempty"`
+	// PolicyViolationInfo carries org-policy / VPC Service Controls violation
+	// details when a request is denied by policy — a detection class of its own
+	// (org-policy and perimeter denials). Shape varies; kept generic.
+	PolicyViolationInfo map[string]interface{} `json:"policyViolationInfo,omitempty"`
+	// ResourceLocation is where the resource is/was located (current vs original),
+	// e.g. for data-residency-aware rules.
+	ResourceLocation *GcpResourceLocation `json:"resourceLocation,omitempty"`
+	// NumResponseItems is the number of items returned by a list/query method.
+	// protojson encodes int64 as a JSON string, so it is modeled as a string.
+	NumResponseItems string `json:"numResponseItems,omitempty"`
 	// Request is the operation-specific request bag; shape varies by method.
 	Request map[string]interface{} `json:"request,omitempty"`
 	// Response is the operation-specific response bag; for create-style methods
 	// Response["name"] is the created resource (the real target).
 	Response map[string]interface{} `json:"response,omitempty"`
+	// Metadata is where several services (GKE, BigQuery, Cloud SQL, ...) put their
+	// audit detail instead of Request / Response; shape varies by service.
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// GcpResourceLocation is the AuditLog.resourceLocation — the resource's current
+// and (for moves) original locations.
+type GcpResourceLocation struct {
+	CurrentLocations  []string `json:"currentLocations,omitempty"`
+	OriginalLocations []string `json:"originalLocations,omitempty"`
 }
 
 // GcpAuthenticationInfo is the AuditLog.authenticationInfo — the caller identity.
@@ -141,8 +161,36 @@ type GcpAuthenticationInfo struct {
 	// which cleanly distinguishes user from service-account callers for
 	// common.Identifiers normalization (POC FINDINGS §1c⑤).
 	PrincipalSubject string `json:"principalSubject,omitempty"`
+	// ServiceAccountKeyName is the resource name of the service-account key used
+	// to authenticate, when a long-lived key was used rather than short-lived
+	// credentials — a standing detection / compliance signal.
+	ServiceAccountKeyName string `json:"serviceAccountKeyName,omitempty"`
+	// ServiceAccountDelegationInfo is the identity-delegation (impersonation)
+	// chain. Service-account impersonation (iam.serviceAccounts.getAccessToken /
+	// actAs) is the canonical GCP privilege-escalation path; this is what lets an
+	// alert say who impersonated whom. Absent unless impersonation occurred (so
+	// not seen in the human-auth POC run — its absence there is not evidence of
+	// rarity in the field).
+	ServiceAccountDelegationInfo []GcpServiceAccountDelegationInfo `json:"serviceAccountDelegationInfo,omitempty"`
 	// OAuthInfo carries the OAuth client that made the call, when present.
 	OAuthInfo *GcpOAuthInfo `json:"oauthInfo,omitempty"`
+}
+
+// GcpServiceAccountDelegationInfo is one link in the impersonation chain
+// (AuditLog.authenticationInfo.serviceAccountDelegationInfo[]).
+type GcpServiceAccountDelegationInfo struct {
+	// PrincipalSubject is the delegated principal at this link.
+	PrincipalSubject string `json:"principalSubject,omitempty"`
+	// FirstPartyPrincipal is set when a first-party (Google) identity delegated.
+	FirstPartyPrincipal *GcpFirstPartyPrincipal `json:"firstPartyPrincipal,omitempty"`
+	// ThirdPartyPrincipal is set for third-party (external) delegation; shape
+	// varies, kept generic.
+	ThirdPartyPrincipal map[string]interface{} `json:"thirdPartyPrincipal,omitempty"`
+}
+
+// GcpFirstPartyPrincipal is the first-party identity in a delegation link.
+type GcpFirstPartyPrincipal struct {
+	PrincipalEmail string `json:"principalEmail,omitempty"`
 }
 
 // GcpOAuthInfo is the AuditLog.authenticationInfo.oauthInfo block.
@@ -162,6 +210,19 @@ type GcpAuthorizationInfo struct {
 	PermissionType string `json:"permissionType,omitempty"`
 	Granted        bool   `json:"granted,omitempty"`
 	Resource       string `json:"resource,omitempty"`
+	// ResourceAttributes describes the resource the permission was checked
+	// against. Its Type (e.g. "iam.googleapis.com/ServiceAccount") is the kind of
+	// thing touched — the field to fall back on when ResourceName is the parent
+	// rather than the target (POC FINDINGS §1c②); mirrors AWS Resource.ResourceType.
+	ResourceAttributes *GcpResourceAttributes `json:"resourceAttributes,omitempty"`
+}
+
+// GcpResourceAttributes is the AuthorizationInfo.resourceAttributes — the typed
+// resource the authorization decision was made against.
+type GcpResourceAttributes struct {
+	Service string `json:"service,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Type    string `json:"type,omitempty"`
 }
 
 // GcpRequestMetadata is the AuditLog.requestMetadata — the caller's network
@@ -169,6 +230,14 @@ type GcpAuthorizationInfo struct {
 type GcpRequestMetadata struct {
 	CallerIP                string `json:"callerIp,omitempty"`
 	CallerSuppliedUserAgent string `json:"callerSuppliedUserAgent,omitempty"`
+	// CallerNetwork is the VPC network the call originated from, when applicable.
+	CallerNetwork string `json:"callerNetwork,omitempty"`
+	// RequestAttributes is the request context (time, auth, method, ...); shape
+	// varies, kept generic.
+	RequestAttributes map[string]interface{} `json:"requestAttributes,omitempty"`
+	// DestinationAttributes is the request destination context; shape varies,
+	// kept generic.
+	DestinationAttributes map[string]interface{} `json:"destinationAttributes,omitempty"`
 }
 
 // GcpStatus is the AuditLog.status (google.rpc.Status). Empty ({}) on success,

--- a/armotypes/cdr/gcp.go
+++ b/armotypes/cdr/gcp.go
@@ -4,9 +4,9 @@ import "time"
 
 const (
 	// CdrEventGcpProjectIDJsonPath is the JSON path to the GCP project ID on a GCP
-	// Cloud Audit Log event — the account key the CDR alert is matched to (see
-	// SUB-7649). It is the GCP equivalent of the AWS accountId / Azure
-	// subscriptionId account-matching path.
+	// Cloud Audit Log event — the account key the CDR alert is matched to. It is
+	// the GCP equivalent of the AWS accountId / Azure subscriptionId
+	// account-matching path.
 	//
 	// GCP exposes NO org-key equivalent of the AWS orgId / Azure tenantId path:
 	// the audit record carries only project_id, with no org/folder ancestry, so

--- a/armotypes/cdr/gcp.go
+++ b/armotypes/cdr/gcp.go
@@ -1,0 +1,175 @@
+package cdr
+
+import "time"
+
+const (
+	// CdrEventGcpProjectIDJsonPath is the JSON path to the GCP project ID on a GCP
+	// Cloud Audit Log event — the account key the CDR alert is matched to (see
+	// SUB-7649). It is the GCP equivalent of the AWS accountId / Azure
+	// subscriptionId account-matching path.
+	//
+	// GCP exposes NO org-key equivalent of the AWS orgId / Azure tenantId path:
+	// the audit record carries only project_id, with no org/folder ancestry, so
+	// there is no field to point such a constant at. Org-level connections are
+	// instead attributed by resolving this project_id to the org-connected
+	// account via CADRGcpConfig (an armosec-infra concern), not from the event.
+	CdrEventGcpProjectIDJsonPath = "cdrevent.eventData.gcpAuditLog.resource.labels.project_id"
+)
+
+// GcpAuditLogEvent is a single GCP Cloud Logging LogEntry carrying an Admin
+// Activity audit record — the control-plane audit event that is the GCP
+// equivalent of an AWS CloudTrail management event (see CloudTrailEvent in
+// aws.go) and the Azure Activity Log record (see AzureActivityLogEvent in
+// azure.go).
+//
+// The Pub/Sub push pipe delivers one LogEntry per message; unlike the Azure
+// Event Hub path there is no batch envelope. The audit payload lives under
+// ProtoPayload (google.cloud.audit.AuditLog), while Operation lives at the
+// LogEntry level — deliberately, because the synchronous-vs-long-running
+// distinction the detection gate depends on is a LogEntry property, not a
+// payload one.
+//
+// The field set and its nil-safety were measured against real events in the
+// gcp-cdr-poc (see its FINDINGS.md §1); the round-trip test in gcp_test.go is
+// the guard. POC corrections baked into the shape below:
+//   - Operation is a pointer: synchronous admin calls (create SA, set IAM
+//     policy) carry NO operation block at all, so the detection gate is
+//     `!has(operation) || operation.last`. Long-running calls emit two entries
+//     sharing operation.id, flagged first / last.
+//   - Operation booleans are OMITTED when false (not serialized as false), so
+//     CEL rules must use has() guards; the Go zero-value (false) is safe.
+//   - ResourceName is the PARENT for create-style methods (CreateServiceAccount
+//     -> projects/X); the created resource is in response.name — model both.
+//   - Status is `{}` on success, so status.code is absent rather than 0.
+//   - AuthorizationInfo carries permission / permissionType / granted, enabling
+//     denied-attempt (granted:false) detection rules.
+//
+// All optional fields are nil-safe / omitempty so CEL has()-guards behave and
+// GCP's per-service field omissions round-trip cleanly.
+type GcpAuditLogEvent struct {
+	// InsertID uniquely identifies the log entry; it is stable across Pub/Sub
+	// redeliveries and forms half of the dedup key hash(insertId + rule_id).
+	InsertID string `json:"insertId,omitempty"`
+	// LogName is the fully-qualified log name, e.g.
+	// projects/<project>/logs/cloudaudit.googleapis.com%2Factivity.
+	LogName string `json:"logName,omitempty"`
+	// Timestamp is when the logged action occurred.
+	Timestamp time.Time `json:"timestamp"`
+	// ReceiveTimestamp is when Cloud Logging received the entry.
+	ReceiveTimestamp time.Time `json:"receiveTimestamp"`
+	// Severity is the log severity (e.g. "NOTICE").
+	Severity string `json:"severity,omitempty"`
+	// Resource is the monitored resource the entry is about; resource.labels
+	// carries the project_id used to match the alert to a GCP account.
+	Resource *GcpMonitoredResource `json:"resource,omitempty"`
+	// Operation ties together the entries of a single long-running operation.
+	// ABSENT on synchronous events — the detection gate is
+	// `!has(operation) || operation.last`.
+	Operation *GcpLogEntryOperation `json:"operation,omitempty"`
+	// ProtoPayload is the google.cloud.audit.AuditLog record.
+	ProtoPayload *GcpAuditLogPayload `json:"protoPayload,omitempty"`
+}
+
+// GcpMonitoredResource is the Cloud Logging monitored-resource descriptor.
+// For an Admin Activity entry, Type is e.g. "service_account" / "gce_network"
+// and Labels carries "project_id" (and often "location", etc.).
+type GcpMonitoredResource struct {
+	Type   string            `json:"type,omitempty"`
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+// GcpLogEntryOperation is the LogEntry.operation block. It is present only on
+// long-running operations, whose request and completion entries share the same
+// ID and are flagged First / Last respectively.
+//
+// NOTE: First / Last are omitted from the wire when false (they are not
+// serialized as false). Go unmarshals the missing key to the false zero-value
+// (safe), but CEL rule authors must use has() guards rather than comparing to
+// false. The chosen gate reads only operation.last, so it is has()-safe.
+type GcpLogEntryOperation struct {
+	ID       string `json:"id,omitempty"`
+	Producer string `json:"producer,omitempty"`
+	First    bool   `json:"first,omitempty"`
+	Last     bool   `json:"last,omitempty"`
+}
+
+// GcpAuditLogPayload models the google.cloud.audit.AuditLog protoPayload of an
+// Admin Activity entry — the fields the CDR detection and identifier
+// normalization lean on. Optional bags (Request / Response) are kept generic;
+// Response in particular carries the real target of create-style methods
+// (response.name) that ResourceName does not.
+type GcpAuditLogPayload struct {
+	// Type is the payload @type discriminator
+	// ("type.googleapis.com/google.cloud.audit.AuditLog").
+	Type string `json:"@type,omitempty"`
+	// ServiceName is the API that produced the event (e.g. "iam.googleapis.com").
+	ServiceName string `json:"serviceName,omitempty"`
+	// MethodName is the API method invoked (e.g.
+	// "google.iam.admin.v1.CreateServiceAccount").
+	MethodName string `json:"methodName,omitempty"`
+	// ResourceName is the resource the request targets. For create-style methods
+	// it is the PARENT (e.g. "projects/X"), not the created resource — the real
+	// target is in Response["name"]. Do NOT assume ResourceName == affected
+	// resource (POC FINDINGS §1c②).
+	ResourceName string `json:"resourceName,omitempty"`
+	// AuthenticationInfo is the caller identity (principalEmail / principalSubject).
+	AuthenticationInfo *GcpAuthenticationInfo `json:"authenticationInfo,omitempty"`
+	// AuthorizationInfo is the per-permission authorization decisions for the
+	// call; granted:false entries enable denied/attempted-action detection.
+	AuthorizationInfo []GcpAuthorizationInfo `json:"authorizationInfo,omitempty"`
+	// RequestMetadata carries the caller IP and user agent.
+	RequestMetadata *GcpRequestMetadata `json:"requestMetadata,omitempty"`
+	// Status is the operation status. Present but EMPTY ({}) on success, so
+	// status.code is absent rather than 0 — guard with has() in CEL.
+	Status *GcpStatus `json:"status,omitempty"`
+	// Request is the operation-specific request bag; shape varies by method.
+	Request map[string]interface{} `json:"request,omitempty"`
+	// Response is the operation-specific response bag; for create-style methods
+	// Response["name"] is the created resource (the real target).
+	Response map[string]interface{} `json:"response,omitempty"`
+}
+
+// GcpAuthenticationInfo is the AuditLog.authenticationInfo — the caller identity.
+type GcpAuthenticationInfo struct {
+	// PrincipalEmail is the caller's email (user or service account).
+	PrincipalEmail string `json:"principalEmail,omitempty"`
+	// PrincipalSubject is the prefixed principal ("user:..." / "serviceAccount:..."),
+	// which cleanly distinguishes user from service-account callers for
+	// common.Identifiers normalization (POC FINDINGS §1c⑤).
+	PrincipalSubject string `json:"principalSubject,omitempty"`
+	// OAuthInfo carries the OAuth client that made the call, when present.
+	OAuthInfo *GcpOAuthInfo `json:"oauthInfo,omitempty"`
+}
+
+// GcpOAuthInfo is the AuditLog.authenticationInfo.oauthInfo block.
+type GcpOAuthInfo struct {
+	OAuthClientID string `json:"oauthClientId,omitempty"`
+}
+
+// GcpAuthorizationInfo is one AuditLog.authorizationInfo[] entry — the
+// authorization decision for a single permission. PermissionType (e.g.
+// "ADMIN_WRITE") is a clean control-plane-write discriminator, and Granted:false
+// surfaces denied/attempted privileged actions (recon, privilege probing).
+//
+// NOTE: like the operation booleans, GCP omits Granted from the wire when false,
+// so it unmarshals to the false zero-value; CEL rules must has()-guard it.
+type GcpAuthorizationInfo struct {
+	Permission     string `json:"permission,omitempty"`
+	PermissionType string `json:"permissionType,omitempty"`
+	Granted        bool   `json:"granted,omitempty"`
+	Resource       string `json:"resource,omitempty"`
+}
+
+// GcpRequestMetadata is the AuditLog.requestMetadata — the caller's network
+// context, useful for SourceInformation normalization.
+type GcpRequestMetadata struct {
+	CallerIP                string `json:"callerIp,omitempty"`
+	CallerSuppliedUserAgent string `json:"callerSuppliedUserAgent,omitempty"`
+}
+
+// GcpStatus is the AuditLog.status (google.rpc.Status). Empty ({}) on success,
+// so Code is absent rather than 0.
+type GcpStatus struct {
+	Code    int    `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+}

--- a/armotypes/cdr/gcp.go
+++ b/armotypes/cdr/gcp.go
@@ -44,8 +44,12 @@ const (
 //   - AuthorizationInfo carries permission / permissionType / granted, enabling
 //     denied-attempt (granted:false) detection rules.
 //
-// All optional fields are nil-safe / omitempty so CEL has()-guards behave and
-// GCP's per-service field omissions round-trip cleanly.
+// All optional object/slice/string fields are pointers or omitempty so CEL
+// has()-guards behave and GCP's per-service omissions round-trip cleanly. The
+// two time.Time fields follow the aws.go/azure.go convention (bare, non-pointer);
+// like EventTime/Time there, an absent timestamp re-serializes as the zero time
+// rather than staying omitted — harmless in practice, as Cloud Logging stamps
+// both timestamp and receiveTimestamp on every delivered entry.
 type GcpAuditLogEvent struct {
 	// InsertID uniquely identifies the log entry; it is stable across Pub/Sub
 	// redeliveries and forms half of the dedup key hash(insertId + rule_id).

--- a/armotypes/cdr/gcp.go
+++ b/armotypes/cdr/gcp.go
@@ -1,6 +1,9 @@
 package cdr
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 const (
 	// CdrEventGcpProjectIDJsonPath is the JSON path to the GCP project ID on a GCP
@@ -134,8 +137,11 @@ type GcpAuditLogPayload struct {
 	// e.g. for data-residency-aware rules.
 	ResourceLocation *GcpResourceLocation `json:"resourceLocation,omitempty"`
 	// NumResponseItems is the number of items returned by a list/query method.
-	// protojson encodes int64 as a JSON string, so it is modeled as a string.
-	NumResponseItems string `json:"numResponseItems,omitempty"`
+	// protojson encodes int64 as a quoted JSON string ("3"), but the protobuf-JSON
+	// spec also accepts a bare number (3) on parse. json.Number accepts BOTH forms;
+	// a plain string would fail the whole decode on a bare number — a dropped event
+	// for a field nothing depends on.
+	NumResponseItems json.Number `json:"numResponseItems,omitempty"`
 	// Request is the operation-specific request bag; shape varies by method.
 	Request map[string]interface{} `json:"request,omitempty"`
 	// Response is the operation-specific response bag; for create-style methods

--- a/armotypes/cdr/gcp_test.go
+++ b/armotypes/cdr/gcp_test.go
@@ -280,6 +280,21 @@ func TestGcpImpersonationFields(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestGcpNumResponseItemsBothForms guards that numResponseItems decodes from both
+// wire forms — protojson's quoted string ("3") and a bare number (3, spec-legal on
+// parse). A plain string type would fail the whole-event decode on the bare form.
+func TestGcpNumResponseItemsBothForms(t *testing.T) {
+	for _, in := range []string{
+		`{"protoPayload":{"numResponseItems":"3"}}`,
+		`{"protoPayload":{"numResponseItems":3}}`,
+	} {
+		var e GcpAuditLogEvent
+		require.NoError(t, json.Unmarshal([]byte(in), &e), "decode failed for %s", in)
+		require.NotNil(t, e.ProtoPayload)
+		assert.Equal(t, "3", e.ProtoPayload.NumResponseItems.String())
+	}
+}
+
 // TestGcpAuditLogSyncSpecifics pins the two GCP quirks that are easy to regress:
 // resourceName is the parent (real target in response.name) for create-style
 // methods, and status is empty ({}) on success so status.code is absent.

--- a/armotypes/cdr/gcp_test.go
+++ b/armotypes/cdr/gcp_test.go
@@ -9,12 +9,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// gcpSyncAuditLogSample is a real synchronous Admin Activity entry captured in
-// the gcp-cdr-poc (FINDINGS.md §1d, redacted). Synchronous admin calls carry NO
-// top-level "operation" block — the majority case the detection gate
-// `!has(operation) || operation.last` must let through. Note resourceName is the
-// PARENT project while the created service account is only in response.name, and
-// status is {} on success.
+// gcpSyncAuditLogSample is the real synchronous Admin Activity entry captured in
+// the gcp-cdr-poc (FINDINGS.md §1d, redacted) — kept UNTRIMMED, including
+// authorizationInfo[].resourceAttributes and requestMetadata.requestAttributes,
+// so TestGcpAuditLogFieldCoverage can assert we model every field the real
+// capture carries. Synchronous admin calls carry NO top-level "operation" block —
+// the majority case the detection gate `!has(operation) || operation.last` must
+// let through. Note resourceName is the PARENT project while the created service
+// account is only in response.name, and status is {} on success.
 const gcpSyncAuditLogSample = `{
   "insertId": "1ort6tqf2s9qz6",
   "logName": "projects/cdr-project-503613/logs/cloudaudit.googleapis.com%2Factivity",
@@ -35,11 +37,13 @@ const gcpSyncAuditLogSample = `{
     },
     "authorizationInfo": [
       { "granted": true, "permission": "iam.serviceAccounts.create",
-        "permissionType": "ADMIN_WRITE", "resource": "projects/cdr-project-503613" }
+        "permissionType": "ADMIN_WRITE", "resource": "projects/cdr-project-503613",
+        "resourceAttributes": { "type": "iam.googleapis.com/ServiceAccount" } }
     ],
     "requestMetadata": {
       "callerIp": "199.203.132.136",
-      "callerSuppliedUserAgent": "google-cloud-sdk gcloud/552.0.0"
+      "callerSuppliedUserAgent": "google-cloud-sdk gcloud/552.0.0",
+      "requestAttributes": { "time": "2026-07-26T13:42:27.024755819Z" }
     },
     "request": {
       "@type": "type.googleapis.com/google.iam.admin.v1.CreateServiceAccountRequest",
@@ -193,6 +197,87 @@ func TestGcpAuditLogRoundTrip(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+// TestGcpAuditLogFieldCoverage decodes the untrimmed real capture with
+// DisallowUnknownFields, so the struct is proven to model every field the real
+// GCP event carries. This is the guard the plain round-trip lacks: encoding/json
+// silently drops unmodeled fields, so without this a wire field we forgot to
+// model would vanish undetected. If GCP (or a fixture update) introduces a field
+// we don't model, this fails loudly — the signal to extend the struct.
+func TestGcpAuditLogFieldCoverage(t *testing.T) {
+	dec := json.NewDecoder(strings.NewReader(gcpSyncAuditLogSample))
+	dec.DisallowUnknownFields()
+	var e GcpAuditLogEvent
+	require.NoError(t, dec.Decode(&e), "an unmodeled field is present in the real capture — extend GcpAuditLogEvent")
+
+	// The two fields Ben's review flagged as silently dropped are now modeled.
+	require.NotNil(t, e.ProtoPayload)
+	require.Len(t, e.ProtoPayload.AuthorizationInfo, 1)
+	require.NotNil(t, e.ProtoPayload.AuthorizationInfo[0].ResourceAttributes)
+	assert.Equal(t, "iam.googleapis.com/ServiceAccount", e.ProtoPayload.AuthorizationInfo[0].ResourceAttributes.Type)
+	require.NotNil(t, e.ProtoPayload.RequestMetadata)
+	assert.NotEmpty(t, e.ProtoPayload.RequestMetadata.RequestAttributes["time"])
+}
+
+// gcpImpersonationSample is a synthetic (NOT POC-captured) Admin Activity entry
+// modeling a service-account impersonation + static-key call — the canonical GCP
+// privilege-escalation path. The POC authenticated as a human via gcloud so it
+// never exercised these fields; this fixture guards that the struct models them.
+const gcpImpersonationSample = `{
+  "insertId": "imp1",
+  "logName": "projects/cdr-project-503613/logs/cloudaudit.googleapis.com%2Factivity",
+  "timestamp": "2026-07-26T14:00:00Z",
+  "resource": { "type": "service_account", "labels": { "project_id": "cdr-project-503613" } },
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "serviceName": "iamcredentials.googleapis.com",
+    "methodName": "GenerateAccessToken",
+    "resourceName": "projects/-/serviceAccounts/victim@cdr-project-503613.iam.gserviceaccount.com",
+    "authenticationInfo": {
+      "principalEmail": "victim@cdr-project-503613.iam.gserviceaccount.com",
+      "principalSubject": "serviceAccount:victim@cdr-project-503613.iam.gserviceaccount.com",
+      "serviceAccountKeyName": "projects/cdr-project-503613/serviceAccounts/attacker@cdr-project-503613.iam.gserviceaccount.com/keys/abc123",
+      "serviceAccountDelegationInfo": [
+        { "principalSubject": "user:attacker@armosec.io",
+          "firstPartyPrincipal": { "principalEmail": "attacker@armosec.io" } }
+      ]
+    },
+    "authorizationInfo": [
+      { "granted": false, "permission": "iam.serviceAccounts.getAccessToken",
+        "permissionType": "ADMIN_WRITE",
+        "resource": "projects/-/serviceAccounts/victim@cdr-project-503613.iam.gserviceaccount.com" }
+    ],
+    "policyViolationInfo": { "orgPolicyViolationInfo": { "violationInfo": [] } }
+  }
+}`
+
+// TestGcpImpersonationFields verifies the privilege-escalation fields Ben's review
+// added (serviceAccountDelegationInfo, serviceAccountKeyName) parse, and that a
+// denied attempt (granted:false, omitted on the wire) reads as false.
+func TestGcpImpersonationFields(t *testing.T) {
+	var e GcpAuditLogEvent
+	require.NoError(t, json.Unmarshal([]byte(gcpImpersonationSample), &e))
+	require.NotNil(t, e.ProtoPayload)
+
+	ai := e.ProtoPayload.AuthenticationInfo
+	require.NotNil(t, ai)
+	assert.Equal(t, "projects/cdr-project-503613/serviceAccounts/attacker@cdr-project-503613.iam.gserviceaccount.com/keys/abc123", ai.ServiceAccountKeyName)
+	require.Len(t, ai.ServiceAccountDelegationInfo, 1)
+	assert.Equal(t, "user:attacker@armosec.io", ai.ServiceAccountDelegationInfo[0].PrincipalSubject)
+	require.NotNil(t, ai.ServiceAccountDelegationInfo[0].FirstPartyPrincipal)
+	assert.Equal(t, "attacker@armosec.io", ai.ServiceAccountDelegationInfo[0].FirstPartyPrincipal.PrincipalEmail)
+
+	// Denied attempt: granted omitted-when-false => reads false (denied-attempt rule signal).
+	require.Len(t, e.ProtoPayload.AuthorizationInfo, 1)
+	assert.False(t, e.ProtoPayload.AuthorizationInfo[0].Granted)
+
+	// policyViolationInfo present (org-policy/VPC-SC denial detail).
+	assert.NotNil(t, e.ProtoPayload.PolicyViolationInfo)
+
+	// Round-trips without error.
+	_, err := json.Marshal(e)
+	require.NoError(t, err)
 }
 
 // TestGcpAuditLogSyncSpecifics pins the two GCP quirks that are easy to regress:

--- a/armotypes/cdr/gcp_test.go
+++ b/armotypes/cdr/gcp_test.go
@@ -1,0 +1,335 @@
+package cdr
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gcpSyncAuditLogSample is a real synchronous Admin Activity entry captured in
+// the gcp-cdr-poc (FINDINGS.md §1d, redacted). Synchronous admin calls carry NO
+// top-level "operation" block — the majority case the detection gate
+// `!has(operation) || operation.last` must let through. Note resourceName is the
+// PARENT project while the created service account is only in response.name, and
+// status is {} on success.
+const gcpSyncAuditLogSample = `{
+  "insertId": "1ort6tqf2s9qz6",
+  "logName": "projects/cdr-project-503613/logs/cloudaudit.googleapis.com%2Factivity",
+  "severity": "NOTICE",
+  "timestamp": "2026-07-26T13:42:27.024755819Z",
+  "receiveTimestamp": "2026-07-26T13:42:28.100000000Z",
+  "resource": { "type": "service_account", "labels": { "project_id": "cdr-project-503613" } },
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "serviceName": "iam.googleapis.com",
+    "methodName": "google.iam.admin.v1.CreateServiceAccount",
+    "resourceName": "projects/cdr-project-503613",
+    "status": {},
+    "authenticationInfo": {
+      "principalEmail": "attacker@armosec.io",
+      "principalSubject": "user:attacker@armosec.io",
+      "oauthInfo": { "oauthClientId": "32555940559.apps.googleusercontent.com" }
+    },
+    "authorizationInfo": [
+      { "granted": true, "permission": "iam.serviceAccounts.create",
+        "permissionType": "ADMIN_WRITE", "resource": "projects/cdr-project-503613" }
+    ],
+    "requestMetadata": {
+      "callerIp": "199.203.132.136",
+      "callerSuppliedUserAgent": "google-cloud-sdk gcloud/552.0.0"
+    },
+    "request": {
+      "@type": "type.googleapis.com/google.iam.admin.v1.CreateServiceAccountRequest",
+      "account_id": "cdr-poc-ss1", "name": "projects/cdr-project-503613"
+    },
+    "response": {
+      "@type": "type.googleapis.com/google.iam.admin.v1.ServiceAccount",
+      "name": "projects/cdr-project-503613/serviceAccounts/cdr-poc-ss5@cdr-project-503613.iam.gserviceaccount.com"
+    }
+  }
+}`
+
+// gcpLongRunningCompletionSample is the completion entry of a long-running
+// operation captured in the POC (FINDINGS.md §1b/§1c). It carries an "operation"
+// block with last=true (and NO "first" key — booleans are omitted when false).
+// This is the entry the gate keeps; it retains full authenticationInfo, and for
+// networks.insert its resourceName IS the target resource.
+const gcpLongRunningCompletionSample = `{
+  "insertId": "3byqwkd4f8m",
+  "logName": "projects/cdr-project-503613/logs/cloudaudit.googleapis.com%2Factivity",
+  "severity": "NOTICE",
+  "timestamp": "2026-07-26T13:33:09.401394Z",
+  "resource": { "type": "gce_network", "labels": { "project_id": "cdr-project-503613" } },
+  "operation": {
+    "id": "operation-1785072775774-65783a4b2c062-c7f6a912-641fdc82",
+    "producer": "compute.googleapis.com",
+    "last": true
+  },
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "serviceName": "compute.googleapis.com",
+    "methodName": "v1.compute.networks.insert",
+    "resourceName": "projects/cdr-project-503613/global/networks/cdr-poc-lro-net",
+    "status": {},
+    "authenticationInfo": {
+      "principalEmail": "attacker@armosec.io",
+      "principalSubject": "user:attacker@armosec.io"
+    },
+    "authorizationInfo": [
+      { "granted": true, "permission": "compute.networks.create",
+        "permissionType": "ADMIN_WRITE", "resource": "projects/cdr-project-503613/global/networks/cdr-poc-lro-net" }
+    ]
+  }
+}`
+
+// gcpLongRunningRequestSample is the request (first) entry of the same
+// long-running operation — same operation.id, first=true, no "last" key. The
+// gate skips it.
+const gcpLongRunningRequestSample = `{
+  "insertId": "1yg3nhe1wbpq",
+  "logName": "projects/cdr-project-503613/logs/cloudaudit.googleapis.com%2Factivity",
+  "timestamp": "2026-07-26T13:32:55.853384Z",
+  "resource": { "type": "gce_network", "labels": { "project_id": "cdr-project-503613" } },
+  "operation": {
+    "id": "operation-1785072775774-65783a4b2c062-c7f6a912-641fdc82",
+    "producer": "compute.googleapis.com",
+    "first": true
+  },
+  "protoPayload": {
+    "@type": "type.googleapis.com/google.cloud.audit.AuditLog",
+    "serviceName": "compute.googleapis.com",
+    "methodName": "v1.compute.networks.insert",
+    "resourceName": "projects/cdr-project-503613/global/networks/cdr-poc-lro-net",
+    "authenticationInfo": {
+      "principalEmail": "attacker@armosec.io",
+      "principalSubject": "user:attacker@armosec.io"
+    }
+  }
+}`
+
+// gcpEventGate mirrors the HLD §3.4 detection gate `!has(operation) || operation.last`.
+func gcpEventGate(e *GcpAuditLogEvent) bool {
+	return e.Operation == nil || e.Operation.Last
+}
+
+// TestGcpAuditLogRoundTrip round-trips real synchronous and long-running samples
+// from the POC and asserts the POC-measured corrections hold: operation is nil on
+// synchronous events, non-nil with last=true on the completion entry, the
+// detection gate behaves, response.name carries the create target that
+// resourceName does not, and marshal/unmarshal is lossless.
+func TestGcpAuditLogRoundTrip(t *testing.T) {
+	tests := []struct {
+		name             string
+		sample           string
+		wantHasOperation bool
+		wantLast         bool
+		wantGatePass     bool
+		wantMethod       string
+		wantService      string
+		wantPrincipal    string
+	}{
+		{
+			name:             "synchronous CreateServiceAccount (no operation block)",
+			sample:           gcpSyncAuditLogSample,
+			wantHasOperation: false,
+			wantGatePass:     true, // !has(operation) => alerts
+			wantMethod:       "google.iam.admin.v1.CreateServiceAccount",
+			wantService:      "iam.googleapis.com",
+			wantPrincipal:    "attacker@armosec.io",
+		},
+		{
+			name:             "long-running networks.insert request entry (first)",
+			sample:           gcpLongRunningRequestSample,
+			wantHasOperation: true,
+			wantLast:         false,
+			wantGatePass:     false, // first entry is skipped
+			wantMethod:       "v1.compute.networks.insert",
+			wantService:      "compute.googleapis.com",
+			wantPrincipal:    "attacker@armosec.io",
+		},
+		{
+			name:             "long-running networks.insert completion entry (last)",
+			sample:           gcpLongRunningCompletionSample,
+			wantHasOperation: true,
+			wantLast:         true,
+			wantGatePass:     true, // completion entry alerts
+			wantMethod:       "v1.compute.networks.insert",
+			wantService:      "compute.googleapis.com",
+			wantPrincipal:    "attacker@armosec.io",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var e GcpAuditLogEvent
+			require.NoError(t, json.Unmarshal([]byte(tc.sample), &e))
+
+			require.NotNil(t, e.ProtoPayload)
+			assert.Equal(t, tc.wantMethod, e.ProtoPayload.MethodName)
+			assert.Equal(t, tc.wantService, e.ProtoPayload.ServiceName)
+
+			require.NotNil(t, e.ProtoPayload.AuthenticationInfo, "completion/sync entries must retain identity")
+			assert.Equal(t, tc.wantPrincipal, e.ProtoPayload.AuthenticationInfo.PrincipalEmail)
+			assert.True(t, strings.HasPrefix(e.ProtoPayload.AuthenticationInfo.PrincipalSubject, "user:"),
+				"principalSubject should carry the user:/serviceAccount: prefix")
+
+			// operation is nilable — the load-bearing POC correction.
+			if tc.wantHasOperation {
+				require.NotNil(t, e.Operation)
+				assert.Equal(t, tc.wantLast, e.Operation.Last)
+				assert.NotEmpty(t, e.Operation.ID)
+			} else {
+				assert.Nil(t, e.Operation, "synchronous events carry no operation block")
+			}
+
+			// Detection gate `!has(operation) || operation.last`.
+			assert.Equal(t, tc.wantGatePass, gcpEventGate(&e), "detection gate mismatch")
+
+			// Round-trip back to JSON must not error.
+			_, err := json.Marshal(e)
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestGcpAuditLogSyncSpecifics pins the two GCP quirks that are easy to regress:
+// resourceName is the parent (real target in response.name) for create-style
+// methods, and status is empty ({}) on success so status.code is absent.
+func TestGcpAuditLogSyncSpecifics(t *testing.T) {
+	var e GcpAuditLogEvent
+	require.NoError(t, json.Unmarshal([]byte(gcpSyncAuditLogSample), &e))
+	require.NotNil(t, e.ProtoPayload)
+
+	// resourceName is the PARENT; the created SA is only in response.name.
+	assert.Equal(t, "projects/cdr-project-503613", e.ProtoPayload.ResourceName)
+	require.NotNil(t, e.ProtoPayload.Response)
+	assert.Contains(t, e.ProtoPayload.Response["name"], "serviceAccounts/")
+
+	// status {} on success => present but code absent (Go zero-value, nil-safe).
+	require.NotNil(t, e.ProtoPayload.Status)
+	assert.Equal(t, 0, e.ProtoPayload.Status.Code)
+
+	// authorizationInfo enables denied-attempt rules; ADMIN_WRITE + granted.
+	require.Len(t, e.ProtoPayload.AuthorizationInfo, 1)
+	assert.Equal(t, "ADMIN_WRITE", e.ProtoPayload.AuthorizationInfo[0].PermissionType)
+	assert.True(t, e.ProtoPayload.AuthorizationInfo[0].Granted)
+}
+
+// TestGcpNilSafety verifies CEL-style has()-guarded access is panic-free when the
+// per-service optional fields GCP omits are absent (empty event, and the minimal
+// long-running request entry).
+func TestGcpNilSafety(t *testing.T) {
+	// A zero event: nothing set. Guarded access must not panic.
+	var empty GcpAuditLogEvent
+	assert.True(t, gcpEventGate(&empty), "empty event has no operation => gate passes")
+	assert.Nil(t, empty.ProtoPayload)
+	assert.Nil(t, empty.Resource)
+
+	// The minimal request entry has operation but no authorizationInfo / status /
+	// requestMetadata / response.
+	var e GcpAuditLogEvent
+	require.NoError(t, json.Unmarshal([]byte(gcpLongRunningRequestSample), &e))
+	require.NotNil(t, e.Operation)
+	assert.True(t, e.Operation.First)
+	assert.False(t, e.Operation.Last)
+	require.NotNil(t, e.ProtoPayload)
+	assert.Nil(t, e.ProtoPayload.Status)
+	assert.Nil(t, e.ProtoPayload.RequestMetadata)
+	assert.Empty(t, e.ProtoPayload.AuthorizationInfo)
+}
+
+// TestGcpOperationBooleanOmittedWhenFalse guards the POC finding that operation
+// booleans are omitted from the wire when false (not serialized as false), so
+// re-marshalling the completion entry must NOT emit "first".
+func TestGcpOperationBooleanOmittedWhenFalse(t *testing.T) {
+	var e GcpAuditLogEvent
+	require.NoError(t, json.Unmarshal([]byte(gcpLongRunningCompletionSample), &e))
+	require.NotNil(t, e.Operation)
+
+	b, err := json.Marshal(e.Operation)
+	require.NoError(t, err)
+	assert.NotContains(t, string(b), `"first"`, "false booleans must be omitted, not serialized")
+	assert.Contains(t, string(b), `"last":true`)
+}
+
+// TestGcpEventDataEmbedding verifies the GCP event embeds in the shared CdrAlert
+// contract without disturbing the AWS or Azure paths (regression guard).
+func TestGcpEventDataEmbedding(t *testing.T) {
+	alert := CdrAlert{
+		CloudMetadata: CloudMetadata{Provider: GCP, SourceService: CloudAuditLogs},
+		EventData: EventData{GcpAuditLog: &GcpAuditLogEvent{
+			ProtoPayload: &GcpAuditLogPayload{MethodName: "test"},
+		}},
+	}
+	b, err := json.Marshal(alert)
+	require.NoError(t, err)
+
+	var got CdrAlert
+	require.NoError(t, json.Unmarshal(b, &got))
+	assert.Equal(t, GCP, got.Provider)
+	assert.Equal(t, CloudAuditLogs, got.SourceService)
+	require.NotNil(t, got.GcpAuditLog)
+	require.NotNil(t, got.GcpAuditLog.ProtoPayload)
+	assert.Equal(t, "test", got.GcpAuditLog.ProtoPayload.MethodName)
+	assert.Nil(t, got.AWSCloudTrail, "AWS path must stay nil")
+	assert.Nil(t, got.AzureActivityLog, "Azure path must stay nil")
+}
+
+// TestGcpProviderEnumsUnchanged is a regression guard: adding GCP must not alter
+// the existing AWS/Azure enum values or the GCP additions themselves.
+func TestGcpProviderEnumsUnchanged(t *testing.T) {
+	assert.Equal(t, CloudProvider("aws"), AWS)
+	assert.Equal(t, CloudProvider("azure"), Azure)
+	assert.Equal(t, CloudProvider("gcp"), GCP)
+	assert.Equal(t, CloudService("cloudtrail"), CloudTrail)
+	assert.Equal(t, CloudService("activitylogs"), ActivityLogs)
+	assert.Equal(t, CloudService("cloudauditlogs"), CloudAuditLogs)
+}
+
+// TestCdrAlertGcpJsonPath verifies the GCP project-ID JSON-path constant matches
+// the json tags on CdrAlert, so config-service account matching doesn't drift
+// from the wire contract (mirrors TestCdrAlertJsonPath / TestCdrAlertAzureJsonPath).
+func TestCdrAlertGcpJsonPath(t *testing.T) {
+	tests := []struct {
+		Name          string
+		Path          string
+		CdrAlert      CdrAlert
+		ExpectedValue string
+	}{
+		{
+			Name: "Test CdrEventGcpProjectIDJsonPath",
+			Path: CdrEventGcpProjectIDJsonPath,
+			CdrAlert: CdrAlert{
+				EventData: EventData{
+					GcpAuditLog: &GcpAuditLogEvent{
+						Resource: &GcpMonitoredResource{
+							Labels: map[string]string{"project_id": "cdr-project-503613"},
+						},
+					},
+				},
+			},
+			ExpectedValue: "cdr-project-503613",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			// 1. Marshal to JSON
+			data, err := json.Marshal(test.CdrAlert)
+			require.NoError(t, err)
+
+			// 2. Unmarshal into a generic map
+			var genericCdrAlert map[string]interface{}
+			require.NoError(t, json.Unmarshal(data, &genericCdrAlert))
+
+			// 3. Traverse the path (shared helper lives in aws_test.go)
+			pathWithoutPrefix := strings.TrimPrefix(test.Path, "cdrevent.")
+			val, ok := getValueAtJsonPath(genericCdrAlert, pathWithoutPrefix)
+			require.True(t, ok)
+			assert.Equal(t, test.ExpectedValue, val)
+		})
+	}
+}

--- a/docs/repo/architecture.md
+++ b/docs/repo/architecture.md
@@ -28,7 +28,8 @@ armoapi-go/
 │   ├── cdr/                 # Cloud Detection & Response types
 │   │   ├── cdr.go           # CdrAlert, CloudMetadata, CdrAlertBatch
 │   │   ├── aws.go           # CloudTrailEvent, AWS-specific types
-│   │   └── azure.go         # AzureActivityLogEvent, Azure-specific types
+│   │   ├── azure.go         # AzureActivityLogEvent, Azure-specific types
+│   │   └── gcp.go           # GcpAuditLogEvent, GCP-specific types
 │   └── common/              # Shared runtime sub-types (ProcessEntity, FileEntity)
 ├── identifiers/             # Resource designator system
 │   ├── designators.go       # PortalDesignator, DesignatorType, constants

--- a/docs/services/armoapi-go/service.md
+++ b/docs/services/armoapi-go/service.md
@@ -20,7 +20,7 @@ This is a **pure type/utility library** with no runtime services (no HTTP server
 |---------|-------------|
 | `apis` | Command dispatch types, websocket scan commands, backend connector interfaces, and pagination helpers |
 | `armotypes` | Core platform domain types: clusters, configurations, policies, incidents, security risks, registries, vulnerability exceptions |
-| `armotypes/cdr` | Cloud Detection & Response alert types (CdrAlert, CloudTrailEvent, AzureActivityLogEvent; AWS + Azure structures) |
+| `armotypes/cdr` | Cloud Detection & Response alert types (CdrAlert, CloudTrailEvent, AzureActivityLogEvent, GcpAuditLogEvent; AWS + Azure + GCP structures) |
 | `armotypes/common` | Shared runtime sub-types (ProcessEntity, FileEntity) used across detection features |
 | `identifiers` | Workload and resource designator system (WLID, SID, PortalDesignator) with parsing utilities |
 | `containerscan` | Container vulnerability scan report interfaces defining the contract between scanner and consumers |


### PR DESCRIPTION
## What

First, **unblocking** ticket of the GCP CDR epic (SUB-7808): the shared types downstream repos (armosec-infra, cadashboardbe, event-ingester) build against. Additive and non-breaking — AWS/Azure enum values and JSON paths are untouched.

Jira: **[SUB-7810](https://cyberarmor-io.atlassian.net/browse/SUB-7810)** · HLD §7 (`shared-designs-and-docs/cdr/cdr-gcp-hld.md`, approved).

## Changes

- **`cdr.go`** — `CloudProvider "gcp"`, `CloudService "cloudauditlogs"`, and a `GcpAuditLog *GcpAuditLogEvent` variant on `EventData`.
- **`gcp.go`** — `GcpAuditLogEvent` models a Cloud Logging LogEntry carrying an Admin Activity record (parallel to `aws.go`/`azure.go`): `authenticationInfo` (`principalEmail`/`principalSubject`), `methodName`, `serviceName`, `resourceName`, `authorizationInfo[]`, `status`, and the **LogEntry-level** `operation` block. Plus `CdrEventGcpProjectIDJsonPath` — the account-matching key.
- **`gcp_test.go`** — table-driven round-trip on **real POC events**: a synchronous sample (no `operation`) and long-running first/last samples; plus gate, nil-safety, omitted-when-false booleans, `EventData` embedding, and enum regression guards.
- **Docs** — updated `docs/repo/architecture.md` and `docs/services/armoapi-go/service.md`.

## POC corrections modeled

Measured on real Admin Activity events (`gcp-cdr-poc` FINDINGS.md §1):

- `operation` is a **nilable pointer** — absent on synchronous events; detection gate is `!has(operation) || operation.last`.
- `operation`/`authorization` booleans are **omitted when false**, not serialized as `false`.
- `resourceName` is the **PARENT** for create-style methods; the real target is in `response.name` — both modeled.
- `status` is `{}` on success (`status.code` absent) — nil-safe.
- `authorizationInfo[]` carries `permission`/`permissionType`/`granted` (denied-attempt rules); `principalSubject` accompanies `principalEmail`.

**Note on JSON-path constants:** only `project_id` (the account key, = AWS `accountId` / Azure `subscriptionId`). GCP emits **no** org-key equivalent of `orgId`/`tenantId` — the audit record carries no org/folder ancestry — so org-level connections attribute via `project_id` → `CADRGcpConfig` (an armosec-infra / G2 concern), documented inline.

## Acceptance criteria

- [x] Marshal/unmarshal round-trip on both a synchronous and a long-running POC sample.
- [x] No change to AWS/Azure enum values or JSON paths (regression guard).
- [x] Nil-safe access when optional fields are absent (no panic).
- [x] `go build ./...`, `go vet`, `gofmt`, and package tests all green. Additive change → downstream consumers keep building.

Do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SUB-7810]: https://cyberarmor-io.atlassian.net/browse/SUB-7810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ