### PR TITLE
feat(networkstream): per-connection process attribution

### DIFF
--- a/armotypes/networkstream.go
+++ b/armotypes/networkstream.go
@@ -1,6 +1,9 @@
 package armotypes
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -28,10 +31,147 @@ const (
 	EndpointKindRaw     EndpointKind = "raw"
 )
 
+// NetworkStreamProcessAttributionV1 is the current revision of the
+// process-attribution extension to NetworkStream: NetworkStream.Processes plus
+// the per-connection NetworkStreamEvent.Process reference. See
+// NetworkStream.ProcessAttributionVersion for why an explicit marker exists at
+// all, and bump this constant if the meaning of either field changes.
+const NetworkStreamProcessAttributionV1 = 1
+
+// processRefSep separates the two integer components of a ProcessRef's textual
+// form.
+//
+// It is deliberately "/" and not the U+241F (␟) that CommPID in linuxobjects.go
+// uses. CommPID needs an exotic separator because its first component (Comm) is
+// a free-form string that may itself contain "/" or ":". Both components of a
+// ProcessRef are decimal integers, so no escaping hazard exists, and "/" keeps
+// this file internally consistent: NetworkStreamEntity.Inbound/Outbound are
+// already keyed by the composite "<ip>/<port>/<protocol>". It is also 1 byte
+// rather than 3 (UTF-8), which matters because this text appears once per
+// connection — see NetworkStream.Processes on the wire budget.
+const processRefSep = "/"
+
+// ProcessRef identifies one OS process on the node that produced a
+// NetworkStream message. It is both the key of NetworkStream.Processes and the
+// value of NetworkStreamEvent.Process, so a consumer joins a connection to its
+// process tree with `stream.Processes[*event.Process]` — no string formatting
+// at the call site and no way for the two sides to disagree on key format.
+//
+// StartTime is CLOCK_BOOTTIME in clock ticks since boot (USER_HZ = 100, i.e.
+// 10 ms per tick), NOT a wall-clock time.Time. This is deliberate:
+//
+//   - The only start-time source with full process coverage is
+//     /proc/<pid>/stat field 22 (starttime), which is denominated in clock
+//     ticks since boot.
+//   - Rendering those ticks to wall-clock requires the boot timestamp from
+//     /proc/stat `btime`, which has whole-second resolution only. A time.Time
+//     on the wire would therefore be lossy by up to a second — for a value
+//     whose entire job is to disambiguate identity, that is the wrong trade.
+//   - Ticks are exact, need no boot-time lookup, and 10 ms granularity is
+//     safe for pid-reuse disambiguation by 2-5 orders of magnitude (a kernel
+//     needs to cycle the whole pid space to reuse a pid).
+//
+// A zero StartTime means the sensor could not read the process's start time
+// (typically a process that exited before /proc could be sampled). Such a ref
+// carries pid-only identity: it is still a valid key within the message, but it
+// must not be treated as equal to a ref for the same pid with a known start
+// time, and it is not safe to compare across messages.
+//
+// PID is a host-namespace pid, matching what the sensor's eBPF network gadget
+// reports (the socket enricher's pid_tgid >> 32, i.e. task->tgid; there is no
+// pid-namespace translation on that path). Host pids are node-unique, which is
+// what makes a single message-scoped Processes map correct.
+type ProcessRef struct {
+	PID       uint32 `json:"pid,omitempty" bson:"pid,omitempty"`
+	StartTime uint64 `json:"startTime,omitempty" bson:"startTime,omitempty"`
+}
+
+// MarshalText implements encoding.TextMarshaler. Both encoding/json and
+// mongo-driver's bson use it for map keys and for plain values, so a ProcessRef
+// is always the single string "<pid>/<startTime>" on the wire.
+func (p ProcessRef) MarshalText() ([]byte, error) {
+	return []byte(strconv.FormatUint(uint64(p.PID), 10) + processRefSep + strconv.FormatUint(p.StartTime, 10)), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler. The receiver is left
+// untouched on error so a caller that ignores the error cannot end up
+// attributing a connection to a half-parsed process.
+func (p *ProcessRef) UnmarshalText(text []byte) error {
+	pidStr, startTimeStr, found := strings.Cut(string(text), processRefSep)
+	if !found {
+		return fmt.Errorf("invalid ProcessRef representation: %q", text)
+	}
+	pid, err := strconv.ParseUint(pidStr, 10, 32)
+	if err != nil {
+		return fmt.Errorf("invalid ProcessRef pid %q: %w", pidStr, err)
+	}
+	// startTime is ticks since boot; it outgrows uint32 after ~497 days of
+	// uptime at USER_HZ = 100, so it is parsed and stored as 64-bit.
+	startTime, err := strconv.ParseUint(startTimeStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid ProcessRef startTime %q: %w", startTimeStr, err)
+	}
+	p.PID = uint32(pid) // range-checked by ParseUint's bitSize 32 above
+	p.StartTime = startTime
+	return nil
+}
+
 // NetworkStream represents a collection of network traffic events for a specific pod/container
 type NetworkStream struct {
 	// <identifier> to <network stream entity>
 	Entities map[string]NetworkStreamEntity `json:"entities,omitempty"`
+
+	// ProcessAttributionVersion states which revision of process attribution
+	// the producing sensor implements; see NetworkStreamProcessAttributionV1.
+	//
+	// Absent or zero means "this sensor predates process attribution", NOT
+	// "attribution ran and produced nothing". The backend genuinely needs to
+	// tell those apart: an upgraded sensor can legitimately emit an empty
+	// Processes map (every connection unattributable in that interval), so
+	// `len(Processes) == 0` is not a usable proxy for sensor capability.
+	//
+	// This marker is new to the repo — there is no existing schema-version-field
+	// convention here. Versioning is otherwise done by the CRD kind string
+	// (kubescape.io/v1/networkstreams) plus Pulsar topic name, and the
+	// established pattern for additive changes is `omitempty` plus a documented
+	// consumer tolerance (see HostCVEOnFinishedMessage in hot_cve.go). That
+	// pattern alone is not sufficient here precisely because absence of data
+	// and absence of the feature are different states. Bumping the kind string
+	// to a v2 was rejected: both consumers decode with plain json.Unmarshal and
+	// neither sets DisallowUnknownFields, so a purely additive change needs no
+	// breaking version, and a kind bump would force a coordinated consumer
+	// rollout. Note also that this repo auto-tags v0.0.<run_number> on push to
+	// main, so the module version carries no semver signal a consumer could
+	// branch on.
+	ProcessAttributionVersion int `json:"processAttributionVersion,omitempty" bson:"processAttributionVersion,omitempty"`
+
+	// Processes maps a process identity to the process tree that produced the
+	// connections referencing it. Connections point here via
+	// NetworkStreamEvent.Process.
+	//
+	// The map is scoped once per MESSAGE, not per container, and the tree is
+	// shipped once per PROCESS, not once per connection. Both choices are about
+	// size:
+	//
+	//   - The synchronizer envelope carries this payload base64-encoded in its
+	//     `patch` field, so every byte added on this type costs x1.333 on the
+	//     wire.
+	//   - Process trees dominate that cost, not the number of map entries:
+	//     they are chain-shaped and measure ~2.0 KB serialised at the median
+	//     and ~5.1 KB at p90, of which `cmdline` alone is ~40% and is
+	//     unbounded. Inlining a tree per connection (the pre-existing
+	//     NetworkStreamEvent.ProcessTree shape) is what forced the sensor to
+	//     nil trees out entirely before sending; deduplicating per process is
+	//     what makes attribution affordable at all. A worst case observed
+	//     message (109 container entities, 283 connections, 142 KB on the
+	//     wire) lands near 970 KB with full attribution, against a 5 MiB
+	//     broker limit.
+	//   - Message scope is correct rather than merely cheaper: ProcessRef.PID
+	//     is a host-namespace pid and a stream message covers exactly one node,
+	//     so the keys are already unique across the message. Per-container
+	//     scoping would duplicate every tree shared between containers and buy
+	//     nothing.
+	Processes map[ProcessRef]*ProcessTree `json:"processes,omitempty" bson:"processes,omitempty"`
 }
 
 // NetworkStreamEntity represents an aggregation of network connections from/to a specific source
@@ -70,6 +210,21 @@ type NetworkStreamEvent struct {
 	Port        int32                      `json:"port,omitempty"`
 	Protocol    NetworkStreamEventProtocol `json:"protocol,omitempty"`
 	ProcessTree *ProcessTree               `json:"processTree,omitempty"`
+	// Process attributes this connection to a process in the message-scoped
+	// NetworkStream.Processes map: `stream.Processes[*event.Process]`.
+	//
+	// This is the field to use. The ProcessTree field above inlines a whole
+	// tree per connection and is nilled out by the sensor before the message is
+	// sent; it survives only because an in-process notification channel feeds a
+	// separate host-network sensor from the pre-nil struct.
+	//
+	// It is a pointer so `omitempty` actually drops it — encoding/json does not
+	// omit zero structs, and an always-present "process":"0/0" on every
+	// unattributed connection is exactly the per-connection waste this design
+	// exists to avoid. A single text-marshalled field also beats two flat
+	// scalars (pid + startTime) on the wire by ~6 bytes per connection, because
+	// it spends one JSON key instead of two.
+	Process *ProcessRef `json:"process,omitempty" bson:"process,omitempty"`
 	// endpoint kind (pod, service, raw)
 	Kind EndpointKind `json:"kind,omitempty"`
 	// endpoint details in case of pod

--- a/armotypes/networkstream.go
+++ b/armotypes/networkstream.go
@@ -38,13 +38,12 @@ const (
 // all, and bump this constant if the meaning of either field changes.
 const NetworkStreamProcessAttributionV1 = 1
 
-// processRefSep separates the two integer components of a ProcessRef's textual
-// form.
+// processRefSep separates the components of a ProcessRef's textual form.
 //
 // It is deliberately "/" and not the U+241F (␟) that CommPID in linuxobjects.go
 // uses. CommPID needs an exotic separator because its first component (Comm) is
-// a free-form string that may itself contain "/" or ":". Both components of a
-// ProcessRef are decimal integers, so no escaping hazard exists, and "/" keeps
+// a free-form string that may itself contain "/" or ":". Every component of a
+// ProcessRef is a decimal integer, so no escaping hazard exists, and "/" keeps
 // this file internally consistent: NetworkStreamEntity.Inbound/Outbound are
 // already keyed by the composite "<ip>/<port>/<protocol>". It is also 1 byte
 // rather than 3 (UTF-8), which matters because this text appears once per
@@ -53,12 +52,18 @@ const processRefSep = "/"
 
 // ProcessRef identifies one OS process on the node that produced a
 // NetworkStream message. It is both the key of NetworkStream.Processes and the
-// value of NetworkStreamEvent.Process, so a consumer joins a connection to its
-// process tree with `stream.Processes[*event.Process]` — no string formatting
-// at the call site and no way for the two sides to disagree on key format.
+// value of NetworkStreamEvent.ProcessRef, so a consumer resolves a connection's
+// process tree with NetworkStream.ProcessTreeFor — no string formatting at the
+// call site and no way for the two sides to disagree on key format.
 //
-// StartTime is CLOCK_BOOTTIME in clock ticks since boot (USER_HZ = 100, i.e.
-// 10 ms per tick), NOT a wall-clock time.Time. This is deliberate:
+// StartTimeTicks is CLOCK_BOOTTIME in clock ticks since boot (USER_HZ = 100,
+// i.e. 10 ms per tick), NOT a wall-clock time. The name carries the unit
+// because armotypes.Process.StartTime — the same concept on the tree this ref
+// points at — is a wall-clock time.Time, and confusing the two would be silent.
+// The unit costs nothing on the wire: ProcessRef is text-marshalled, so these
+// field names never appear in JSON at all.
+//
+// Ticks rather than a time.Time, deliberately:
 //
 //   - The only start-time source with full process coverage is
 //     /proc/<pid>/stat field 22 (starttime), which is denominated in clock
@@ -71,10 +76,10 @@ const processRefSep = "/"
 //     safe for pid-reuse disambiguation by 2-5 orders of magnitude (a kernel
 //     needs to cycle the whole pid space to reuse a pid).
 //
-// A zero StartTime means the sensor could not read the process's start time
-// (typically a process that exited before /proc could be sampled). Such a ref
-// carries pid-only identity: it is still a valid key within the message, but it
-// must not be treated as equal to a ref for the same pid with a known start
+// A zero StartTimeTicks means the sensor could not read the process's start
+// time (typically a process that exited before /proc could be sampled). Such a
+// ref carries pid-only identity: it is still a valid key within the message, but
+// it must not be treated as equal to a ref for the same pid with a known start
 // time, and it is not safe to compare across messages.
 //
 // PID is a host-namespace pid, matching what the sensor's eBPF network gadget
@@ -82,37 +87,68 @@ const processRefSep = "/"
 // pid-namespace translation on that path). Host pids are node-unique, which is
 // what makes a single message-scoped Processes map correct.
 type ProcessRef struct {
-	PID       uint32 `json:"pid,omitempty" bson:"pid,omitempty"`
-	StartTime uint64 `json:"startTime,omitempty" bson:"startTime,omitempty"`
+	PID            uint32 `json:"pid,omitempty" bson:"pid,omitempty"`
+	StartTimeTicks uint64 `json:"startTimeTicks,omitempty" bson:"startTimeTicks,omitempty"`
 }
 
-// MarshalText implements encoding.TextMarshaler. Both encoding/json and
-// mongo-driver's bson use it for map keys and for plain values, so a ProcessRef
-// is always the single string "<pid>/<startTime>" on the wire.
+// MarshalText implements encoding.TextMarshaler, rendering a ProcessRef as the
+// single string "<pid>/<startTimeTicks>". It never returns an error.
+//
+// encoding/json uses this for both map keys and plain values, so JSON carries
+// the text form everywhere. mongo-driver honours encoding.TextMarshaler for map
+// KEYS ONLY, so in BSON the Processes key is this same string but a
+// NetworkStreamEvent.ProcessRef is a subdocument built from the struct tags
+// above. Both round-trip; only the query syntax differs.
 func (p ProcessRef) MarshalText() ([]byte, error) {
-	return []byte(strconv.FormatUint(uint64(p.PID), 10) + processRefSep + strconv.FormatUint(p.StartTime, 10)), nil
+	return []byte(p.String()), nil
 }
 
-// UnmarshalText implements encoding.TextUnmarshaler. The receiver is left
-// untouched on error so a caller that ignores the error cannot end up
-// attributing a connection to a half-parsed process.
+// String returns the same "<pid>/<startTimeTicks>" text as MarshalText, so a
+// logged ref is greppable against the payload it came from.
+func (p ProcessRef) String() string {
+	return strconv.FormatUint(uint64(p.PID), 10) + processRefSep + strconv.FormatUint(p.StartTimeTicks, 10)
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+//
+// Components beyond the first two are IGNORED rather than rejected. This is the
+// forward-compatibility guarantee, and it is load-bearing: encoding/json aborts
+// the entire enclosing decode when a TextUnmarshaler map key fails — unlike an
+// int-keyed map, which skips the offending entry and carries on — and both
+// stream consumers nack or drop a message whose decode returns an error. So
+// without this tolerance, a future revision that appends a component to the key
+// format would make every un-upgraded consumer reject whole messages, losing a
+// node's entire interval of network visibility. Appending components is the
+// designed way to extend this format; do not make the parser stricter.
+//
+// Leading zeros are likewise accepted, so non-canonical keys for the same
+// process collapse to one map entry (last wins) instead of failing the message.
+//
+// The receiver is left untouched when an error is returned. Note that guarantee
+// only reaches direct callers: encoding/json allocates the pointer target before
+// calling this method and leaves it installed on failure, so a caller that
+// ignores an Unmarshal error sees a non-nil, zero-valued ref.
 func (p *ProcessRef) UnmarshalText(text []byte) error {
-	pidStr, startTimeStr, found := strings.Cut(string(text), processRefSep)
+	pidStr, rest, found := strings.Cut(string(text), processRefSep)
 	if !found {
 		return fmt.Errorf("invalid ProcessRef representation: %q", text)
 	}
+	// Anything after the second component belongs to a later revision of this
+	// format; drop it rather than failing.
+	startTimeStr, _, _ := strings.Cut(rest, processRefSep)
+
 	pid, err := strconv.ParseUint(pidStr, 10, 32)
 	if err != nil {
 		return fmt.Errorf("invalid ProcessRef pid %q: %w", pidStr, err)
 	}
-	// startTime is ticks since boot; it outgrows uint32 after ~497 days of
-	// uptime at USER_HZ = 100, so it is parsed and stored as 64-bit.
-	startTime, err := strconv.ParseUint(startTimeStr, 10, 64)
+	// Ticks since boot outgrow uint32 after ~497 days of uptime at
+	// USER_HZ = 100, so this is parsed and stored as 64-bit.
+	startTimeTicks, err := strconv.ParseUint(startTimeStr, 10, 64)
 	if err != nil {
-		return fmt.Errorf("invalid ProcessRef startTime %q: %w", startTimeStr, err)
+		return fmt.Errorf("invalid ProcessRef startTimeTicks %q: %w", startTimeStr, err)
 	}
 	p.PID = uint32(pid) // range-checked by ParseUint's bitSize 32 above
-	p.StartTime = startTime
+	p.StartTimeTicks = startTimeTicks
 	return nil
 }
 
@@ -147,7 +183,8 @@ type NetworkStream struct {
 
 	// Processes maps a process identity to the process tree that produced the
 	// connections referencing it. Connections point here via
-	// NetworkStreamEvent.Process.
+	// NetworkStreamEvent.ProcessRef; resolve with ProcessTreeFor rather than
+	// indexing the map directly.
 	//
 	// The map is scoped once per MESSAGE, not per container, and the tree is
 	// shipped once per PROCESS, not once per connection. Both choices are about
@@ -156,22 +193,48 @@ type NetworkStream struct {
 	//   - The synchronizer envelope carries this payload base64-encoded in its
 	//     `patch` field, so every byte added on this type costs x1.333 on the
 	//     wire.
-	//   - Process trees dominate that cost, not the number of map entries:
-	//     they are chain-shaped and measure ~2.0 KB serialised at the median
-	//     and ~5.1 KB at p90, of which `cmdline` alone is ~40% and is
-	//     unbounded. Inlining a tree per connection (the pre-existing
-	//     NetworkStreamEvent.ProcessTree shape) is what forced the sensor to
-	//     nil trees out entirely before sending; deduplicating per process is
-	//     what makes attribution affordable at all. A worst case observed
-	//     message (109 container entities, 283 connections, 142 KB on the
-	//     wire) lands near 970 KB with full attribution, against a 5 MiB
-	//     broker limit.
+	//   - Process trees dominate that cost, not the number of map entries.
+	//     They are chain-shaped, and measurement during design put them at
+	//     ~2.0 KB serialised at the median and ~5.1 KB at p90, of which
+	//     `cmdline` alone is ~40% and is unbounded. Inlining a tree per
+	//     connection (the pre-existing NetworkStreamEvent.ProcessTree shape) is
+	//     what forced the sensor to nil trees out entirely before sending;
+	//     deduplicating per process is what makes attribution affordable at
+	//     all.
+	//   - Headroom against the 5 MiB broker limit is comfortable but NOT
+	//     unbounded, and it is set by the tail rather than the median. Applying
+	//     the p90 tree size to the largest message observed during design (109
+	//     container entities, 283 connections, 142 KB on the wire) gives
+	//     roughly 2 MB; the median tree size gives roughly 900 KB. Since
+	//     `cmdline` is unbounded, a sensor-side cap on tree or cmdline size is
+	//     the right lever if this ever approaches the limit — not dropping
+	//     attribution.
 	//   - Message scope is correct rather than merely cheaper: ProcessRef.PID
 	//     is a host-namespace pid and a stream message covers exactly one node,
 	//     so the keys are already unique across the message. Per-container
 	//     scoping would duplicate every tree shared between containers and buy
 	//     nothing.
 	Processes map[ProcessRef]*ProcessTree `json:"processes,omitempty" bson:"processes,omitempty"`
+}
+
+// ProcessTreeFor resolves the process tree that opened the given connection,
+// returning nil when attribution is absent, dangling or nil-valued.
+//
+// Use this instead of indexing Processes directly. A bare
+// `n.Processes[*event.ProcessRef]` has three sharp edges: it panics when
+// event.ProcessRef is nil (every event from a sensor that predates attribution,
+// and any connection the sensor could not attribute), it cannot distinguish a
+// missing entry from a present-but-nil one, and a `"processes":{"1/2":null}`
+// payload decodes to exactly that present-but-nil case — so the map index
+// returns ok == true with a nil tree and the next field access panics.
+//
+// This deliberately does not fall back to the deprecated per-event ProcessTree
+// field; the two have different lifecycles (see NetworkStreamEvent.ProcessRef).
+func (n *NetworkStream) ProcessTreeFor(event *NetworkStreamEvent) *ProcessTree {
+	if n == nil || event == nil || event.ProcessRef == nil {
+		return nil
+	}
+	return n.Processes[*event.ProcessRef]
 }
 
 // NetworkStreamEntity represents an aggregation of network connections from/to a specific source
@@ -210,21 +273,25 @@ type NetworkStreamEvent struct {
 	Port        int32                      `json:"port,omitempty"`
 	Protocol    NetworkStreamEventProtocol `json:"protocol,omitempty"`
 	ProcessTree *ProcessTree               `json:"processTree,omitempty"`
-	// Process attributes this connection to a process in the message-scoped
-	// NetworkStream.Processes map: `stream.Processes[*event.Process]`.
+	// ProcessRef attributes this connection to an entry in the message-scoped
+	// NetworkStream.Processes map. Resolve it with
+	// NetworkStream.ProcessTreeFor(event), not by indexing the map.
 	//
-	// This is the field to use. The ProcessTree field above inlines a whole
-	// tree per connection and is nilled out by the sensor before the message is
-	// sent; it survives only because an in-process notification channel feeds a
-	// separate host-network sensor from the pre-nil struct.
+	// This is the field to use for anything travelling over the wire. The
+	// ProcessTree field above inlines a whole tree per connection and is nilled
+	// out by the sensor before the message is sent (node-agent
+	// removeProcessTreeFromEvents); it survives because private-node-agent
+	// wires an in-process notification channel that its host network sensor
+	// reads pre-nil (pkg/hostnetworksensor/v1 reads outbound.ProcessTree
+	// directly). Do not remove or repurpose it.
 	//
 	// It is a pointer so `omitempty` actually drops it — encoding/json does not
-	// omit zero structs, and an always-present "process":"0/0" on every
+	// omit zero structs, and an always-present "processRef":"0/0" on every
 	// unattributed connection is exactly the per-connection waste this design
 	// exists to avoid. A single text-marshalled field also beats two flat
-	// scalars (pid + startTime) on the wire by ~6 bytes per connection, because
-	// it spends one JSON key instead of two.
-	Process *ProcessRef `json:"process,omitempty" bson:"process,omitempty"`
+	// scalars (pid + startTimeTicks) on the wire by 6 bytes per connection,
+	// because it spends one JSON key instead of two.
+	ProcessRef *ProcessRef `json:"processRef,omitempty" bson:"processRef,omitempty"`
 	// endpoint kind (pod, service, raw)
 	Kind EndpointKind `json:"kind,omitempty"`
 	// endpoint details in case of pod

--- a/armotypes/networkstream.go
+++ b/armotypes/networkstream.go
@@ -31,141 +31,75 @@ const (
 	EndpointKindRaw     EndpointKind = "raw"
 )
 
-// NetworkStreamProcessAttributionV1 is the current revision of the
-// process-attribution extension to NetworkStream: NetworkStream.Processes plus
-// the per-connection NetworkStreamEvent.ProcessRef reference. See
-// NetworkStream.ProcessAttributionVersion for why an explicit marker exists at
-// all, and bump this constant if the meaning of either field changes.
+// Process attribution on the network stream. Design, wire-format rationale and
+// consumer guidance: docs/features/network-stream-process-attribution.md
+
+// NetworkStreamProcessAttributionV1 is the current process-attribution revision.
+// Bump it if the meaning of Processes or NetworkStreamEvent.ProcessRef changes.
 const NetworkStreamProcessAttributionV1 = 1
 
-// processRefSep separates the components of a ProcessRef's textual form.
-//
-// It is deliberately "/" and not the U+241F (␟) that CommPID in linuxobjects.go
-// uses. CommPID needs an exotic separator because its first component (Comm) is
-// a free-form string that may itself contain "/" or ":". Every component of a
-// ProcessRef is a decimal integer, so no escaping hazard exists, and "/" keeps
-// this file internally consistent: NetworkStreamEntity.Inbound/Outbound are
-// already keyed by the composite "<ip>/<port>/<protocol>". It is also 1 byte
-// rather than 3 (UTF-8), which matters because this text appears once per
-// connection — see NetworkStream.Processes on the wire budget.
 const processRefSep = "/"
 
-// ProcessRef identifies one OS process on the node that produced a
-// NetworkStream message. It is both the key of NetworkStream.Processes and the
-// value of NetworkStreamEvent.ProcessRef, so a consumer resolves a connection's
-// process tree with NetworkStream.ProcessTreeFor — no string formatting at the
-// call site and no way for the two sides to disagree on key format.
+// ProcessRef identifies one process on the node, and is both the key of
+// NetworkStream.Processes and the value of NetworkStreamEvent.ProcessRef.
+// Resolve with NetworkStream.ProcessTreeFor.
 //
-// StartTimeNs is the process's creation time as nanoseconds since boot
-// (CLOCK_BOOTTIME), NOT a wall-clock time. The name carries the unit because
-// armotypes.Process.StartTime — the same concept on the tree this ref points
-// at — is a wall-clock time.Time, and confusing the two would be silent. The
-// unit costs nothing on the wire: ProcessRef is text-marshalled, so these field
-// names never appear in JSON at all.
+// PID is a host-namespace pid. StartTimeNs is process CREATION time in
+// nanoseconds since boot — not wall-clock, and not an exec timestamp (an
+// exec-derived value changes on re-exec and breaks identity mid-life). Zero
+// means unknown, leaving pid-only identity that is unsafe to compare across
+// messages.
 //
-// The start time is in the identity purely to survive pid reuse — that is the
-// stated mitigation in the network-reputation GA design (shared-designs-and-docs
-// projects/epics/network-reputation-ga/network-reputation-consolidation-design.md
-// §13: "join reliability across process restarts / pid reuse (mitigated by
-// startTime in the key)"). Nothing renders it. Anything that needs a
-// human-facing process start time should read Process.StartTime off the tree
-// this ref resolves to, which is a wall-clock time.Time.
-//
-// Boot-relative rather than a wall-clock time.Time, deliberately: converting to
-// wall-clock requires the boot timestamp from /proc/stat `btime`, which has
-// whole-second resolution only. A time.Time on the wire would therefore be lossy
-// by up to a second — for a value whose entire job is to disambiguate identity,
-// that is the wrong trade. A boot-relative integer needs no boot-time lookup and
-// is exact.
-//
-// NANOSECONDS ARE THE UNIT, NOT THE RESOLUTION. Do not read this as a precise
-// timestamp. The only start-time source with full process coverage is
-// /proc/<pid>/stat field 22, which is denominated in clock ticks (USER_HZ = 100,
-// i.e. 10 ms), so procfs-derived values are exact multiples of 10,000,000 ns and
-// carry far less precision than the unit implies. Nanoseconds are chosen anyway
-// because conversion only loses information in the other direction — ticks to ns
-// is an exact x10^7, ns to ticks is a lossy division — so no source has to
-// discard anything, and there is one unit for one concept either side of the
-// serialisation boundary. 10 ms granularity is safe for pid-reuse
-// disambiguation by 2-5 orders of magnitude (a kernel must cycle the whole pid
-// space to reuse a pid).
-//
-// The value MUST be process creation time. Never derive it from an exec event:
-// exec does not create a process, so an exec-derived value changes when a
-// process re-execs and the identity silently breaks mid-life.
-//
-// A zero StartTimeNs means the sensor could not read the process's start time
-// (typically a process that exited before /proc could be sampled). Such a ref
-// carries pid-only identity: it is still a valid key within the message, but it
-// must not be treated as equal to a ref for the same pid with a known start
-// time, and it is not safe to compare across messages.
-//
-// PID is a host-namespace pid, matching what the sensor's eBPF network gadget
-// reports (the socket enricher's pid_tgid >> 32, i.e. task->tgid; there is no
-// pid-namespace translation on that path). Host pids are node-unique, which is
-// what makes a single message-scoped Processes map correct.
+// The unit is nanoseconds; the resolution is not. procfs-derived values come
+// from /proc/<pid>/stat field 22 in 10 ms clock ticks, so they are exact
+// multiples of 10^7 ns. Fine for pid-reuse disambiguation, not a precise
+// timestamp.
 type ProcessRef struct {
 	PID         uint32 `json:"pid,omitempty" bson:"pid,omitempty"`
 	StartTimeNs uint64 `json:"startTimeNs,omitempty" bson:"startTimeNs,omitempty"`
 }
 
-// MarshalText implements encoding.TextMarshaler, rendering a ProcessRef as the
-// single string "<pid>/<startTimeNs>". It never returns an error.
+// MarshalText renders a ProcessRef as "<pid>/<startTimeNs>". It never errors.
 //
-// encoding/json uses this for both map keys and plain values, so JSON carries
-// the text form everywhere. mongo-driver honours encoding.TextMarshaler for map
-// KEYS ONLY, so in BSON the Processes key is this same string but a
-// NetworkStreamEvent.ProcessRef is a subdocument built from the struct tags
-// above. Both round-trip; only the query syntax differs.
+// encoding/json uses this for map keys and values alike; mongo-driver uses it
+// for map keys only, so in BSON an event's ProcessRef is a subdocument instead.
 func (p ProcessRef) MarshalText() ([]byte, error) {
 	return []byte(p.String()), nil
 }
 
-// String returns the same "<pid>/<startTimeNs>" text as MarshalText, so a
-// logged ref is greppable against the payload it came from.
+// String returns the same text as MarshalText, so a logged ref greps against
+// the payload it came from.
 func (p ProcessRef) String() string {
 	return strconv.FormatUint(uint64(p.PID), 10) + processRefSep + strconv.FormatUint(p.StartTimeNs, 10)
 }
 
-// UnmarshalText implements encoding.TextUnmarshaler.
+// UnmarshalText parses "<pid>/<startTimeNs>", ignoring any further components
+// and accepting leading zeros.
 //
-// Components beyond the first two are IGNORED rather than rejected. This is the
-// forward-compatibility guarantee, and it is load-bearing: encoding/json aborts
-// the entire enclosing decode when a TextUnmarshaler map key fails — unlike an
-// int-keyed map, which skips the offending entry and carries on — and both
-// stream consumers nack or drop a message whose decode returns an error. So
-// without this tolerance, a future revision that appends a component to the key
-// format would make every un-upgraded consumer reject whole messages, losing a
-// node's entire interval of network visibility. Appending components is the
-// designed way to extend this format; do not make the parser stricter.
+// Do not make this stricter. encoding/json aborts the whole enclosing decode
+// when a TextUnmarshaler map key fails, and both stream consumers drop or nack
+// such a message — so one bad key costs a node's entire interval. Appending
+// components is the designed way to extend the format.
 //
-// Leading zeros are likewise accepted, so non-canonical keys for the same
-// process collapse to one map entry (last wins) instead of failing the message.
-//
-// The receiver is left untouched when an error is returned. Note that guarantee
-// only reaches direct callers: encoding/json allocates the pointer target before
-// calling this method and leaves it installed on failure, so a caller that
-// ignores an Unmarshal error sees a non-nil, zero-valued ref.
+// The receiver is untouched on error, but only for direct callers: encoding/json
+// leaves the allocated pointer installed, so ignoring its error yields a
+// non-nil zero ref.
 func (p *ProcessRef) UnmarshalText(text []byte) error {
 	pidStr, rest, found := strings.Cut(string(text), processRefSep)
 	if !found {
 		return fmt.Errorf("invalid ProcessRef representation: %q", text)
 	}
-	// Anything after the second component belongs to a later revision of this
-	// format; drop it rather than failing.
-	startTimeStr, _, _ := strings.Cut(rest, processRefSep)
+	startTimeStr, _, _ := strings.Cut(rest, processRefSep) // drop later-revision components
 
 	pid, err := strconv.ParseUint(pidStr, 10, 32)
 	if err != nil {
 		return fmt.Errorf("invalid ProcessRef pid %q: %w", pidStr, err)
 	}
-	// Nanoseconds since boot need 64 bits: they exceed uint32 after ~4.3
-	// seconds of uptime, and reach the uint64 ceiling after ~584 years.
 	startTimeNs, err := strconv.ParseUint(startTimeStr, 10, 64)
 	if err != nil {
 		return fmt.Errorf("invalid ProcessRef startTimeNs %q: %w", startTimeStr, err)
 	}
-	p.PID = uint32(pid) // range-checked by ParseUint's bitSize 32 above
+	p.PID = uint32(pid) // range-checked by ParseUint above
 	p.StartTimeNs = startTimeNs
 	return nil
 }
@@ -175,79 +109,28 @@ type NetworkStream struct {
 	// <identifier> to <network stream entity>
 	Entities map[string]NetworkStreamEntity `json:"entities,omitempty"`
 
-	// ProcessAttributionVersion states which revision of process attribution
-	// the producing sensor implements; see NetworkStreamProcessAttributionV1.
-	//
-	// Absent or zero means "this sensor predates process attribution", NOT
-	// "attribution ran and produced nothing". The backend genuinely needs to
-	// tell those apart: an upgraded sensor can legitimately emit an empty
-	// Processes map (every connection unattributable in that interval), so
-	// `len(Processes) == 0` is not a usable proxy for sensor capability.
-	//
-	// This marker is new to the repo — there is no existing schema-version-field
-	// convention here. Versioning is otherwise done by the CRD kind string
-	// (kubescape.io/v1/networkstreams) plus Pulsar topic name, and the
-	// established pattern for additive changes is `omitempty` plus a documented
-	// consumer tolerance (see HostCVEOnFinishedMessage in hot_cve.go). That
-	// pattern alone is not sufficient here precisely because absence of data
-	// and absence of the feature are different states. Bumping the kind string
-	// to a v2 was rejected: both consumers decode with plain json.Unmarshal and
-	// neither sets DisallowUnknownFields, so a purely additive change needs no
-	// breaking version, and a kind bump would force a coordinated consumer
-	// rollout. Note also that this repo auto-tags v0.0.<run_number> on push to
-	// main, so the module version carries no semver signal a consumer could
-	// branch on.
+	// ProcessAttributionVersion is the revision the producing sensor implements.
+	// Absent/zero means the sensor predates process attribution — not that it ran
+	// and found nothing, which an empty Processes map legitimately means.
 	ProcessAttributionVersion int `json:"processAttributionVersion,omitempty" bson:"processAttributionVersion,omitempty"`
 
-	// Processes maps a process identity to the process tree that produced the
-	// connections referencing it. Connections point here via
-	// NetworkStreamEvent.ProcessRef; resolve with ProcessTreeFor rather than
-	// indexing the map directly.
+	// Processes holds each contributing process tree once per message, keyed by
+	// identity; connections reference it via NetworkStreamEvent.ProcessRef.
+	// Resolve with ProcessTreeFor.
 	//
-	// The map is scoped once per MESSAGE, not per container, and the tree is
-	// shipped once per PROCESS, not once per connection. Both choices are about
-	// size:
-	//
-	//   - The synchronizer envelope carries this payload base64-encoded in its
-	//     `patch` field, so every byte added on this type costs x1.333 on the
-	//     wire.
-	//   - Process trees dominate that cost, not the number of map entries.
-	//     They are chain-shaped, and measurement during design put them at
-	//     ~2.0 KB serialised at the median and ~5.1 KB at p90, of which
-	//     `cmdline` alone is ~40% and is unbounded. Inlining a tree per
-	//     connection (the pre-existing NetworkStreamEvent.ProcessTree shape) is
-	//     what forced the sensor to nil trees out entirely before sending;
-	//     deduplicating per process is what makes attribution affordable at
-	//     all.
-	//   - Headroom against the 5 MiB broker limit is comfortable but NOT
-	//     unbounded, and it is set by the tail rather than the median. Applying
-	//     the p90 tree size to the largest message observed during design (109
-	//     container entities, 283 connections, 142 KB on the wire) gives
-	//     roughly 2 MB; the median tree size gives roughly 900 KB. Since
-	//     `cmdline` is unbounded, a sensor-side cap on tree or cmdline size is
-	//     the right lever if this ever approaches the limit — not dropping
-	//     attribution.
-	//   - Message scope is correct rather than merely cheaper: ProcessRef.PID
-	//     is a host-namespace pid and a stream message covers exactly one node,
-	//     so the keys are already unique across the message. Per-container
-	//     scoping would duplicate every tree shared between containers and buy
-	//     nothing.
+	// Once per process rather than per connection because trees dominate the
+	// payload (~2 KB median, unbounded cmdline) and the synchronizer envelope is
+	// base64, costing x1.333 per byte. Message scope is safe because PIDs are
+	// host-namespace and a message covers one node.
 	Processes map[ProcessRef]*ProcessTree `json:"processes,omitempty" bson:"processes,omitempty"`
 }
 
-// ProcessTreeFor resolves the process tree that opened the given connection,
-// returning nil when attribution is absent, dangling or nil-valued.
+// ProcessTreeFor resolves the tree that opened the given connection, returning
+// nil when attribution is absent, dangling or nil-valued. Prefer it to indexing
+// Processes, which panics on a nil ref and cannot tell a missing entry from a
+// present-but-nil one (reachable from a `"processes":{"1/2":null}` payload).
 //
-// Use this instead of indexing Processes directly. A bare
-// `n.Processes[*event.ProcessRef]` has three sharp edges: it panics when
-// event.ProcessRef is nil (every event from a sensor that predates attribution,
-// and any connection the sensor could not attribute), it cannot distinguish a
-// missing entry from a present-but-nil one, and a `"processes":{"1/2":null}`
-// payload decodes to exactly that present-but-nil case — so the map index
-// returns ok == true with a nil tree and the next field access panics.
-//
-// This deliberately does not fall back to the deprecated per-event ProcessTree
-// field; the two have different lifecycles (see NetworkStreamEvent.ProcessRef).
+// It deliberately does not fall back to the per-event ProcessTree field.
 func (n *NetworkStream) ProcessTreeFor(event *NetworkStreamEvent) *ProcessTree {
 	if n == nil || event == nil || event.ProcessRef == nil {
 		return nil
@@ -291,34 +174,11 @@ type NetworkStreamEvent struct {
 	Port        int32                      `json:"port,omitempty"`
 	Protocol    NetworkStreamEventProtocol `json:"protocol,omitempty"`
 	ProcessTree *ProcessTree               `json:"processTree,omitempty"`
-	// ProcessRef attributes this connection to an entry in the message-scoped
-	// NetworkStream.Processes map. Resolve it with
-	// NetworkStream.ProcessTreeFor(event), not by indexing the map.
-	//
-	// This is the field to use for anything travelling over the wire. The
-	// ProcessTree field above inlines a whole tree per connection and is nilled
-	// out by the sensor before the message is sent (node-agent
-	// removeProcessTreeFromEvents); it survives because private-node-agent
-	// wires an in-process notification channel that its host network sensor
-	// reads pre-nil (pkg/hostnetworksensor/v1 reads outbound.ProcessTree
-	// directly). Searching only the OSS node-agent makes it look dead — that
-	// main passes nil for the channel.
-	//
-	// So: do not remove it as part of adding attribution. It does become
-	// removable once HostNetworkSensor is retired, which the network-reputation
-	// GA design (shared-designs-and-docs
-	// projects/epics/network-reputation-ga/network-reputation-consolidation-design.md
-	// §5) plans across private-node-agent's three mains and pkg/hostnetworksensor.
-	// Drop it in that change, not this one.
-	//
-	// It is a pointer so `omitempty` actually drops it — encoding/json does not
-	// omit zero structs, and an always-present "processRef":"0/0" on every
-	// unattributed connection is exactly the per-connection waste this design
-	// exists to avoid. A single text-marshalled field also beats two flat
-	// scalars (pid + startTimeNs) on the wire by 5 bytes per connection,
-	// because it spends one JSON key instead of two. That 5 is pure key
-	// overhead — independent of the pid and start-time values, but it shifts if
-	// either field is renamed.
+	// ProcessRef is the wire-side attribution: it points at an entry in the
+	// message-scoped NetworkStream.Processes map. Resolve with ProcessTreeFor.
+	// Use this rather than ProcessTree above, which the sensor nils out before
+	// sending and which only survives for private-node-agent's in-process host
+	// network sensor — do not remove it here.
 	ProcessRef *ProcessRef `json:"processRef,omitempty" bson:"processRef,omitempty"`
 	// endpoint kind (pod, service, raw)
 	Kind EndpointKind `json:"kind,omitempty"`

--- a/armotypes/networkstream.go
+++ b/armotypes/networkstream.go
@@ -315,8 +315,10 @@ type NetworkStreamEvent struct {
 	// omit zero structs, and an always-present "processRef":"0/0" on every
 	// unattributed connection is exactly the per-connection waste this design
 	// exists to avoid. A single text-marshalled field also beats two flat
-	// scalars (pid + startTimeNs) on the wire by 6 bytes per connection,
-	// because it spends one JSON key instead of two.
+	// scalars (pid + startTimeNs) on the wire by 5 bytes per connection,
+	// because it spends one JSON key instead of two. That 5 is pure key
+	// overhead — independent of the pid and start-time values, but it shifts if
+	// either field is renamed.
 	ProcessRef *ProcessRef `json:"processRef,omitempty" bson:"processRef,omitempty"`
 	// endpoint kind (pod, service, raw)
 	Kind EndpointKind `json:"kind,omitempty"`

--- a/armotypes/networkstream.go
+++ b/armotypes/networkstream.go
@@ -63,6 +63,14 @@ const processRefSep = "/"
 // The unit costs nothing on the wire: ProcessRef is text-marshalled, so these
 // field names never appear in JSON at all.
 //
+// The start time is in the identity purely to survive pid reuse — that is the
+// stated mitigation in the network-reputation GA design (shared-designs-and-docs
+// projects/epics/network-reputation-ga/network-reputation-consolidation-design.md
+// §13: "join reliability across process restarts / pid reuse (mitigated by
+// startTime in the key)"). Nothing renders it. Anything that needs a
+// human-facing process start time should read Process.StartTime off the tree
+// this ref resolves to, which is a wall-clock time.Time.
+//
 // Ticks rather than a time.Time, deliberately:
 //
 //   - The only start-time source with full process coverage is
@@ -283,7 +291,15 @@ type NetworkStreamEvent struct {
 	// removeProcessTreeFromEvents); it survives because private-node-agent
 	// wires an in-process notification channel that its host network sensor
 	// reads pre-nil (pkg/hostnetworksensor/v1 reads outbound.ProcessTree
-	// directly). Do not remove or repurpose it.
+	// directly). Searching only the OSS node-agent makes it look dead — that
+	// main passes nil for the channel.
+	//
+	// So: do not remove it as part of adding attribution. It does become
+	// removable once HostNetworkSensor is retired, which the network-reputation
+	// GA design (shared-designs-and-docs
+	// projects/epics/network-reputation-ga/network-reputation-consolidation-design.md
+	// §5) plans across private-node-agent's three mains and pkg/hostnetworksensor.
+	// Drop it in that change, not this one.
 	//
 	// It is a pointer so `omitempty` actually drops it — encoding/json does not
 	// omit zero structs, and an always-present "processRef":"0/0" on every

--- a/armotypes/networkstream.go
+++ b/armotypes/networkstream.go
@@ -33,7 +33,7 @@ const (
 
 // NetworkStreamProcessAttributionV1 is the current revision of the
 // process-attribution extension to NetworkStream: NetworkStream.Processes plus
-// the per-connection NetworkStreamEvent.Process reference. See
+// the per-connection NetworkStreamEvent.ProcessRef reference. See
 // NetworkStream.ProcessAttributionVersion for why an explicit marker exists at
 // all, and bump this constant if the meaning of either field changes.
 const NetworkStreamProcessAttributionV1 = 1
@@ -56,12 +56,12 @@ const processRefSep = "/"
 // process tree with NetworkStream.ProcessTreeFor — no string formatting at the
 // call site and no way for the two sides to disagree on key format.
 //
-// StartTimeTicks is CLOCK_BOOTTIME in clock ticks since boot (USER_HZ = 100,
-// i.e. 10 ms per tick), NOT a wall-clock time. The name carries the unit
-// because armotypes.Process.StartTime — the same concept on the tree this ref
-// points at — is a wall-clock time.Time, and confusing the two would be silent.
-// The unit costs nothing on the wire: ProcessRef is text-marshalled, so these
-// field names never appear in JSON at all.
+// StartTimeNs is the process's creation time as nanoseconds since boot
+// (CLOCK_BOOTTIME), NOT a wall-clock time. The name carries the unit because
+// armotypes.Process.StartTime — the same concept on the tree this ref points
+// at — is a wall-clock time.Time, and confusing the two would be silent. The
+// unit costs nothing on the wire: ProcessRef is text-marshalled, so these field
+// names never appear in JSON at all.
 //
 // The start time is in the identity purely to survive pid reuse — that is the
 // stated mitigation in the network-reputation GA design (shared-designs-and-docs
@@ -71,23 +71,33 @@ const processRefSep = "/"
 // human-facing process start time should read Process.StartTime off the tree
 // this ref resolves to, which is a wall-clock time.Time.
 //
-// Ticks rather than a time.Time, deliberately:
+// Boot-relative rather than a wall-clock time.Time, deliberately: converting to
+// wall-clock requires the boot timestamp from /proc/stat `btime`, which has
+// whole-second resolution only. A time.Time on the wire would therefore be lossy
+// by up to a second — for a value whose entire job is to disambiguate identity,
+// that is the wrong trade. A boot-relative integer needs no boot-time lookup and
+// is exact.
 //
-//   - The only start-time source with full process coverage is
-//     /proc/<pid>/stat field 22 (starttime), which is denominated in clock
-//     ticks since boot.
-//   - Rendering those ticks to wall-clock requires the boot timestamp from
-//     /proc/stat `btime`, which has whole-second resolution only. A time.Time
-//     on the wire would therefore be lossy by up to a second — for a value
-//     whose entire job is to disambiguate identity, that is the wrong trade.
-//   - Ticks are exact, need no boot-time lookup, and 10 ms granularity is
-//     safe for pid-reuse disambiguation by 2-5 orders of magnitude (a kernel
-//     needs to cycle the whole pid space to reuse a pid).
+// NANOSECONDS ARE THE UNIT, NOT THE RESOLUTION. Do not read this as a precise
+// timestamp. The only start-time source with full process coverage is
+// /proc/<pid>/stat field 22, which is denominated in clock ticks (USER_HZ = 100,
+// i.e. 10 ms), so procfs-derived values are exact multiples of 10,000,000 ns and
+// carry far less precision than the unit implies. Nanoseconds are chosen anyway
+// because conversion only loses information in the other direction — ticks to ns
+// is an exact x10^7, ns to ticks is a lossy division — so no source has to
+// discard anything, and there is one unit for one concept either side of the
+// serialisation boundary. 10 ms granularity is safe for pid-reuse
+// disambiguation by 2-5 orders of magnitude (a kernel must cycle the whole pid
+// space to reuse a pid).
 //
-// A zero StartTimeTicks means the sensor could not read the process's start
-// time (typically a process that exited before /proc could be sampled). Such a
-// ref carries pid-only identity: it is still a valid key within the message, but
-// it must not be treated as equal to a ref for the same pid with a known start
+// The value MUST be process creation time. Never derive it from an exec event:
+// exec does not create a process, so an exec-derived value changes when a
+// process re-execs and the identity silently breaks mid-life.
+//
+// A zero StartTimeNs means the sensor could not read the process's start time
+// (typically a process that exited before /proc could be sampled). Such a ref
+// carries pid-only identity: it is still a valid key within the message, but it
+// must not be treated as equal to a ref for the same pid with a known start
 // time, and it is not safe to compare across messages.
 //
 // PID is a host-namespace pid, matching what the sensor's eBPF network gadget
@@ -95,12 +105,12 @@ const processRefSep = "/"
 // pid-namespace translation on that path). Host pids are node-unique, which is
 // what makes a single message-scoped Processes map correct.
 type ProcessRef struct {
-	PID            uint32 `json:"pid,omitempty" bson:"pid,omitempty"`
-	StartTimeTicks uint64 `json:"startTimeTicks,omitempty" bson:"startTimeTicks,omitempty"`
+	PID         uint32 `json:"pid,omitempty" bson:"pid,omitempty"`
+	StartTimeNs uint64 `json:"startTimeNs,omitempty" bson:"startTimeNs,omitempty"`
 }
 
 // MarshalText implements encoding.TextMarshaler, rendering a ProcessRef as the
-// single string "<pid>/<startTimeTicks>". It never returns an error.
+// single string "<pid>/<startTimeNs>". It never returns an error.
 //
 // encoding/json uses this for both map keys and plain values, so JSON carries
 // the text form everywhere. mongo-driver honours encoding.TextMarshaler for map
@@ -111,10 +121,10 @@ func (p ProcessRef) MarshalText() ([]byte, error) {
 	return []byte(p.String()), nil
 }
 
-// String returns the same "<pid>/<startTimeTicks>" text as MarshalText, so a
+// String returns the same "<pid>/<startTimeNs>" text as MarshalText, so a
 // logged ref is greppable against the payload it came from.
 func (p ProcessRef) String() string {
-	return strconv.FormatUint(uint64(p.PID), 10) + processRefSep + strconv.FormatUint(p.StartTimeTicks, 10)
+	return strconv.FormatUint(uint64(p.PID), 10) + processRefSep + strconv.FormatUint(p.StartTimeNs, 10)
 }
 
 // UnmarshalText implements encoding.TextUnmarshaler.
@@ -149,14 +159,14 @@ func (p *ProcessRef) UnmarshalText(text []byte) error {
 	if err != nil {
 		return fmt.Errorf("invalid ProcessRef pid %q: %w", pidStr, err)
 	}
-	// Ticks since boot outgrow uint32 after ~497 days of uptime at
-	// USER_HZ = 100, so this is parsed and stored as 64-bit.
-	startTimeTicks, err := strconv.ParseUint(startTimeStr, 10, 64)
+	// Nanoseconds since boot need 64 bits: they exceed uint32 after ~4.3
+	// seconds of uptime, and reach the uint64 ceiling after ~584 years.
+	startTimeNs, err := strconv.ParseUint(startTimeStr, 10, 64)
 	if err != nil {
-		return fmt.Errorf("invalid ProcessRef startTimeTicks %q: %w", startTimeStr, err)
+		return fmt.Errorf("invalid ProcessRef startTimeNs %q: %w", startTimeStr, err)
 	}
 	p.PID = uint32(pid) // range-checked by ParseUint's bitSize 32 above
-	p.StartTimeTicks = startTimeTicks
+	p.StartTimeNs = startTimeNs
 	return nil
 }
 
@@ -305,7 +315,7 @@ type NetworkStreamEvent struct {
 	// omit zero structs, and an always-present "processRef":"0/0" on every
 	// unattributed connection is exactly the per-connection waste this design
 	// exists to avoid. A single text-marshalled field also beats two flat
-	// scalars (pid + startTimeTicks) on the wire by 6 bytes per connection,
+	// scalars (pid + startTimeNs) on the wire by 6 bytes per connection,
 	// because it spends one JSON key instead of two.
 	ProcessRef *ProcessRef `json:"processRef,omitempty" bson:"processRef,omitempty"`
 	// endpoint kind (pod, service, raw)

--- a/armotypes/networkstream_test.go
+++ b/armotypes/networkstream_test.go
@@ -22,12 +22,12 @@ func TestProcessRefMarshalText(t *testing.T) {
 		ref  ProcessRef
 		want string
 	}{
-		{name: "typical", ref: ProcessRef{PID: 12345, StartTimeTicks: 91827364}, want: "12345/91827364"},
-		{name: "zero pid", ref: ProcessRef{PID: 0, StartTimeTicks: 91827364}, want: "0/91827364"},
-		{name: "unknown start time", ref: ProcessRef{PID: 12345, StartTimeTicks: 0}, want: "12345/0"},
+		{name: "typical", ref: ProcessRef{PID: 12345, StartTimeNs: 91827364}, want: "12345/91827364"},
+		{name: "zero pid", ref: ProcessRef{PID: 0, StartTimeNs: 91827364}, want: "0/91827364"},
+		{name: "unknown start time", ref: ProcessRef{PID: 12345, StartTimeNs: 0}, want: "12345/0"},
 		{name: "zero value", ref: ProcessRef{}, want: "0/0"},
-		{name: "max pid", ref: ProcessRef{PID: math.MaxUint32, StartTimeTicks: 1}, want: "4294967295/1"},
-		{name: "max start time", ref: ProcessRef{PID: 1, StartTimeTicks: math.MaxUint64}, want: "1/18446744073709551615"},
+		{name: "max pid", ref: ProcessRef{PID: math.MaxUint32, StartTimeNs: 1}, want: "4294967295/1"},
+		{name: "max start time", ref: ProcessRef{PID: 1, StartTimeNs: math.MaxUint64}, want: "1/18446744073709551615"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -52,12 +52,12 @@ func TestProcessRefMarshalText(t *testing.T) {
 func TestProcessRefRoundTrip(t *testing.T) {
 	t.Parallel()
 	tests := []ProcessRef{
-		{PID: 12345, StartTimeTicks: 91827364},
-		{PID: 0, StartTimeTicks: 91827364},
-		{PID: 12345, StartTimeTicks: 0},
+		{PID: 12345, StartTimeNs: 91827364},
+		{PID: 0, StartTimeNs: 91827364},
+		{PID: 12345, StartTimeNs: 0},
 		{},
-		{PID: math.MaxUint32, StartTimeTicks: math.MaxUint64},
-		{PID: 1, StartTimeTicks: 1},
+		{PID: math.MaxUint32, StartTimeNs: math.MaxUint64},
+		{PID: 1, StartTimeNs: 1},
 	}
 	for _, want := range tests {
 		text, err := want.MarshalText()
@@ -85,10 +85,10 @@ func TestProcessRefUnmarshalTextIgnoresExtraComponents(t *testing.T) {
 		text string
 		want ProcessRef
 	}{
-		{name: "one extra component", text: "12345/678/90", want: ProcessRef{PID: 12345, StartTimeTicks: 678}},
-		{name: "several extra components", text: "1/2/3/4/5", want: ProcessRef{PID: 1, StartTimeTicks: 2}},
-		{name: "extra component is non numeric", text: "1/2/abc", want: ProcessRef{PID: 1, StartTimeTicks: 2}},
-		{name: "trailing separator", text: "1/2/", want: ProcessRef{PID: 1, StartTimeTicks: 2}},
+		{name: "one extra component", text: "12345/678/90", want: ProcessRef{PID: 12345, StartTimeNs: 678}},
+		{name: "several extra components", text: "1/2/3/4/5", want: ProcessRef{PID: 1, StartTimeNs: 2}},
+		{name: "extra component is non numeric", text: "1/2/abc", want: ProcessRef{PID: 1, StartTimeNs: 2}},
+		{name: "trailing separator", text: "1/2/", want: ProcessRef{PID: 1, StartTimeNs: 2}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -132,9 +132,9 @@ func TestProcessRefUnmarshalTextErrors(t *testing.T) {
 // not survive encoding/json — see TestNetworkStreamEventMalformedRefInstallsZeroPointer.
 func TestProcessRefUnmarshalTextDoesNotPartiallyMutate(t *testing.T) {
 	t.Parallel()
-	got := ProcessRef{PID: 7, StartTimeTicks: 8}
+	got := ProcessRef{PID: 7, StartTimeNs: 8}
 	require.Error(t, got.UnmarshalText([]byte("99/bad")))
-	assert.Equal(t, ProcessRef{PID: 7, StartTimeTicks: 8}, got)
+	assert.Equal(t, ProcessRef{PID: 7, StartTimeNs: 8}, got)
 }
 
 // TestProcessRefUnmarshalTextAcceptsNonCanonical documents that leading zeros
@@ -154,7 +154,7 @@ func TestProcessRefUnmarshalTextAcceptsNonCanonical(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(payload), &out))
 	require.Len(t, out.Processes, 1, "non-canonical keys for one process collapse to one entry")
 
-	tree := out.Processes[ProcessRef{PID: 12345, StartTimeTicks: 1}]
+	tree := out.Processes[ProcessRef{PID: 12345, StartTimeNs: 1}]
 	require.NotNil(t, tree)
 	assert.Equal(t, "third", tree.ProcessTree.Comm, "last key wins")
 }
@@ -165,7 +165,7 @@ func TestProcessRefUnmarshalTextAcceptsNonCanonical(t *testing.T) {
 // string formatting at the call site.
 func TestProcessRefAsJSONMapKey(t *testing.T) {
 	t.Parallel()
-	ref := ProcessRef{PID: 4242, StartTimeTicks: 314159}
+	ref := ProcessRef{PID: 4242, StartTimeNs: 314159}
 	in := NetworkStream{
 		ProcessAttributionVersion: NetworkStreamProcessAttributionV1,
 		Processes: map[ProcessRef]*ProcessTree{
@@ -221,7 +221,7 @@ func TestProcessRefAsJSONMapKey(t *testing.T) {
 // which is reachable from a malformed payload.
 func TestProcessTreeForDegradesToNil(t *testing.T) {
 	t.Parallel()
-	ref := ProcessRef{PID: 1, StartTimeTicks: 2}
+	ref := ProcessRef{PID: 1, StartTimeNs: 2}
 	tests := []struct {
 		name   string
 		stream *NetworkStream
@@ -233,7 +233,7 @@ func TestProcessTreeForDegradesToNil(t *testing.T) {
 		{name: "no processes map", stream: &NetworkStream{}, event: &NetworkStreamEvent{ProcessRef: &ref}},
 		{
 			name:   "dangling ref",
-			stream: &NetworkStream{Processes: map[ProcessRef]*ProcessTree{{PID: 9, StartTimeTicks: 9}: {}}},
+			stream: &NetworkStream{Processes: map[ProcessRef]*ProcessTree{{PID: 9, StartTimeNs: 9}: {}}},
 			event:  &NetworkStreamEvent{ProcessRef: &ref},
 		},
 		{
@@ -257,11 +257,11 @@ func TestProcessTreeForNilMapValueFromPayload(t *testing.T) {
 	var out NetworkStream
 	require.NoError(t, json.Unmarshal([]byte(`{"processes":{"1/2":null}}`), &out))
 
-	tree, ok := out.Processes[ProcessRef{PID: 1, StartTimeTicks: 2}]
+	tree, ok := out.Processes[ProcessRef{PID: 1, StartTimeNs: 2}]
 	require.True(t, ok, "key present")
 	require.Nil(t, tree, "value nil — a bare map index would return a nil tree that reads as found")
 
-	assert.Nil(t, out.ProcessTreeFor(&NetworkStreamEvent{ProcessRef: &ProcessRef{PID: 1, StartTimeTicks: 2}}))
+	assert.Nil(t, out.ProcessTreeFor(&NetworkStreamEvent{ProcessRef: &ProcessRef{PID: 1, StartTimeNs: 2}}))
 }
 
 // TestNetworkStreamEventMalformedRefInstallsZeroPointer documents that
@@ -346,7 +346,7 @@ func TestNetworkStreamPreProcessAttributionPayloadDecodes(t *testing.T) {
 // processRef.pid where JSONB needs the string.
 func TestProcessRefBSONRoundTrip(t *testing.T) {
 	t.Parallel()
-	ref := ProcessRef{PID: 4242, StartTimeTicks: 314159}
+	ref := ProcessRef{PID: 4242, StartTimeNs: 314159}
 	in := NetworkStream{
 		ProcessAttributionVersion: NetworkStreamProcessAttributionV1,
 		Processes:                 map[ProcessRef]*ProcessTree{ref: {ProcessTree: Process{PID: 4242, Comm: "curl"}}},
@@ -366,7 +366,7 @@ func TestProcessRefBSONRoundTrip(t *testing.T) {
 	event := raw["entities"].(bson.M)["entity-1"].(bson.M)["outbound"].(bson.M)["1.2.3.4/443/TCP"].(bson.M)
 	// Both components widen to int64: mongo-driver encodes Go unsigned integers
 	// as int64 so the full unsigned range survives.
-	assert.Equal(t, bson.M{"pid": int64(4242), "startTimeTicks": int64(314159)}, event["processRef"],
+	assert.Equal(t, bson.M{"pid": int64(4242), "startTimeNs": int64(314159)}, event["processRef"],
 		"bson emits the event-level ref as a subdocument, NOT the text form")
 
 	var out NetworkStream

--- a/armotypes/networkstream_test.go
+++ b/armotypes/networkstream_test.go
@@ -1,0 +1,207 @@
+package armotypes
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+// TestProcessRefMarshalText pins the exact textual form of a ProcessRef. The
+// format is part of the wire contract (it is the JSON object key of
+// NetworkStream.Processes), so a change here is a breaking change for every
+// consumer that decodes the map.
+func TestProcessRefMarshalText(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  ProcessRef
+		want string
+	}{
+		{name: "typical", ref: ProcessRef{PID: 12345, StartTime: 91827364}, want: "12345/91827364"},
+		{name: "zero pid", ref: ProcessRef{PID: 0, StartTime: 91827364}, want: "0/91827364"},
+		{name: "zero start time", ref: ProcessRef{PID: 12345, StartTime: 0}, want: "12345/0"},
+		{name: "zero value", ref: ProcessRef{}, want: "0/0"},
+		{name: "max pid", ref: ProcessRef{PID: math.MaxUint32, StartTime: 1}, want: "4294967295/1"},
+		{name: "max start time", ref: ProcessRef{PID: 1, StartTime: math.MaxUint64}, want: "1/18446744073709551615"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.ref.MarshalText()
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
+// TestProcessRefRoundTrip asserts MarshalText/UnmarshalText are exact inverses,
+// including the edge cases that matter for identity: pid 0 and a zero start
+// time must survive the round trip rather than being silently dropped, because
+// the pair is what disambiguates a reused pid.
+func TestProcessRefRoundTrip(t *testing.T) {
+	tests := []ProcessRef{
+		{PID: 12345, StartTime: 91827364},
+		{PID: 0, StartTime: 91827364},
+		{PID: 12345, StartTime: 0},
+		{},
+		{PID: math.MaxUint32, StartTime: math.MaxUint64},
+		{PID: 1, StartTime: 1},
+	}
+	for _, want := range tests {
+		text, err := want.MarshalText()
+		require.NoError(t, err)
+
+		t.Run(string(text), func(t *testing.T) {
+			var got ProcessRef
+			require.NoError(t, got.UnmarshalText(text))
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestProcessRefUnmarshalTextErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+	}{
+		{name: "empty", text: ""},
+		{name: "no separator", text: "12345"},
+		{name: "extra separator", text: "1/2/3"},
+		{name: "non numeric pid", text: "abc/1"},
+		{name: "non numeric start time", text: "1/abc"},
+		{name: "empty pid", text: "/1"},
+		{name: "empty start time", text: "1/"},
+		{name: "negative pid", text: "-1/1"},
+		{name: "negative start time", text: "1/-1"},
+		{name: "pid overflows uint32", text: "4294967296/1"},
+		{name: "start time overflows uint64", text: "1/18446744073709551616"},
+		{name: "separator only", text: "/"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got ProcessRef
+			assert.Error(t, got.UnmarshalText([]byte(tt.text)))
+		})
+	}
+}
+
+// TestProcessRefUnmarshalTextDoesNotPartiallyMutate asserts a rejected input
+// leaves the receiver untouched. A consumer that ignores the error must not end
+// up attributing a connection to a half-parsed process.
+func TestProcessRefUnmarshalTextDoesNotPartiallyMutate(t *testing.T) {
+	got := ProcessRef{PID: 7, StartTime: 8}
+	require.Error(t, got.UnmarshalText([]byte("99/bad")))
+	assert.Equal(t, ProcessRef{PID: 7, StartTime: 8}, got)
+}
+
+// TestProcessRefAsJSONMapKey is the load-bearing test for the design: the same
+// ProcessRef value is both the key of NetworkStream.Processes and the value of
+// NetworkStreamEvent.Process, so a consumer can look up the tree with
+// stream.Processes[*event.Process] and no string formatting at the call site.
+func TestProcessRefAsJSONMapKey(t *testing.T) {
+	ref := ProcessRef{PID: 4242, StartTime: 314159}
+	in := NetworkStream{
+		ProcessAttributionVersion: NetworkStreamProcessAttributionV1,
+		Processes: map[ProcessRef]*ProcessTree{
+			ref: {ProcessTree: Process{PID: 4242, Comm: "curl", Cmdline: "curl https://example.com"}, ContainerID: "abc123"},
+		},
+		Entities: map[string]NetworkStreamEntity{
+			"entity-1": {
+				Kind: NetworkStreamEntityKindContainer,
+				Outbound: map[string]NetworkStreamEvent{
+					"1.2.3.4/443/TCP": {
+						IPAddress: "1.2.3.4",
+						Port:      443,
+						Protocol:  NetworkStreamEventProtocolTCP,
+						Process:   &ref,
+					},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(in)
+	require.NoError(t, err)
+
+	// The map key must serialise as the composite string, and the per-connection
+	// reference as the same string, so the two are joinable on the wire.
+	assert.Contains(t, string(data), `"processes":{"4242/314159":`)
+	assert.Contains(t, string(data), `"process":"4242/314159"`)
+
+	var out NetworkStream
+	require.NoError(t, json.Unmarshal(data, &out))
+	assert.Equal(t, in, out)
+
+	// The join a consumer actually performs.
+	event := out.Entities["entity-1"].Outbound["1.2.3.4/443/TCP"]
+	require.NotNil(t, event.Process)
+	tree, ok := out.Processes[*event.Process]
+	require.True(t, ok, "per-connection ProcessRef must key into Processes")
+	assert.Equal(t, "curl", tree.ProcessTree.Comm)
+}
+
+// TestNetworkStreamProcessAttributionOmitted asserts the addition is invisible
+// on the wire for an un-upgraded sensor. Both consumers decode with plain
+// json.Unmarshal and neither sets DisallowUnknownFields, so absent fields are
+// the entire backward-compatibility story.
+func TestNetworkStreamProcessAttributionOmitted(t *testing.T) {
+	in := NetworkStream{
+		Entities: map[string]NetworkStreamEntity{
+			"entity-1": {
+				Kind:     NetworkStreamEntityKindContainer,
+				Outbound: map[string]NetworkStreamEvent{"1.2.3.4/443/TCP": {IPAddress: "1.2.3.4", Port: 443}},
+			},
+		},
+	}
+
+	data, err := json.Marshal(in)
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(data), "processAttributionVersion")
+	assert.NotContains(t, string(data), "processes")
+	assert.NotContains(t, string(data), `"process"`)
+}
+
+// TestNetworkStreamPreProcessAttributionPayloadDecodes asserts a payload
+// produced by a sensor that predates process attribution still decodes, and
+// that the absent version marker reads as "no attribution available" rather
+// than "attribution ran and found nothing".
+func TestNetworkStreamPreProcessAttributionPayloadDecodes(t *testing.T) {
+	const legacy = `{"entities":{"e1":{"kind":"container","containerName":"nginx","outbound":{"1.2.3.4/443/TCP":{"ipAddress":"1.2.3.4","port":443,"protocol":"TCP"}}}}}`
+
+	var out NetworkStream
+	require.NoError(t, json.Unmarshal([]byte(legacy), &out))
+
+	assert.Zero(t, out.ProcessAttributionVersion)
+	assert.Nil(t, out.Processes)
+	assert.Nil(t, out.Entities["e1"].Outbound["1.2.3.4/443/TCP"].Process)
+}
+
+// TestProcessRefBSONRoundTrip covers the bson tags. mongo-driver honours
+// encoding.TextMarshaler/TextUnmarshaler for struct map keys, so the Processes
+// map survives a bson round trip with the same composite key as JSON.
+func TestProcessRefBSONRoundTrip(t *testing.T) {
+	ref := ProcessRef{PID: 4242, StartTime: 314159}
+	in := NetworkStream{
+		ProcessAttributionVersion: NetworkStreamProcessAttributionV1,
+		Processes:                 map[ProcessRef]*ProcessTree{ref: {ProcessTree: Process{PID: 4242, Comm: "curl"}}},
+		Entities: map[string]NetworkStreamEntity{
+			"entity-1": {Outbound: map[string]NetworkStreamEvent{"1.2.3.4/443/TCP": {IPAddress: "1.2.3.4", Process: &ref}}},
+		},
+	}
+
+	data, err := bson.Marshal(in)
+	require.NoError(t, err)
+
+	var raw bson.M
+	require.NoError(t, bson.Unmarshal(data, &raw))
+	assert.Equal(t, int32(NetworkStreamProcessAttributionV1), raw["processAttributionVersion"])
+	assert.Contains(t, raw["processes"], "4242/314159")
+
+	var out NetworkStream
+	require.NoError(t, bson.Unmarshal(data, &out))
+	require.NotNil(t, out.Processes[ref])
+	assert.Equal(t, "curl", out.Processes[ref].ProcessTree.Comm)
+}

--- a/armotypes/networkstream_test.go
+++ b/armotypes/networkstream_test.go
@@ -3,6 +3,7 @@ package armotypes
 import (
 	"encoding/json"
 	"math"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,45 +16,55 @@ import (
 // NetworkStream.Processes), so a change here is a breaking change for every
 // consumer that decodes the map.
 func TestProcessRefMarshalText(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		ref  ProcessRef
 		want string
 	}{
-		{name: "typical", ref: ProcessRef{PID: 12345, StartTime: 91827364}, want: "12345/91827364"},
-		{name: "zero pid", ref: ProcessRef{PID: 0, StartTime: 91827364}, want: "0/91827364"},
-		{name: "zero start time", ref: ProcessRef{PID: 12345, StartTime: 0}, want: "12345/0"},
+		{name: "typical", ref: ProcessRef{PID: 12345, StartTimeTicks: 91827364}, want: "12345/91827364"},
+		{name: "zero pid", ref: ProcessRef{PID: 0, StartTimeTicks: 91827364}, want: "0/91827364"},
+		{name: "unknown start time", ref: ProcessRef{PID: 12345, StartTimeTicks: 0}, want: "12345/0"},
 		{name: "zero value", ref: ProcessRef{}, want: "0/0"},
-		{name: "max pid", ref: ProcessRef{PID: math.MaxUint32, StartTime: 1}, want: "4294967295/1"},
-		{name: "max start time", ref: ProcessRef{PID: 1, StartTime: math.MaxUint64}, want: "1/18446744073709551615"},
+		{name: "max pid", ref: ProcessRef{PID: math.MaxUint32, StartTimeTicks: 1}, want: "4294967295/1"},
+		{name: "max start time", ref: ProcessRef{PID: 1, StartTimeTicks: math.MaxUint64}, want: "1/18446744073709551615"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := tt.ref.MarshalText()
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, string(got))
+			// String must agree with the wire form so a logged ref is greppable
+			// against the payload.
+			assert.Equal(t, tt.want, tt.ref.String())
 		})
 	}
 }
 
-// TestProcessRefRoundTrip asserts MarshalText/UnmarshalText are exact inverses,
-// including the edge cases that matter for identity: pid 0 and a zero start
-// time must survive the round trip rather than being silently dropped, because
-// the pair is what disambiguates a reused pid.
+// TestProcessRefRoundTrip asserts ref -> text -> ref is lossless, including the
+// edge cases that matter for identity: pid 0 and a zero start time must survive
+// rather than being silently dropped, because the pair is what disambiguates a
+// reused pid.
+//
+// Note this is one direction only. text -> ref -> text is NOT injective; see
+// TestProcessRefUnmarshalTextAcceptsNonCanonical.
 func TestProcessRefRoundTrip(t *testing.T) {
+	t.Parallel()
 	tests := []ProcessRef{
-		{PID: 12345, StartTime: 91827364},
-		{PID: 0, StartTime: 91827364},
-		{PID: 12345, StartTime: 0},
+		{PID: 12345, StartTimeTicks: 91827364},
+		{PID: 0, StartTimeTicks: 91827364},
+		{PID: 12345, StartTimeTicks: 0},
 		{},
-		{PID: math.MaxUint32, StartTime: math.MaxUint64},
-		{PID: 1, StartTime: 1},
+		{PID: math.MaxUint32, StartTimeTicks: math.MaxUint64},
+		{PID: 1, StartTimeTicks: 1},
 	}
 	for _, want := range tests {
 		text, err := want.MarshalText()
 		require.NoError(t, err)
 
 		t.Run(string(text), func(t *testing.T) {
+			t.Parallel()
 			var got ProcessRef
 			require.NoError(t, got.UnmarshalText(text))
 			assert.Equal(t, want, got)
@@ -61,14 +72,42 @@ func TestProcessRefRoundTrip(t *testing.T) {
 	}
 }
 
+// TestProcessRefUnmarshalTextIgnoresExtraComponents is the forward-compatibility
+// guarantee. encoding/json aborts the ENTIRE decode when a TextUnmarshaler map
+// key fails (unlike int keys, which only skip the entry), and both stream
+// consumers nack or drop a message whose decode errors. So a future revision
+// that appends a component to the key format must not be able to make older
+// consumers reject whole messages.
+func TestProcessRefUnmarshalTextIgnoresExtraComponents(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		text string
+		want ProcessRef
+	}{
+		{name: "one extra component", text: "12345/678/90", want: ProcessRef{PID: 12345, StartTimeTicks: 678}},
+		{name: "several extra components", text: "1/2/3/4/5", want: ProcessRef{PID: 1, StartTimeTicks: 2}},
+		{name: "extra component is non numeric", text: "1/2/abc", want: ProcessRef{PID: 1, StartTimeTicks: 2}},
+		{name: "trailing separator", text: "1/2/", want: ProcessRef{PID: 1, StartTimeTicks: 2}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var got ProcessRef
+			require.NoError(t, got.UnmarshalText([]byte(tt.text)))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestProcessRefUnmarshalTextErrors(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		text string
 	}{
 		{name: "empty", text: ""},
 		{name: "no separator", text: "12345"},
-		{name: "extra separator", text: "1/2/3"},
 		{name: "non numeric pid", text: "abc/1"},
 		{name: "non numeric start time", text: "1/abc"},
 		{name: "empty pid", text: "/1"},
@@ -81,6 +120,7 @@ func TestProcessRefUnmarshalTextErrors(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var got ProcessRef
 			assert.Error(t, got.UnmarshalText([]byte(tt.text)))
 		})
@@ -88,20 +128,44 @@ func TestProcessRefUnmarshalTextErrors(t *testing.T) {
 }
 
 // TestProcessRefUnmarshalTextDoesNotPartiallyMutate asserts a rejected input
-// leaves the receiver untouched. A consumer that ignores the error must not end
-// up attributing a connection to a half-parsed process.
+// leaves the receiver untouched for a DIRECT caller. Note this guarantee does
+// not survive encoding/json — see TestNetworkStreamEventMalformedRefInstallsZeroPointer.
 func TestProcessRefUnmarshalTextDoesNotPartiallyMutate(t *testing.T) {
-	got := ProcessRef{PID: 7, StartTime: 8}
+	t.Parallel()
+	got := ProcessRef{PID: 7, StartTimeTicks: 8}
 	require.Error(t, got.UnmarshalText([]byte("99/bad")))
-	assert.Equal(t, ProcessRef{PID: 7, StartTime: 8}, got)
+	assert.Equal(t, ProcessRef{PID: 7, StartTimeTicks: 8}, got)
+}
+
+// TestProcessRefUnmarshalTextAcceptsNonCanonical documents that leading zeros
+// are accepted, so distinct wire keys for the same process collapse to one map
+// entry (last wins). Tightening this would turn a cosmetically odd producer
+// into a whole-message decode failure, which is the worse trade — see
+// TestProcessRefUnmarshalTextIgnoresExtraComponents.
+func TestProcessRefUnmarshalTextAcceptsNonCanonical(t *testing.T) {
+	t.Parallel()
+	const payload = `{"processes":{
+		"12345/1":  {"processTree":{"comm":"first"}},
+		"0012345/1":{"processTree":{"comm":"second"}},
+		"12345/01": {"processTree":{"comm":"third"}}
+	}}`
+
+	var out NetworkStream
+	require.NoError(t, json.Unmarshal([]byte(payload), &out))
+	require.Len(t, out.Processes, 1, "non-canonical keys for one process collapse to one entry")
+
+	tree := out.Processes[ProcessRef{PID: 12345, StartTimeTicks: 1}]
+	require.NotNil(t, tree)
+	assert.Equal(t, "third", tree.ProcessTree.Comm, "last key wins")
 }
 
 // TestProcessRefAsJSONMapKey is the load-bearing test for the design: the same
 // ProcessRef value is both the key of NetworkStream.Processes and the value of
-// NetworkStreamEvent.Process, so a consumer can look up the tree with
-// stream.Processes[*event.Process] and no string formatting at the call site.
+// NetworkStreamEvent.ProcessRef, so a consumer resolves the tree without any
+// string formatting at the call site.
 func TestProcessRefAsJSONMapKey(t *testing.T) {
-	ref := ProcessRef{PID: 4242, StartTime: 314159}
+	t.Parallel()
+	ref := ProcessRef{PID: 4242, StartTimeTicks: 314159}
 	in := NetworkStream{
 		ProcessAttributionVersion: NetworkStreamProcessAttributionV1,
 		Processes: map[ProcessRef]*ProcessTree{
@@ -112,10 +176,10 @@ func TestProcessRefAsJSONMapKey(t *testing.T) {
 				Kind: NetworkStreamEntityKindContainer,
 				Outbound: map[string]NetworkStreamEvent{
 					"1.2.3.4/443/TCP": {
-						IPAddress: "1.2.3.4",
-						Port:      443,
-						Protocol:  NetworkStreamEventProtocolTCP,
-						Process:   &ref,
+						IPAddress:  "1.2.3.4",
+						Port:       443,
+						Protocol:   NetworkStreamEventProtocolTCP,
+						ProcessRef: &ref,
 					},
 				},
 			},
@@ -125,10 +189,20 @@ func TestProcessRefAsJSONMapKey(t *testing.T) {
 	data, err := json.Marshal(in)
 	require.NoError(t, err)
 
-	// The map key must serialise as the composite string, and the per-connection
-	// reference as the same string, so the two are joinable on the wire.
-	assert.Contains(t, string(data), `"processes":{"4242/314159":`)
-	assert.Contains(t, string(data), `"process":"4242/314159"`)
+	// Both sides must render the ref as the same composite string, so the two
+	// are joinable on the wire. Asserted structurally rather than as a
+	// substring, so the test does not depend on key ordering.
+	var top struct {
+		Processes map[string]json.RawMessage `json:"processes"`
+		Entities  map[string]struct {
+			Outbound map[string]struct {
+				ProcessRef string `json:"processRef"`
+			} `json:"outbound"`
+		} `json:"entities"`
+	}
+	require.NoError(t, json.Unmarshal(data, &top))
+	assert.Equal(t, []string{"4242/314159"}, sortedKeys(top.Processes))
+	assert.Equal(t, "4242/314159", top.Entities["entity-1"].Outbound["1.2.3.4/443/TCP"].ProcessRef)
 
 	var out NetworkStream
 	require.NoError(t, json.Unmarshal(data, &out))
@@ -136,10 +210,88 @@ func TestProcessRefAsJSONMapKey(t *testing.T) {
 
 	// The join a consumer actually performs.
 	event := out.Entities["entity-1"].Outbound["1.2.3.4/443/TCP"]
-	require.NotNil(t, event.Process)
-	tree, ok := out.Processes[*event.Process]
-	require.True(t, ok, "per-connection ProcessRef must key into Processes")
+	tree := out.ProcessTreeFor(&event)
+	require.NotNil(t, tree, "per-connection ProcessRef must resolve against Processes")
 	assert.Equal(t, "curl", tree.ProcessTree.Comm)
+}
+
+// TestProcessTreeForDegradesToNil covers every way attribution can be absent or
+// broken. ProcessTreeFor exists so consumers do not each reimplement these
+// guards — a bare Processes[*event.ProcessRef] panics on a null map value,
+// which is reachable from a malformed payload.
+func TestProcessTreeForDegradesToNil(t *testing.T) {
+	t.Parallel()
+	ref := ProcessRef{PID: 1, StartTimeTicks: 2}
+	tests := []struct {
+		name   string
+		stream *NetworkStream
+		event  *NetworkStreamEvent
+	}{
+		{name: "nil stream", stream: nil, event: &NetworkStreamEvent{ProcessRef: &ref}},
+		{name: "nil event", stream: &NetworkStream{}, event: nil},
+		{name: "unattributed event", stream: &NetworkStream{Processes: map[ProcessRef]*ProcessTree{ref: {}}}, event: &NetworkStreamEvent{}},
+		{name: "no processes map", stream: &NetworkStream{}, event: &NetworkStreamEvent{ProcessRef: &ref}},
+		{
+			name:   "dangling ref",
+			stream: &NetworkStream{Processes: map[ProcessRef]*ProcessTree{{PID: 9, StartTimeTicks: 9}: {}}},
+			event:  &NetworkStreamEvent{ProcessRef: &ref},
+		},
+		{
+			name:   "nil map value",
+			stream: &NetworkStream{Processes: map[ProcessRef]*ProcessTree{ref: nil}},
+			event:  &NetworkStreamEvent{ProcessRef: &ref},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Nil(t, tt.stream.ProcessTreeFor(tt.event))
+		})
+	}
+}
+
+// TestProcessTreeForNilMapValueFromPayload proves the "nil map value" case above
+// is reachable from the wire, not just constructible in Go.
+func TestProcessTreeForNilMapValueFromPayload(t *testing.T) {
+	t.Parallel()
+	var out NetworkStream
+	require.NoError(t, json.Unmarshal([]byte(`{"processes":{"1/2":null}}`), &out))
+
+	tree, ok := out.Processes[ProcessRef{PID: 1, StartTimeTicks: 2}]
+	require.True(t, ok, "key present")
+	require.Nil(t, tree, "value nil — a bare map index would return a nil tree that reads as found")
+
+	assert.Nil(t, out.ProcessTreeFor(&NetworkStreamEvent{ProcessRef: &ProcessRef{PID: 1, StartTimeTicks: 2}}))
+}
+
+// TestNetworkStreamEventMalformedRefInstallsZeroPointer documents that
+// encoding/json allocates the pointer target before calling UnmarshalText and
+// leaves it installed on failure. A caller that ignores the Unmarshal error
+// therefore sees a NON-nil ref reading as pid 0. Both stream consumers do check
+// the error, so this is a documented sharp edge rather than a live hazard.
+func TestNetworkStreamEventMalformedRefInstallsZeroPointer(t *testing.T) {
+	t.Parallel()
+	for _, payload := range []string{`{"processRef":"abc/1"}`, `{"processRef":"1"}`, `{"processRef":123}`} {
+		var ev NetworkStreamEvent
+		require.Error(t, json.Unmarshal([]byte(payload), &ev), payload)
+		if assert.NotNil(t, ev.ProcessRef, payload) {
+			assert.Equal(t, ProcessRef{}, *ev.ProcessRef, payload)
+		}
+	}
+}
+
+// TestNetworkStreamMalformedKeyDiscardsWholeMap records the cost of a typed map
+// key: unlike an int-keyed map (which skips the bad entry and continues),
+// encoding/json returns immediately, so the whole Processes map is lost and the
+// caller gets an error. This is why UnmarshalText tolerates extra components.
+func TestNetworkStreamMalformedKeyDiscardsWholeMap(t *testing.T) {
+	t.Parallel()
+	const payload = `{"entities":{"e1":{"containerName":"nginx"}},"processes":{"BAD":{"processTree":{"comm":"x"}},"1/2":{"processTree":{"comm":"good"}}}}`
+
+	var out NetworkStream
+	err := json.Unmarshal([]byte(payload), &out)
+	require.Error(t, err)
+	assert.Empty(t, out.Processes, "one unparseable key discards every entry, including valid ones")
 }
 
 // TestNetworkStreamProcessAttributionOmitted asserts the addition is invisible
@@ -147,6 +299,7 @@ func TestProcessRefAsJSONMapKey(t *testing.T) {
 // json.Unmarshal and neither sets DisallowUnknownFields, so absent fields are
 // the entire backward-compatibility story.
 func TestNetworkStreamProcessAttributionOmitted(t *testing.T) {
+	t.Parallel()
 	in := NetworkStream{
 		Entities: map[string]NetworkStreamEntity{
 			"entity-1": {
@@ -159,9 +312,14 @@ func TestNetworkStreamProcessAttributionOmitted(t *testing.T) {
 	data, err := json.Marshal(in)
 	require.NoError(t, err)
 
-	assert.NotContains(t, string(data), "processAttributionVersion")
-	assert.NotContains(t, string(data), "processes")
-	assert.NotContains(t, string(data), `"process"`)
+	var top map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &top))
+	assert.Equal(t, []string{"entities"}, sortedKeys(top),
+		"neither ProcessAttributionVersion nor Processes may appear when unset")
+
+	var event map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(mustNestedEvent(t, data), &event))
+	assert.NotContains(t, sortedKeys(event), "processRef")
 }
 
 // TestNetworkStreamPreProcessAttributionPayloadDecodes asserts a payload
@@ -169,6 +327,7 @@ func TestNetworkStreamProcessAttributionOmitted(t *testing.T) {
 // that the absent version marker reads as "no attribution available" rather
 // than "attribution ran and found nothing".
 func TestNetworkStreamPreProcessAttributionPayloadDecodes(t *testing.T) {
+	t.Parallel()
 	const legacy = `{"entities":{"e1":{"kind":"container","containerName":"nginx","outbound":{"1.2.3.4/443/TCP":{"ipAddress":"1.2.3.4","port":443,"protocol":"TCP"}}}}}`
 
 	var out NetworkStream
@@ -176,19 +335,23 @@ func TestNetworkStreamPreProcessAttributionPayloadDecodes(t *testing.T) {
 
 	assert.Zero(t, out.ProcessAttributionVersion)
 	assert.Nil(t, out.Processes)
-	assert.Nil(t, out.Entities["e1"].Outbound["1.2.3.4/443/TCP"].Process)
+	assert.Nil(t, out.Entities["e1"].Outbound["1.2.3.4/443/TCP"].ProcessRef)
 }
 
-// TestProcessRefBSONRoundTrip covers the bson tags. mongo-driver honours
-// encoding.TextMarshaler/TextUnmarshaler for struct map keys, so the Processes
-// map survives a bson round trip with the same composite key as JSON.
+// TestProcessRefBSONRoundTrip covers the bson tags, and pins the fact that bson
+// and JSON do NOT agree on the per-connection representation: mongo-driver
+// honours encoding.TextMarshaler for map KEYS only, so Processes is keyed by the
+// same composite string in both, while the event-level ref is a string in JSON
+// and a subdocument in BSON. It round-trips either way, but a Mongo query needs
+// processRef.pid where JSONB needs the string.
 func TestProcessRefBSONRoundTrip(t *testing.T) {
-	ref := ProcessRef{PID: 4242, StartTime: 314159}
+	t.Parallel()
+	ref := ProcessRef{PID: 4242, StartTimeTicks: 314159}
 	in := NetworkStream{
 		ProcessAttributionVersion: NetworkStreamProcessAttributionV1,
 		Processes:                 map[ProcessRef]*ProcessTree{ref: {ProcessTree: Process{PID: 4242, Comm: "curl"}}},
 		Entities: map[string]NetworkStreamEntity{
-			"entity-1": {Outbound: map[string]NetworkStreamEvent{"1.2.3.4/443/TCP": {IPAddress: "1.2.3.4", Process: &ref}}},
+			"entity-1": {Outbound: map[string]NetworkStreamEvent{"1.2.3.4/443/TCP": {IPAddress: "1.2.3.4", ProcessRef: &ref}}},
 		},
 	}
 
@@ -198,10 +361,45 @@ func TestProcessRefBSONRoundTrip(t *testing.T) {
 	var raw bson.M
 	require.NoError(t, bson.Unmarshal(data, &raw))
 	assert.Equal(t, int32(NetworkStreamProcessAttributionV1), raw["processAttributionVersion"])
-	assert.Contains(t, raw["processes"], "4242/314159")
+	assert.Contains(t, raw["processes"], ref.String(), "map key is the composite string in bson too")
+
+	event := raw["entities"].(bson.M)["entity-1"].(bson.M)["outbound"].(bson.M)["1.2.3.4/443/TCP"].(bson.M)
+	// Both components widen to int64: mongo-driver encodes Go unsigned integers
+	// as int64 so the full unsigned range survives.
+	assert.Equal(t, bson.M{"pid": int64(4242), "startTimeTicks": int64(314159)}, event["processRef"],
+		"bson emits the event-level ref as a subdocument, NOT the text form")
 
 	var out NetworkStream
 	require.NoError(t, bson.Unmarshal(data, &out))
 	require.NotNil(t, out.Processes[ref])
 	assert.Equal(t, "curl", out.Processes[ref].ProcessTree.Comm)
+	assert.Equal(t, &ref, out.Entities["entity-1"].Outbound["1.2.3.4/443/TCP"].ProcessRef)
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// mustNestedEvent extracts the single outbound event object from a marshalled
+// NetworkStream.
+func mustNestedEvent(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var top struct {
+		Entities map[string]struct {
+			Outbound map[string]json.RawMessage `json:"outbound"`
+		} `json:"entities"`
+	}
+	require.NoError(t, json.Unmarshal(data, &top))
+	for _, entity := range top.Entities {
+		for _, event := range entity.Outbound {
+			return event
+		}
+	}
+	t.Fatal("no outbound event found")
+	return nil
 }

--- a/armotypes/networkstream_test.go
+++ b/armotypes/networkstream_test.go
@@ -11,10 +11,8 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-// TestProcessRefMarshalText pins the exact textual form of a ProcessRef. The
-// format is part of the wire contract (it is the JSON object key of
-// NetworkStream.Processes), so a change here is a breaking change for every
-// consumer that decodes the map.
+// Pins the textual form: it is the JSON object key of NetworkStream.Processes,
+// so changing it breaks every consumer that decodes the map.
 func TestProcessRefMarshalText(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -42,13 +40,8 @@ func TestProcessRefMarshalText(t *testing.T) {
 	}
 }
 
-// TestProcessRefRoundTrip asserts ref -> text -> ref is lossless, including the
-// edge cases that matter for identity: pid 0 and a zero start time must survive
-// rather than being silently dropped, because the pair is what disambiguates a
-// reused pid.
-//
-// Note this is one direction only. text -> ref -> text is NOT injective; see
-// TestProcessRefUnmarshalTextAcceptsNonCanonical.
+// ref -> text -> ref is lossless, including pid 0 and a zero start time. The
+// reverse direction is not injective; see TestProcessRefUnmarshalTextAcceptsNonCanonical.
 func TestProcessRefRoundTrip(t *testing.T) {
 	t.Parallel()
 	tests := []ProcessRef{
@@ -72,12 +65,8 @@ func TestProcessRefRoundTrip(t *testing.T) {
 	}
 }
 
-// TestProcessRefUnmarshalTextIgnoresExtraComponents is the forward-compatibility
-// guarantee. encoding/json aborts the ENTIRE decode when a TextUnmarshaler map
-// key fails (unlike int keys, which only skip the entry), and both stream
-// consumers nack or drop a message whose decode errors. So a future revision
-// that appends a component to the key format must not be able to make older
-// consumers reject whole messages.
+// Forward compatibility: appending a key component must not make older consumers
+// reject whole messages. See TestNetworkStreamMalformedKeyDiscardsWholeMap for why.
 func TestProcessRefUnmarshalTextIgnoresExtraComponents(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -127,9 +116,8 @@ func TestProcessRefUnmarshalTextErrors(t *testing.T) {
 	}
 }
 
-// TestProcessRefUnmarshalTextDoesNotPartiallyMutate asserts a rejected input
-// leaves the receiver untouched for a DIRECT caller. Note this guarantee does
-// not survive encoding/json — see TestNetworkStreamEventMalformedRefInstallsZeroPointer.
+// Rejected input leaves the receiver untouched — for direct callers only; see
+// TestNetworkStreamEventMalformedRefInstallsZeroPointer.
 func TestProcessRefUnmarshalTextDoesNotPartiallyMutate(t *testing.T) {
 	t.Parallel()
 	got := ProcessRef{PID: 7, StartTimeNs: 8}
@@ -137,11 +125,8 @@ func TestProcessRefUnmarshalTextDoesNotPartiallyMutate(t *testing.T) {
 	assert.Equal(t, ProcessRef{PID: 7, StartTimeNs: 8}, got)
 }
 
-// TestProcessRefUnmarshalTextAcceptsNonCanonical documents that leading zeros
-// are accepted, so distinct wire keys for the same process collapse to one map
-// entry (last wins). Tightening this would turn a cosmetically odd producer
-// into a whole-message decode failure, which is the worse trade — see
-// TestProcessRefUnmarshalTextIgnoresExtraComponents.
+// Leading zeros are accepted, so non-canonical keys for one process collapse to
+// a single entry (last wins). Tightening this would fail the whole message.
 func TestProcessRefUnmarshalTextAcceptsNonCanonical(t *testing.T) {
 	t.Parallel()
 	const payload = `{"processes":{
@@ -159,10 +144,8 @@ func TestProcessRefUnmarshalTextAcceptsNonCanonical(t *testing.T) {
 	assert.Equal(t, "third", tree.ProcessTree.Comm, "last key wins")
 }
 
-// TestProcessRefAsJSONMapKey is the load-bearing test for the design: the same
-// ProcessRef value is both the key of NetworkStream.Processes and the value of
-// NetworkStreamEvent.ProcessRef, so a consumer resolves the tree without any
-// string formatting at the call site.
+// The load-bearing test: one ProcessRef value serves as both map key and event
+// reference, so the join needs no string formatting at the call site.
 func TestProcessRefAsJSONMapKey(t *testing.T) {
 	t.Parallel()
 	ref := ProcessRef{PID: 4242, StartTimeNs: 3141590000000}
@@ -189,9 +172,7 @@ func TestProcessRefAsJSONMapKey(t *testing.T) {
 	data, err := json.Marshal(in)
 	require.NoError(t, err)
 
-	// Both sides must render the ref as the same composite string, so the two
-	// are joinable on the wire. Asserted structurally rather than as a
-	// substring, so the test does not depend on key ordering.
+	// Asserted structurally, not as a substring, so key ordering is irrelevant.
 	var top struct {
 		Processes map[string]json.RawMessage `json:"processes"`
 		Entities  map[string]struct {
@@ -215,10 +196,8 @@ func TestProcessRefAsJSONMapKey(t *testing.T) {
 	assert.Equal(t, "curl", tree.ProcessTree.Comm)
 }
 
-// TestProcessTreeForDegradesToNil covers every way attribution can be absent or
-// broken. ProcessTreeFor exists so consumers do not each reimplement these
-// guards — a bare Processes[*event.ProcessRef] panics on a null map value,
-// which is reachable from a malformed payload.
+// Every way attribution can be absent or broken. ProcessTreeFor exists so each
+// consumer need not reimplement these guards.
 func TestProcessTreeForDegradesToNil(t *testing.T) {
 	t.Parallel()
 	ref := ProcessRef{PID: 1, StartTimeNs: 2}
@@ -264,11 +243,9 @@ func TestProcessTreeForNilMapValueFromPayload(t *testing.T) {
 	assert.Nil(t, out.ProcessTreeFor(&NetworkStreamEvent{ProcessRef: &ProcessRef{PID: 1, StartTimeNs: 2}}))
 }
 
-// TestNetworkStreamEventMalformedRefInstallsZeroPointer documents that
-// encoding/json allocates the pointer target before calling UnmarshalText and
-// leaves it installed on failure. A caller that ignores the Unmarshal error
-// therefore sees a NON-nil ref reading as pid 0. Both stream consumers do check
-// the error, so this is a documented sharp edge rather than a live hazard.
+// encoding/json leaves the allocated pointer installed when UnmarshalText fails,
+// so ignoring its error yields a non-nil ref reading as pid 0. Both consumers do
+// check the error, so this is a sharp edge rather than a live hazard.
 func TestNetworkStreamEventMalformedRefInstallsZeroPointer(t *testing.T) {
 	t.Parallel()
 	for _, payload := range []string{`{"processRef":"abc/1"}`, `{"processRef":"1"}`, `{"processRef":123}`} {
@@ -280,10 +257,9 @@ func TestNetworkStreamEventMalformedRefInstallsZeroPointer(t *testing.T) {
 	}
 }
 
-// TestNetworkStreamMalformedKeyDiscardsWholeMap records the cost of a typed map
-// key: unlike an int-keyed map (which skips the bad entry and continues),
-// encoding/json returns immediately, so the whole Processes map is lost and the
-// caller gets an error. This is why UnmarshalText tolerates extra components.
+// The cost of a typed map key: encoding/json returns immediately rather than
+// skipping the bad entry, so one unparseable key discards the whole map. This is
+// why UnmarshalText is permissive.
 func TestNetworkStreamMalformedKeyDiscardsWholeMap(t *testing.T) {
 	t.Parallel()
 	const payload = `{"entities":{"e1":{"containerName":"nginx"}},"processes":{"BAD":{"processTree":{"comm":"x"}},"1/2":{"processTree":{"comm":"good"}}}}`
@@ -294,10 +270,8 @@ func TestNetworkStreamMalformedKeyDiscardsWholeMap(t *testing.T) {
 	assert.Empty(t, out.Processes, "one unparseable key discards every entry, including valid ones")
 }
 
-// TestNetworkStreamProcessAttributionOmitted asserts the addition is invisible
-// on the wire for an un-upgraded sensor. Both consumers decode with plain
-// json.Unmarshal and neither sets DisallowUnknownFields, so absent fields are
-// the entire backward-compatibility story.
+// The addition must be invisible on the wire for an un-upgraded sensor: absent
+// fields are the entire backward-compatibility story.
 func TestNetworkStreamProcessAttributionOmitted(t *testing.T) {
 	t.Parallel()
 	in := NetworkStream{
@@ -322,10 +296,8 @@ func TestNetworkStreamProcessAttributionOmitted(t *testing.T) {
 	assert.NotContains(t, sortedKeys(event), "processRef")
 }
 
-// TestNetworkStreamPreProcessAttributionPayloadDecodes asserts a payload
-// produced by a sensor that predates process attribution still decodes, and
-// that the absent version marker reads as "no attribution available" rather
-// than "attribution ran and found nothing".
+// A pre-attribution payload still decodes, and the absent version marker reads as
+// "sensor cannot attribute" rather than "attributed nothing".
 func TestNetworkStreamPreProcessAttributionPayloadDecodes(t *testing.T) {
 	t.Parallel()
 	const legacy = `{"entities":{"e1":{"kind":"container","containerName":"nginx","outbound":{"1.2.3.4/443/TCP":{"ipAddress":"1.2.3.4","port":443,"protocol":"TCP"}}}}}`
@@ -338,12 +310,9 @@ func TestNetworkStreamPreProcessAttributionPayloadDecodes(t *testing.T) {
 	assert.Nil(t, out.Entities["e1"].Outbound["1.2.3.4/443/TCP"].ProcessRef)
 }
 
-// TestProcessRefBSONRoundTrip covers the bson tags, and pins the fact that bson
-// and JSON do NOT agree on the per-connection representation: mongo-driver
-// honours encoding.TextMarshaler for map KEYS only, so Processes is keyed by the
-// same composite string in both, while the event-level ref is a string in JSON
-// and a subdocument in BSON. It round-trips either way, but a Mongo query needs
-// processRef.pid where JSONB needs the string.
+// Covers the bson tags, and pins that BSON and JSON disagree on the event-level
+// ref: mongo-driver honours TextMarshaler for map keys only, so a Mongo query
+// needs processRef.pid where JSONB needs the string.
 func TestProcessRefBSONRoundTrip(t *testing.T) {
 	t.Parallel()
 	ref := ProcessRef{PID: 4242, StartTimeNs: 3141590000000}
@@ -364,8 +333,7 @@ func TestProcessRefBSONRoundTrip(t *testing.T) {
 	assert.Contains(t, raw["processes"], ref.String(), "map key is the composite string in bson too")
 
 	event := raw["entities"].(bson.M)["entity-1"].(bson.M)["outbound"].(bson.M)["1.2.3.4/443/TCP"].(bson.M)
-	// Both components widen to int64: mongo-driver encodes Go unsigned integers
-	// as int64 so the full unsigned range survives.
+	// Both widen to int64 — mongo-driver encodes Go unsigned ints that way.
 	assert.Equal(t, bson.M{"pid": int64(4242), "startTimeNs": int64(3141590000000)}, event["processRef"],
 		"bson emits the event-level ref as a subdocument, NOT the text form")
 
@@ -385,8 +353,7 @@ func sortedKeys[V any](m map[string]V) []string {
 	return keys
 }
 
-// mustNestedEvent extracts the single outbound event object from a marshalled
-// NetworkStream.
+// mustNestedEvent extracts the single outbound event from a marshalled NetworkStream.
 func mustNestedEvent(t *testing.T, data []byte) []byte {
 	t.Helper()
 	var top struct {

--- a/armotypes/networkstream_test.go
+++ b/armotypes/networkstream_test.go
@@ -22,8 +22,8 @@ func TestProcessRefMarshalText(t *testing.T) {
 		ref  ProcessRef
 		want string
 	}{
-		{name: "typical", ref: ProcessRef{PID: 12345, StartTimeNs: 91827364}, want: "12345/91827364"},
-		{name: "zero pid", ref: ProcessRef{PID: 0, StartTimeNs: 91827364}, want: "0/91827364"},
+		{name: "typical", ref: ProcessRef{PID: 12345, StartTimeNs: 918273640000000}, want: "12345/918273640000000"},
+		{name: "zero pid", ref: ProcessRef{PID: 0, StartTimeNs: 918273640000000}, want: "0/918273640000000"},
 		{name: "unknown start time", ref: ProcessRef{PID: 12345, StartTimeNs: 0}, want: "12345/0"},
 		{name: "zero value", ref: ProcessRef{}, want: "0/0"},
 		{name: "max pid", ref: ProcessRef{PID: math.MaxUint32, StartTimeNs: 1}, want: "4294967295/1"},
@@ -52,8 +52,8 @@ func TestProcessRefMarshalText(t *testing.T) {
 func TestProcessRefRoundTrip(t *testing.T) {
 	t.Parallel()
 	tests := []ProcessRef{
-		{PID: 12345, StartTimeNs: 91827364},
-		{PID: 0, StartTimeNs: 91827364},
+		{PID: 12345, StartTimeNs: 918273640000000},
+		{PID: 0, StartTimeNs: 918273640000000},
 		{PID: 12345, StartTimeNs: 0},
 		{},
 		{PID: math.MaxUint32, StartTimeNs: math.MaxUint64},
@@ -165,7 +165,7 @@ func TestProcessRefUnmarshalTextAcceptsNonCanonical(t *testing.T) {
 // string formatting at the call site.
 func TestProcessRefAsJSONMapKey(t *testing.T) {
 	t.Parallel()
-	ref := ProcessRef{PID: 4242, StartTimeNs: 314159}
+	ref := ProcessRef{PID: 4242, StartTimeNs: 3141590000000}
 	in := NetworkStream{
 		ProcessAttributionVersion: NetworkStreamProcessAttributionV1,
 		Processes: map[ProcessRef]*ProcessTree{
@@ -201,8 +201,8 @@ func TestProcessRefAsJSONMapKey(t *testing.T) {
 		} `json:"entities"`
 	}
 	require.NoError(t, json.Unmarshal(data, &top))
-	assert.Equal(t, []string{"4242/314159"}, sortedKeys(top.Processes))
-	assert.Equal(t, "4242/314159", top.Entities["entity-1"].Outbound["1.2.3.4/443/TCP"].ProcessRef)
+	assert.Equal(t, []string{"4242/3141590000000"}, sortedKeys(top.Processes))
+	assert.Equal(t, "4242/3141590000000", top.Entities["entity-1"].Outbound["1.2.3.4/443/TCP"].ProcessRef)
 
 	var out NetworkStream
 	require.NoError(t, json.Unmarshal(data, &out))
@@ -346,7 +346,7 @@ func TestNetworkStreamPreProcessAttributionPayloadDecodes(t *testing.T) {
 // processRef.pid where JSONB needs the string.
 func TestProcessRefBSONRoundTrip(t *testing.T) {
 	t.Parallel()
-	ref := ProcessRef{PID: 4242, StartTimeNs: 314159}
+	ref := ProcessRef{PID: 4242, StartTimeNs: 3141590000000}
 	in := NetworkStream{
 		ProcessAttributionVersion: NetworkStreamProcessAttributionV1,
 		Processes:                 map[ProcessRef]*ProcessTree{ref: {ProcessTree: Process{PID: 4242, Comm: "curl"}}},
@@ -366,7 +366,7 @@ func TestProcessRefBSONRoundTrip(t *testing.T) {
 	event := raw["entities"].(bson.M)["entity-1"].(bson.M)["outbound"].(bson.M)["1.2.3.4/443/TCP"].(bson.M)
 	// Both components widen to int64: mongo-driver encodes Go unsigned integers
 	// as int64 so the full unsigned range survives.
-	assert.Equal(t, bson.M{"pid": int64(4242), "startTimeNs": int64(314159)}, event["processRef"],
+	assert.Equal(t, bson.M{"pid": int64(4242), "startTimeNs": int64(3141590000000)}, event["processRef"],
 		"bson emits the event-level ref as a subdocument, NOT the text form")
 
 	var out NetworkStream

--- a/docs/features/network-stream-process-attribution.md
+++ b/docs/features/network-stream-process-attribution.md
@@ -117,6 +117,24 @@ shared between containers and buy nothing.
 A **zero** value means the sensor could not read the start time; such a ref
 carries pid-only identity and must not be compared across messages.
 
+The start time is in the identity **purely to survive pid reuse**, which is the
+mitigation the GA design itself names
+(`projects/epics/network-reputation-ga/network-reputation-consolidation-design.md`
+§13: "join reliability across process restarts / pid reuse (mitigated by
+`startTime` in the key)"). Nothing renders this value. Anything needing a
+human-facing process start time reads `Process.StartTime` off the resolved tree,
+which is a wall-clock `time.Time`.
+
+> **Open question — units.** node-agent's process tree already carries
+> `StartTimeNs uint64` ("Process start time in nanoseconds for unique
+> identification", `pkg/processtree/conversion/types.go:30`), fed from eBPF event
+> timestamps and a procfs scan. Ticks therefore require the sensor to divide
+> ns by 10⁷, discarding precision it already holds, and leave two different units
+> for one concept. Nanoseconds would match the producer exactly at a cost of ~6
+> bytes per connection (≈2.3 KB base64 on a 283-connection message). Ticks were
+> specified for this change; switching to ns is a one-line change now and a
+> breaking one after the sensor ships.
+
 The field name carries the unit because `armotypes.Process.StartTime` — the same
 concept on the tree this ref points at — is a wall-clock `time.Time`. The unit is
 free on the wire: `ProcessRef` is text-marshalled, so its field names never

--- a/docs/features/network-stream-process-attribution.md
+++ b/docs/features/network-stream-process-attribution.md
@@ -1,0 +1,164 @@
+---
+type: reality
+status: active
+owner: alonliwsky
+scope: repo
+related_code:
+  - armotypes/networkstream.go
+  - armotypes/networkstream_test.go
+---
+
+# Network Stream Process Attribution — shared model
+
+Lets the backend answer "which process opened this connection?" for events on the
+network stream. This library change defines the wire contract only; populating it
+lives in node-agent and consuming it in event-ingester-service /
+postgres-connector.
+
+## The flow this sits on
+
+node-agent builds `armotypes.GenericCRD[armotypes.NetworkStream]` and POSTs it.
+It reaches the backend on Pulsar topic
+`persistent://armo/internal/network-stream-v1`, wrapped in a synchronizer
+envelope whose `patch` field is **base64-encoded JSON**. Two consumers read it:
+
+| Consumer | Path | Sink |
+|---|---|---|
+| visibility | `event-ingester-service/ingesters/network_stream_ingester/` | Postgres |
+| network reputation | `event-ingester-service/ingesters/network_reputation_ingester/` | `RuntimeAlert` (field-by-field copy) |
+| upsert | `postgres-connector/services/networktraffic/` | Postgres (gorm) |
+
+## What this adds
+
+1. **`ProcessRef`** — `{PID uint32, StartTime uint64}`, text-marshalled to the
+   single string `"<pid>/<startTime>"`.
+2. **`NetworkStream.Processes map[ProcessRef]*ProcessTree`** — message-scoped,
+   one tree per process.
+3. **`NetworkStreamEvent.Process *ProcessRef`** — per-connection pointer into
+   that map.
+4. **`NetworkStream.ProcessAttributionVersion int`** + const
+   `NetworkStreamProcessAttributionV1 = 1`.
+
+The consumer join is `stream.Processes[*event.Process]`. The same `ProcessRef`
+type is both the map key and the per-connection value, so the two sides cannot
+disagree on key format.
+
+## Why the tree is shipped once per process
+
+Process trees dominate the payload cost, not the number of map entries. They are
+chain-shaped and measure ~2.0 KB serialised at the median, ~5.1 KB at p90, of
+which `cmdline` alone is ~40% and is **unbounded**. Because the synchronizer
+`patch` field is base64, every byte added costs **×1.333** on the wire.
+
+Inlining a tree per connection is the pre-existing
+`NetworkStreamEvent.ProcessTree` shape, and it is exactly why the sensor nils
+that field out on every event before sending. Deduplicating per process is what
+makes attribution affordable: a worst-case observed message (109 container
+entities, 283 connections, 142 KB on the wire) lands near 970 KB with full
+attribution, against a 5 MiB broker limit — roughly 5.7× headroom in connection
+count.
+
+`NetworkStreamEvent.ProcessTree` is **retained unchanged**. An in-process
+notification channel in node-agent feeds a separate host-network sensor from the
+pre-nil struct, so removing or repurposing it would break that consumer.
+
+## Why the map is scoped per message, not per container
+
+`ProcessRef.PID` is a **host-namespace** pid. The sensor's eBPF network gadget
+populates it from the socket enricher's `pid_tgid >> 32`
+(`bpf_get_current_pid_tgid()` / `task->tgid`); there is no pid-namespace
+translation on that path and no container-namespace pid is exposed at all. Host
+pids are node-unique and a stream message covers exactly one node, so keys are
+already unique message-wide. Per-container scoping would duplicate every tree
+shared between containers and buy nothing.
+
+## Why StartTime is ticks, not a `time.Time`
+
+`StartTime` is CLOCK_BOOTTIME in clock ticks since boot (USER_HZ = 100, 10 ms
+per tick).
+
+- The only start-time source with full process coverage is `/proc/<pid>/stat`
+  field 22, which is denominated in clock ticks.
+- Converting to wall-clock needs `/proc/stat` `btime`, which has **whole-second
+  resolution only**. A `time.Time` on the wire would therefore be lossy by up to
+  a second — for a value whose entire job is to disambiguate identity, that is
+  the wrong trade.
+- Ticks are exact and need no boot-time lookup. 10 ms granularity is safe for
+  pid-reuse disambiguation by 2–5 orders of magnitude.
+
+`StartTime` is 64-bit because ticks outgrow `uint32` after ~497 days of uptime at
+USER_HZ = 100.
+
+## Why additive fields and not a kind bump
+
+Both consumers decode with plain `json.Unmarshal`, and `DisallowUnknownFields`
+appears nowhere in either. They reject a message only on a wrong `kind` string
+or malformed JSON. So `omitempty` additive fields are invisible to un-upgraded
+consumers, and bumping the kind string to a v2 would have forced a coordinated
+consumer rollout for no benefit.
+
+## Why an explicit version marker
+
+`ProcessAttributionVersion` absent/zero means *"this sensor predates process
+attribution"* — **not** *"attribution ran and produced nothing"*. An upgraded
+sensor can legitimately emit an empty `Processes` map when every connection in an
+interval was unattributable, so `len(Processes) == 0` is not a usable proxy for
+sensor capability.
+
+This marker is new to the repo. Versioning here is otherwise done by CRD kind
+string (`kubescape.io/v1/networkstreams`) plus topic name, and the established
+pattern for additive changes is `omitempty` plus a documented consumer tolerance
+(see `HostCVEOnFinishedMessage` in `armotypes/hot_cve.go`). That pattern alone is
+insufficient here precisely because absence-of-data and absence-of-feature are
+different states. The repo also auto-tags `v0.0.<github.run_number>` on push to
+`main`, so the module version carries no semver signal a consumer could branch
+on.
+
+## Field shape and naming trade-offs
+
+- **One text-marshalled field beats two flat scalars.** `,"process":"12345/91827364"`
+  is 27 bytes against 33 for `,"pid":12345,"startTime":91827364` — one JSON key
+  instead of two, ~6 bytes × 283 connections ≈ 2.3 KB base64 saved per
+  worst-case message — *and* it is type-safe and identical to the map key.
+- **`Process` is a pointer** so `omitempty` drops it. `encoding/json` does not
+  omit zero structs; an always-present `"process":"0/0"` on every unattributed
+  connection is the per-connection waste this design exists to avoid.
+- **The JSON key is `process`, not `proc`.** Abbreviating saves ~1.1 KB base64
+  per worst-case message (0.1%) at the cost of being the only abbreviated key in
+  a file whose tags are all spelled-out camelCase (`ipAddress`, `podNamespace`,
+  `workloadKind`).
+- **The separator is `/`, not `CommPID`'s U+241F (`␟`).** `CommPID` needs an
+  exotic separator because `Comm` is free-form and may contain `/` or `:`. Both
+  `ProcessRef` components are decimal integers, so no escaping hazard exists;
+  `/` matches the composite `"<ip>/<port>/<protocol>"` keys already used by
+  `Inbound`/`Outbound` in the same file, and costs 1 byte rather than 3.
+
+## bson tags
+
+The new fields carry `bson` tags even though `armotypes/networkstream.go` is the
+only file in `armotypes` with none, because:
+
+- `AGENTS.md` is explicit: "Both must be maintained together."
+- Empirically **no BSON path exists today**. `postgres-connector` writes via
+  gorm; `network_stream_ingester` has no bson/mongo reference; the reputation
+  path copies fields into `RuntimeAlert` rather than embedding a `NetworkStream*`
+  type; `cadashboardbe` does not reference these types at all.
+- Tags cost nothing at runtime and pre-empt a real trap: mongo-driver's default
+  encoder would name the field `processattributionversion`, diverging from the
+  JSON key.
+- The identical shape already has bson tags in this repo —
+  `Process.ChildrenMap map[CommPID]*Process` carries `bson:"childrenMap,omitempty"`.
+  Verified that mongo-driver honours `encoding.TextMarshaler`/`TextUnmarshaler`
+  for struct map keys, so `Processes` round-trips through bson with the same
+  composite key as JSON (`TestProcessRefBSONRoundTrip`).
+
+The remaining structs in this file still lack bson tags; that is pre-existing and
+tracked separately.
+
+## Known defect, not fixed here
+
+`NetworkStreamEvent.String()` is broken: `string(e.Port)` converts an `int32` to
+a rune rather than a decimal string (port 8080 becomes one garbage character),
+and `string(e.IPAddress)` is a no-op on a `string`. No callers were found, but
+the search was not exhaustive. Tracked as a separate change to keep this schema
+addition reviewable.

--- a/docs/features/network-stream-process-attribution.md
+++ b/docs/features/network-stream-process-attribution.md
@@ -126,8 +126,9 @@ says nothing about which. Between them:
   means no source ever has to discard anything.
 - **One unit for one concept.** Two units either side of a serialisation boundary
   is a bug factory.
-- **The cost is noise** — ~6 bytes per connection, ≈2.3 KB base64 at the largest
-  observed message, against a 5 MiB limit.
+- **The cost is noise** — exactly 7 bytes per connection, ≈2.6 KB base64 at the
+  largest observed message, against a 5 MiB limit. Exactly 7 because ns is
+  ticks × 10⁷, which appends precisely 7 decimal digits at every magnitude.
 
 > ⚠️ **Nanoseconds are the unit, not the resolution.** Do not read this as a
 > precise timestamp. The only start-time source with full process coverage is
@@ -225,22 +226,28 @@ read it. That is what the permissive parser above is for.
 
 ## Field shape and naming trade-offs
 
-- **One text-marshalled field beats two flat scalars.** `,"processRef":"12345/91827364"`
-  spends one JSON key instead of two — 6 bytes per connection, ≈2.3 KB base64 on
-  a 283-connection message — *and* it is type-safe and identical to the map key.
+- **One text-marshalled field beats two flat scalars.**
+  `,"processRef":"12345/918273640000000"` (37 bytes) against
+  `,"pid":12345,"startTimeNs":918273640000000` (42 bytes) — one JSON key instead
+  of two saves **5 bytes per connection**, ≈1.9 KB base64 on a 283-connection
+  message. The saving is exactly 5 regardless of the pid and start-time values,
+  since it is purely the difference in key overhead; it does move if either field
+  is renamed. And it is type-safe and identical to the map key.
 - **The field is a pointer** so `omitempty` drops it. `encoding/json` does not
   omit zero structs; an always-present `"processRef":"0/0"` on every unattributed
   connection is the per-connection waste this design exists to avoid.
 - **The field is named `ProcessRef`, not `Process`.** `armotypes.Process` is a
   different, heavily-used type in the same package, and its `StartTime` is a
-  wall-clock `time.Time` where `ProcessRef.StartTimeNs` is boot ticks —
-  `event.Process` would read as `*armotypes.Process` to anyone who had not read
-  this file. Naming the field after its type also matches the adjacent
-  `ProcessTree *ProcessTree`. Costs ~1.1 KB base64 on a worst-case message
-  (~0.1%), the cheap side of the trade.
-- **Keys are spelled out, not abbreviated.** `proc` would save ~1.1 KB base64
-  (0.1%) at the cost of being the only abbreviated key in a file whose tags are
-  all spelled-out camelCase (`ipAddress`, `podNamespace`, `workloadKind`).
+  wall-clock `time.Time` where `ProcessRef.StartTimeNs` is boot-relative
+  nanoseconds — `event.Process` would read as `*armotypes.Process` to anyone who
+  had not read this file. Naming the field after its type also matches the
+  adjacent `ProcessTree *ProcessTree`. Costs 3 bytes per connection over
+  `process`, ≈1.1 KB base64 on a 283-connection message: the cheap side of the
+  trade.
+- **Keys are spelled out, not abbreviated.** `proc` would save 6 bytes per
+  connection over `processRef`, ≈2.3 KB base64, at the cost of being the only
+  abbreviated key in a file whose tags are all spelled-out camelCase
+  (`ipAddress`, `podNamespace`, `workloadKind`).
 - **The separator is `/`, not `CommPID`'s U+241F (`␟`).** `CommPID` needs an
   exotic separator because `Comm` is free-form and may contain `/` or `:`. Every
   `ProcessRef` component is a decimal integer, so no escaping hazard exists; `/`
@@ -264,8 +271,8 @@ values. So `Processes` is keyed by the same composite string in both, but the
 event-level ref is a string in JSON and a **subdocument** in BSON:
 
 ```
-JSON: "processRef":"4242/314159"
-BSON: "processRef":{"pid":NumberLong(4242),"startTimeNs":NumberLong(314159)}
+JSON: "processRef":"4242/3141590000000"
+BSON: "processRef":{"pid":NumberLong(4242),"startTimeNs":NumberLong(3141590000000)}
 ```
 
 Both round-trip (`TestProcessRefBSONRoundTrip`), but a Mongo query needs

--- a/docs/features/network-stream-process-attribution.md
+++ b/docs/features/network-stream-process-attribution.md
@@ -30,8 +30,8 @@ envelope whose `patch` field is **base64-encoded JSON**. Consumers:
 
 ## What this adds
 
-1. **`ProcessRef`** — `{PID uint32, StartTimeTicks uint64}`, text-marshalled to
-   the single string `"<pid>/<startTimeTicks>"`, plus `String()`.
+1. **`ProcessRef`** — `{PID uint32, StartTimeNs uint64}`, text-marshalled to
+   the single string `"<pid>/<startTimeNs>"`, plus `String()`.
 2. **`NetworkStream.Processes map[ProcessRef]*ProcessTree`** — message-scoped,
    one tree per process.
 3. **`NetworkStreamEvent.ProcessRef *ProcessRef`** — per-connection pointer into
@@ -99,23 +99,10 @@ pids are node-unique and a stream message covers exactly one node, so keys are
 already unique message-wide. Per-container scoping would duplicate every tree
 shared between containers and buy nothing.
 
-## Why StartTimeTicks is ticks, not a `time.Time`
+## Why StartTimeNs is boot-relative nanoseconds, not a `time.Time`
 
-`StartTimeTicks` is CLOCK_BOOTTIME in clock ticks since boot (USER_HZ = 100,
-10 ms per tick).
-
-- The only start-time source with full process coverage is `/proc/<pid>/stat`
-  field 22, which is denominated in clock ticks.
-- Converting to wall-clock needs `/proc/stat` `btime`, which has **whole-second
-  resolution only**. A `time.Time` on the wire would therefore be lossy by up to
-  a second — for a value whose entire job is to disambiguate identity, that is
-  the wrong trade.
-- Ticks are exact and need no boot-time lookup. 10 ms granularity is safe for
-  pid-reuse disambiguation by 2–5 orders of magnitude.
-
-64-bit because ticks outgrow `uint32` after ~497 days of uptime at USER_HZ = 100.
-A **zero** value means the sensor could not read the start time; such a ref
-carries pid-only identity and must not be compared across messages.
+`StartTimeNs` is the process's **creation** time as nanoseconds since boot
+(CLOCK_BOOTTIME).
 
 The start time is in the identity **purely to survive pid reuse**, which is the
 mitigation the GA design itself names
@@ -125,20 +112,62 @@ mitigation the GA design itself names
 human-facing process start time reads `Process.StartTime` off the resolved tree,
 which is a wall-clock `time.Time`.
 
-> **Open question — units.** node-agent's process tree already carries
-> `StartTimeNs uint64` ("Process start time in nanoseconds for unique
-> identification", `pkg/processtree/conversion/types.go:30`), fed from eBPF event
-> timestamps and a procfs scan. Ticks therefore require the sensor to divide
-> ns by 10⁷, discarding precision it already holds, and leave two different units
-> for one concept. Nanoseconds would match the producer exactly at a cost of ~6
-> bytes per connection (≈2.3 KB base64 on a 283-connection message). Ticks were
-> specified for this change; switching to ns is a one-line change now and a
-> breaking one after the sensor ships.
+**Boot-relative, not wall-clock**, because converting to wall-clock needs
+`/proc/stat btime`, which has whole-second resolution only. A `time.Time` on the
+wire would be lossy by up to a second — wrong for a value whose entire job is
+disambiguation. A boot-relative integer needs no boot-time lookup and is exact.
+
+**Nanoseconds rather than clock ticks**, because that objection rules out a
+*timestamp*, not a unit: both ticks and boot-ns are boot-relative integers, so it
+says nothing about which. Between them:
+
+- **Conversion only loses information in the ticks direction.** procfs ticks → ns
+  is an exact ×10⁷; a boot-ns source → ticks is a lossy division. Choosing ns
+  means no source ever has to discard anything.
+- **One unit for one concept.** Two units either side of a serialisation boundary
+  is a bug factory.
+- **The cost is noise** — ~6 bytes per connection, ≈2.3 KB base64 at the largest
+  observed message, against a 5 MiB limit.
+
+> ⚠️ **Nanoseconds are the unit, not the resolution.** Do not read this as a
+> precise timestamp. The only start-time source with full process coverage is
+> `/proc/<pid>/stat` field 22, denominated in clock ticks (USER_HZ = 100, 10 ms),
+> so procfs-derived values are exact multiples of 10,000,000 ns and carry far less
+> precision than the unit implies. This does not affect correctness — 10 ms is
+> safe for pid-reuse disambiguation by several orders of magnitude — but someone
+> will eventually try to use it as a precise timestamp.
+
+⚠️ **Never derive this from an exec event.** `exec` does not create a process, so
+an exec-derived value changes when a process re-execs and the identity silently
+breaks mid-life.
+
+64-bit is required: boot-ns exceeds `uint32` after ~4.3 seconds of uptime, and
+reaches the `uint64` ceiling after ~584 years. A **zero** value means the sensor
+could not read the start time; such a ref carries pid-only identity and must not
+be compared across messages.
 
 The field name carries the unit because `armotypes.Process.StartTime` — the same
 concept on the tree this ref points at — is a wall-clock `time.Time`. The unit is
 free on the wire: `ProcessRef` is text-marshalled, so its field names never
 appear in JSON at all.
+
+### Producer note: node-agent has the field name, not yet a working value
+
+node-agent already declares `StartTimeNs uint64` — *"Process start time in
+nanoseconds for unique identification"* (`pkg/processtree/conversion/types.go:30`)
+— so this schema aligns with an existing name and unit. It does **not** align with
+a working value, and the sensor-side change cannot simply forward it:
+
+- The exec/fork/exit feeders set it from the **event timestamp**
+  (`pkg/processtree/conversion/convert.go`, *"Use event timestamp for
+  consistency"*). For an exec event that is the exec instant, not process
+  creation — semantically wrong for identity, per the warning above.
+- The procfs feeder passes through `procfsEvent.StartTimeNs`, which nothing
+  upstream ever assigns, so it is **always zero for procfs-sourced processes** —
+  the one source with full coverage. Verified: no `/proc/<pid>/stat` field-22
+  parse exists anywhere in node-agent.
+
+Populating it correctly is separately tracked sensor-side work.
 
 ## The parser is deliberately permissive
 
@@ -204,7 +233,7 @@ read it. That is what the permissive parser above is for.
   connection is the per-connection waste this design exists to avoid.
 - **The field is named `ProcessRef`, not `Process`.** `armotypes.Process` is a
   different, heavily-used type in the same package, and its `StartTime` is a
-  wall-clock `time.Time` where `ProcessRef.StartTimeTicks` is boot ticks —
+  wall-clock `time.Time` where `ProcessRef.StartTimeNs` is boot ticks —
   `event.Process` would read as `*armotypes.Process` to anyone who had not read
   this file. Naming the field after its type also matches the adjacent
   `ProcessTree *ProcessTree`. Costs ~1.1 KB base64 on a worst-case message
@@ -236,7 +265,7 @@ event-level ref is a string in JSON and a **subdocument** in BSON:
 
 ```
 JSON: "processRef":"4242/314159"
-BSON: "processRef":{"pid":NumberLong(4242),"startTimeTicks":NumberLong(314159)}
+BSON: "processRef":{"pid":NumberLong(4242),"startTimeNs":NumberLong(314159)}
 ```
 
 Both round-trip (`TestProcessRefBSONRoundTrip`), but a Mongo query needs

--- a/docs/features/network-stream-process-attribution.md
+++ b/docs/features/network-stream-process-attribution.md
@@ -20,47 +20,74 @@ postgres-connector.
 node-agent builds `armotypes.GenericCRD[armotypes.NetworkStream]` and POSTs it.
 It reaches the backend on Pulsar topic
 `persistent://armo/internal/network-stream-v1`, wrapped in a synchronizer
-envelope whose `patch` field is **base64-encoded JSON**. Two consumers read it:
+envelope whose `patch` field is **base64-encoded JSON**. Consumers:
 
-| Consumer | Path | Sink |
-|---|---|---|
-| visibility | `event-ingester-service/ingesters/network_stream_ingester/` | Postgres |
-| network reputation | `event-ingester-service/ingesters/network_reputation_ingester/` | `RuntimeAlert` (field-by-field copy) |
-| upsert | `postgres-connector/services/networktraffic/` | Postgres (gorm) |
+| Consumer | Path | Sink | On decode error |
+|---|---|---|---|
+| visibility | `event-ingester-service/ingesters/network_stream_ingester/` | Postgres | **nack** → retry → DLQ |
+| network reputation | `event-ingester-service/ingesters/network_reputation_ingester/` | `RuntimeAlert` (field-by-field copy) | log + ack (dropped) |
+| upsert | `postgres-connector/services/networktraffic/` | Postgres (gorm) | — |
 
 ## What this adds
 
-1. **`ProcessRef`** — `{PID uint32, StartTime uint64}`, text-marshalled to the
-   single string `"<pid>/<startTime>"`.
+1. **`ProcessRef`** — `{PID uint32, StartTimeTicks uint64}`, text-marshalled to
+   the single string `"<pid>/<startTimeTicks>"`, plus `String()`.
 2. **`NetworkStream.Processes map[ProcessRef]*ProcessTree`** — message-scoped,
    one tree per process.
-3. **`NetworkStreamEvent.Process *ProcessRef`** — per-connection pointer into
+3. **`NetworkStreamEvent.ProcessRef *ProcessRef`** — per-connection pointer into
    that map.
-4. **`NetworkStream.ProcessAttributionVersion int`** + const
+4. **`NetworkStream.ProcessTreeFor(event)`** — the supported way to resolve a
+   connection's tree.
+5. **`NetworkStream.ProcessAttributionVersion int`** + const
    `NetworkStreamProcessAttributionV1 = 1`.
 
-The consumer join is `stream.Processes[*event.Process]`. The same `ProcessRef`
-type is both the map key and the per-connection value, so the two sides cannot
-disagree on key format.
+The same `ProcessRef` type is both the map key and the per-connection value, so
+the two sides cannot disagree on key format.
+
+## Resolve with `ProcessTreeFor`, never a bare map index
+
+`stream.Processes[*event.ProcessRef]` has three sharp edges:
+
+- it **panics** when `event.ProcessRef` is nil — every event from a pre-attribution
+  sensor, and any connection the sensor could not attribute;
+- it cannot distinguish a missing entry from a present-but-nil one;
+- `{"processes":{"1/2":null}}` decodes to exactly that present-but-nil case, so
+  the index returns `ok == true` with a nil tree and the next field access
+  panics.
+
+`ProcessTreeFor` collapses unattributed, dangling and nil-valued into a single
+nil return. It does **not** fall back to the per-event `ProcessTree` field — the
+two have different lifecycles.
 
 ## Why the tree is shipped once per process
 
 Process trees dominate the payload cost, not the number of map entries. They are
-chain-shaped and measure ~2.0 KB serialised at the median, ~5.1 KB at p90, of
-which `cmdline` alone is ~40% and is **unbounded**. Because the synchronizer
-`patch` field is base64, every byte added costs **×1.333** on the wire.
+chain-shaped, and measurement during design put them at ~2.0 KB serialised at the
+median and ~5.1 KB at p90, of which `cmdline` alone is ~40% and is **unbounded**.
+Because the synchronizer `patch` field is base64, every byte added costs
+**×1.333** on the wire.
 
 Inlining a tree per connection is the pre-existing
 `NetworkStreamEvent.ProcessTree` shape, and it is exactly why the sensor nils
 that field out on every event before sending. Deduplicating per process is what
-makes attribution affordable: a worst-case observed message (109 container
-entities, 283 connections, 142 KB on the wire) lands near 970 KB with full
-attribution, against a 5 MiB broker limit — roughly 5.7× headroom in connection
-count.
+makes attribution affordable at all.
 
-`NetworkStreamEvent.ProcessTree` is **retained unchanged**. An in-process
-notification channel in node-agent feeds a separate host-network sensor from the
-pre-nil struct, so removing or repurposing it would break that consumer.
+**Headroom is comfortable but set by the tail, not the median.** Against the
+5 MiB broker limit, the largest message observed during design (109 container
+entities, 283 connections, 142 KB on the wire) comes to roughly 900 KB at the
+median tree size, but roughly 2 MB at p90. Since `cmdline` is unbounded, the
+right lever if this ever approaches the limit is a sensor-side cap on tree or
+cmdline size — not dropping attribution. The tree-size distribution and the
+observed message shape come from measurement during design and are not
+reproducible from this repo.
+
+`NetworkStreamEvent.ProcessTree` is **retained unchanged**. `private-node-agent`
+wires a non-nil notification channel in all three of its mains
+(`cmd/main.go`, `cmd/host/main.go`, `cmd/ecs/main.go`) and its host network
+sensor reads `outbound.ProcessTree` directly off those events
+(`pkg/hostnetworksensor/v1/hostnetworksensor.go`), exporting `.PID`, `.Comm`,
+`.Uid` and friends. The OSS `node-agent/cmd/main.go` passes `nil` for that
+channel, so searching only the OSS repo makes the field look dead. It is not.
 
 ## Why the map is scoped per message, not per container
 
@@ -72,10 +99,10 @@ pids are node-unique and a stream message covers exactly one node, so keys are
 already unique message-wide. Per-container scoping would duplicate every tree
 shared between containers and buy nothing.
 
-## Why StartTime is ticks, not a `time.Time`
+## Why StartTimeTicks is ticks, not a `time.Time`
 
-`StartTime` is CLOCK_BOOTTIME in clock ticks since boot (USER_HZ = 100, 10 ms
-per tick).
+`StartTimeTicks` is CLOCK_BOOTTIME in clock ticks since boot (USER_HZ = 100,
+10 ms per tick).
 
 - The only start-time source with full process coverage is `/proc/<pid>/stat`
   field 22, which is denominated in clock ticks.
@@ -86,16 +113,48 @@ per tick).
 - Ticks are exact and need no boot-time lookup. 10 ms granularity is safe for
   pid-reuse disambiguation by 2–5 orders of magnitude.
 
-`StartTime` is 64-bit because ticks outgrow `uint32` after ~497 days of uptime at
-USER_HZ = 100.
+64-bit because ticks outgrow `uint32` after ~497 days of uptime at USER_HZ = 100.
+A **zero** value means the sensor could not read the start time; such a ref
+carries pid-only identity and must not be compared across messages.
+
+The field name carries the unit because `armotypes.Process.StartTime` — the same
+concept on the tree this ref points at — is a wall-clock `time.Time`. The unit is
+free on the wire: `ProcessRef` is text-marshalled, so its field names never
+appear in JSON at all.
+
+## The parser is deliberately permissive
+
+`UnmarshalText` **ignores components beyond the first two** and accepts leading
+zeros. This is load-bearing, not sloppiness.
+
+`encoding/json` aborts the **entire enclosing decode** when a `TextUnmarshaler`
+map key fails — `decode.go` does `return err` for that case, where an int-keyed
+map does `saveError; break` and carries on. Measured: one bad key in
+`{"processes":{"BAD":…,"1/2":…}}` discards **both** entries and returns an error.
+The visibility consumer nacks on that error, so every connection row for that
+node's whole interval is lost.
+
+So a future revision that appends a component to the key format must not be able
+to make un-upgraded consumers reject whole messages. Appending is the designed
+extension point; **do not make the parser stricter.** The trade-off accepted in
+exchange: non-canonical keys for one process collapse to a single entry, last
+wins (`TestProcessRefUnmarshalTextAcceptsNonCanonical`).
+
+`UnmarshalText` leaves the receiver untouched on error, but that only reaches
+direct callers — `encoding/json` allocates the pointer target before calling it
+and leaves it installed on failure, so a caller that ignores an `Unmarshal` error
+sees a non-nil, zero-valued ref (`TestNetworkStreamEventMalformedRefInstallsZeroPointer`).
+Both consumers do check the error.
 
 ## Why additive fields and not a kind bump
 
-Both consumers decode with plain `json.Unmarshal`, and `DisallowUnknownFields`
-appears nowhere in either. They reject a message only on a wrong `kind` string
-or malformed JSON. So `omitempty` additive fields are invisible to un-upgraded
-consumers, and bumping the kind string to a v2 would have forced a coordinated
-consumer rollout for no benefit.
+Both consumers decode with plain `json.Unmarshal`. There is exactly one
+`DisallowUnknownFields()` in all four consumer repos, in an unrelated
+cadashboardbe webhook handler; the only non-stdlib JSON in use is `ujson`,
+confined to SBOM parsing. Consumers reject a message only on a wrong `kind`
+string or malformed JSON. So `omitempty` additive fields are invisible to
+un-upgraded consumers, and bumping the kind string to a v2 would have forced a
+coordinated consumer rollout for no benefit.
 
 ## Why an explicit version marker
 
@@ -114,23 +173,31 @@ different states. The repo also auto-tags `v0.0.<github.run_number>` on push to
 `main`, so the module version carries no semver signal a consumer could branch
 on.
 
+Note the marker cannot rescue a key-format break: decode dies before anything can
+read it. That is what the permissive parser above is for.
+
 ## Field shape and naming trade-offs
 
-- **One text-marshalled field beats two flat scalars.** `,"process":"12345/91827364"`
-  is 27 bytes against 33 for `,"pid":12345,"startTime":91827364` — one JSON key
-  instead of two, ~6 bytes × 283 connections ≈ 2.3 KB base64 saved per
-  worst-case message — *and* it is type-safe and identical to the map key.
-- **`Process` is a pointer** so `omitempty` drops it. `encoding/json` does not
-  omit zero structs; an always-present `"process":"0/0"` on every unattributed
+- **One text-marshalled field beats two flat scalars.** `,"processRef":"12345/91827364"`
+  spends one JSON key instead of two — 6 bytes per connection, ≈2.3 KB base64 on
+  a 283-connection message — *and* it is type-safe and identical to the map key.
+- **The field is a pointer** so `omitempty` drops it. `encoding/json` does not
+  omit zero structs; an always-present `"processRef":"0/0"` on every unattributed
   connection is the per-connection waste this design exists to avoid.
-- **The JSON key is `process`, not `proc`.** Abbreviating saves ~1.1 KB base64
-  per worst-case message (0.1%) at the cost of being the only abbreviated key in
-  a file whose tags are all spelled-out camelCase (`ipAddress`, `podNamespace`,
-  `workloadKind`).
+- **The field is named `ProcessRef`, not `Process`.** `armotypes.Process` is a
+  different, heavily-used type in the same package, and its `StartTime` is a
+  wall-clock `time.Time` where `ProcessRef.StartTimeTicks` is boot ticks —
+  `event.Process` would read as `*armotypes.Process` to anyone who had not read
+  this file. Naming the field after its type also matches the adjacent
+  `ProcessTree *ProcessTree`. Costs ~1.1 KB base64 on a worst-case message
+  (~0.1%), the cheap side of the trade.
+- **Keys are spelled out, not abbreviated.** `proc` would save ~1.1 KB base64
+  (0.1%) at the cost of being the only abbreviated key in a file whose tags are
+  all spelled-out camelCase (`ipAddress`, `podNamespace`, `workloadKind`).
 - **The separator is `/`, not `CommPID`'s U+241F (`␟`).** `CommPID` needs an
-  exotic separator because `Comm` is free-form and may contain `/` or `:`. Both
-  `ProcessRef` components are decimal integers, so no escaping hazard exists;
-  `/` matches the composite `"<ip>/<port>/<protocol>"` keys already used by
+  exotic separator because `Comm` is free-form and may contain `/` or `:`. Every
+  `ProcessRef` component is a decimal integer, so no escaping hazard exists; `/`
+  matches the composite `"<ip>/<port>/<protocol>"` keys already used by
   `Inbound`/`Outbound` in the same file, and costs 1 byte rather than 3.
 
 ## bson tags
@@ -139,26 +206,40 @@ The new fields carry `bson` tags even though `armotypes/networkstream.go` is the
 only file in `armotypes` with none, because:
 
 - `AGENTS.md` is explicit: "Both must be maintained together."
-- Empirically **no BSON path exists today**. `postgres-connector` writes via
-  gorm; `network_stream_ingester` has no bson/mongo reference; the reputation
-  path copies fields into `RuntimeAlert` rather than embedding a `NetworkStream*`
-  type; `cadashboardbe` does not reference these types at all.
-- Tags cost nothing at runtime and pre-empt a real trap: mongo-driver's default
-  encoder would name the field `processattributionversion`, diverging from the
-  JSON key.
-- The identical shape already has bson tags in this repo —
+- The identical shape already has them —
   `Process.ChildrenMap map[CommPID]*Process` carries `bson:"childrenMap,omitempty"`.
-  Verified that mongo-driver honours `encoding.TextMarshaler`/`TextUnmarshaler`
-  for struct map keys, so `Processes` round-trips through bson with the same
-  composite key as JSON (`TestProcessRefBSONRoundTrip`).
+- Tags cost nothing at runtime and pre-empt a real trap: mongo-driver's default
+  encoder would name the field `processattributionversion`, diverging from JSON.
 
-The remaining structs in this file still lack bson tags; that is pre-existing and
-tracked separately.
+**JSON and BSON do not agree on the per-connection representation.**
+mongo-driver honours `encoding.TextMarshaler` for map **keys only**, not for
+values. So `Processes` is keyed by the same composite string in both, but the
+event-level ref is a string in JSON and a **subdocument** in BSON:
+
+```
+JSON: "processRef":"4242/314159"
+BSON: "processRef":{"pid":NumberLong(4242),"startTimeTicks":NumberLong(314159)}
+```
+
+Both round-trip (`TestProcessRefBSONRoundTrip`), but a Mongo query needs
+`processRef.pid` where JSONB needs the string. Consequence for the struct tags:
+`ProcessRef`'s inner **`json`** tags are dead weight (MarshalText always wins);
+its inner **`bson`** tags are live and are what name that subdocument.
+
+Empirically **no BSON path exists today**: `postgres-connector` writes via gorm;
+`network_stream_ingester` has no bson/mongo reference; the reputation path copies
+fields into `RuntimeAlert` rather than embedding a `NetworkStream*` type;
+`cadashboardbe` does not reference these types at all. The tags are therefore
+speculative, and because the rest of the file is untagged, a hypothetical BSON
+document would be mixed-case (`processRef` beside default-lowercased `ipaddress`,
+`dnsname`, `processtree`, and embedded structs emitted nested rather than
+inlined). Tagging the whole file is pre-existing work tracked separately.
 
 ## Known defect, not fixed here
 
 `NetworkStreamEvent.String()` is broken: `string(e.Port)` converts an `int32` to
 a rune rather than a decimal string (port 8080 becomes one garbage character),
-and `string(e.IPAddress)` is a no-op on a `string`. No callers were found, but
-the search was not exhaustive. Tracked as a separate change to keep this schema
-addition reviewable.
+and `string(e.IPAddress)` is a no-op on a `string`. `go vet` cannot catch it
+because `rune` *is* `int32`, making the conversion indistinguishable from a
+legitimate one. No callers were found, but the search was not exhaustive. Tracked
+as a separate change to keep this schema addition reviewable.


### PR DESCRIPTION
<!-- armosec-pr: v=1 via=manual -->

## Summary

Adds process attribution to the network stream wire contract, so the backend can answer "which process opened this connection?".

The stream already has a per-event `ProcessTree` field, but the sensor nils it out before sending because inlining a whole tree per connection is too large. This ships each tree **once per process** in a message-scoped map and has each connection carry a small reference into it.

Schema only. Populating it is node-agent's job; reading it is event-ingester-service / postgres-connector's. Implements the "Compact process reference" fast-follow from [`network-reputation-consolidation-design.md`](https://github.com/armosec/shared-designs-and-docs/blob/main/projects/epics/network-reputation-ga/network-reputation-consolidation-design.md) §5.

```go
type ProcessRef struct {
	PID            uint32 `json:"pid,omitempty" bson:"pid,omitempty"`
	StartTimeNs    uint64 `json:"startTimeNs,omitempty" bson:"startTimeNs,omitempty"`
}
// text-marshals to a single string: "12345/918273640000000"

type NetworkStream struct {
	Entities                  map[string]NetworkStreamEntity `json:"entities,omitempty"`
	ProcessAttributionVersion int                            `json:"processAttributionVersion,omitempty"` // NEW
	Processes                 map[ProcessRef]*ProcessTree    `json:"processes,omitempty"`                 // NEW
}

// on NetworkStreamEvent, alongside the untouched ProcessTree:
	ProcessRef *ProcessRef `json:"processRef,omitempty"` // NEW

func (n *NetworkStream) ProcessTreeFor(event *NetworkStreamEvent) *ProcessTree // the supported join
```

A connection gains 37 bytes on the wire (`,"processRef":"12345/918273640000000"`); each distinct process costs one tree instead of one-per-connection.

### Design notes

**Why the tree ships once per process.** Trees dominate payload cost, not map entries — ~2.0 KB median, ~5.1 KB p90, `cmdline` ~40% of that and unbounded. The synchronizer `patch` field is base64, so every byte costs ×1.333. Inlining per connection is exactly why the sensor strips trees today.

**Why `(pid, startTime)`, and why boot-relative nanoseconds.** The start time is in the identity purely to survive pid reuse — the mitigation named in §13 of the design doc. Nothing renders it; human-facing start times come from `Process.StartTime` on the resolved tree, which stays a wall-clock `time.Time`. Not a `time.Time` here because converting to wall-clock needs `/proc/stat btime`, which is whole-second resolution — lossy for a value whose whole job is disambiguation. Nanoseconds rather than clock ticks because that objection rules out a *timestamp*, not a unit: both are boot-relative integers. Between them, conversion only loses information in the ticks direction (procfs ticks → ns is an exact ×10⁷; boot-ns → ticks is a lossy division), and one unit for one concept beats two either side of a serialisation boundary. Cost is exactly 7 bytes/connection, ≈2.6 KB base64 at the largest observed message, against a 5 MiB limit — exactly 7 because ns is ticks × 10⁷, which appends precisely 7 decimal digits at every magnitude. (An earlier revision of this body said ~6 bytes / ≈2.3 KB; that was the adjacent one-field-vs-two-scalars figure carried over by mistake.)

> ⚠️ **Nanoseconds are the unit, not the resolution.** `/proc/<pid>/stat` field 22 is in clock ticks, so procfs-derived values are exact multiples of 10⁷ ns. Harmless for identity (10 ms is safe for pid-reuse by orders of magnitude), but do not use this as a precise timestamp. And never derive it from an **exec** event — exec does not create a process, so an exec-derived value changes on re-exec and breaks identity mid-life.

**Why additive fields, not a kind bump.** Verified rather than assumed: both consumers decode with plain `json.Unmarshal`, and there is exactly one `DisallowUnknownFields()` across all four consumer repos (an unrelated cadashboardbe webhook handler). A kind bump would force a coordinated consumer rollout for no benefit.

**Why an explicit version marker.** An upgraded sensor can legitimately emit an empty `Processes` map, so `len(Processes) == 0` cannot distinguish "sensor predates attribution" from "nothing to attribute". The repo auto-tags `v0.0.<run_number>`, so the module version carries no semver signal to branch on either.

**The parser is deliberately permissive.** `UnmarshalText` ignores components beyond the first two. `encoding/json` does `return err` when a `TextUnmarshaler` map key fails, where an int-keyed map does `saveError; break` and carries on — so one malformed key discards *every* entry in `Processes` and errors, and the visibility ingester nacks → DLQ → a node's whole interval of rows lost. Appending a component is therefore the documented, non-breaking way to extend the key format. **Please don't tighten this parser.**

**`NetworkStreamEvent.ProcessTree` is untouched.** `private-node-agent` wires a non-nil notification channel in all three of its mains and its host network sensor reads `outbound.ProcessTree` directly. The OSS `node-agent` main passes `nil`, so searching only that repo makes the field look dead. It becomes removable when HostNetworkSensor is retired (§5 of the same design), not here.

### Verification

- Full suite green (11/11 packages), 46 new subtests, `-race` clean, `go vet ./...` and `gofmt` clean.
- Compiles against all four pinned consumers — `event-ingester-service`, `cadashboardbe`, `postgres-connector`, `node-agent` (cross-compiled `GOOS=linux`; it does not build on darwin at baseline either). Verified via throwaway clones with a local `replace`, so no consumer repo was modified.
- `network_reputation_ingester`, its `classifier`, and `postgres-connector/services/networktraffic` tests all pass against the new module.

## AI Review

Reviewed by **Claude Opus 5** in a fresh-context subagent using the `armosec-shared-rules:code-review-standards` skill.

**Initial verdict: REQUEST CHANGES.** Addressed in `2665182`:

- **`encoding/json` map-key abort** (the one that mattered) — confirmed against the stdlib and by measurement; fixed by making the key parser forward-tolerant, so a future key-format revision cannot make un-upgraded consumers reject whole messages.
- **Added `ProcessTreeFor`** — a bare `Processes[*event.ProcessRef]` panics on a nil ref *and* on a present-but-nil value, which a `{"processes":{"1/2":null}}` payload produces.
- **Renamed `Process` → `ProcessRef`** (`armotypes.Process` is a different heavily-used type in the same package whose `StartTime` is wall-clock) and **`StartTime` → `StartTimeTicks`** (free: text-marshalling means these names never reach JSON).
- **Added `String()`** — `%s` on the struct previously failed vet, and a logged ref should be greppable against the payload.
- **Corrected two wrong doc comments** — mongo-driver honours `TextMarshaler` for map *keys only*, so BSON emits the event-level ref as a subdocument while JSON emits the text form; and "receiver untouched on error" holds for direct callers but not through `encoding/json`, which leaves the allocated pointer installed.

**One finding rejected with evidence:** the review called the `ProcessTree` retention justification fabricated, having found `node-agent/cmd/main.go` passing `nil`. That search covered only the four consumer repos — `private-node-agent` wires the channel and consumes the field. Retention stands.

**Two corrections made in the author's own numbers**, both flagged rather than buried: the "970 KB worst case / 5.7× headroom" figure is not reproducible from its inputs and applies a *median* tree size to a *worst-case* message (≈2 MB at p90).

**And one correction to an earlier claim in this PR body.** It previously said node-agent "already carries `StartTimeNs` ... the same value, already computed". That is wrong, and worth stating plainly because the sensor-side work must not inherit it. node-agent has the field *name and unit* but **not a working value**: the exec/fork/exit feeders set it from the event timestamp (`convert.go`, *"Use event timestamp for consistency"*), and the procfs feeder passes through a field nothing upstream ever assigns — so it is **always zero for procfs-sourced processes**, the only source with full coverage. Verified: no `/proc/<pid>/stat` field-22 parse exists anywhere in node-agent. Populating it correctly is separate sensor-side work.

## Follow-ups (not in this PR)

- `NetworkStreamEvent.String()` is broken — `string(e.Port)` rune-converts an `int32` (port 8080 → one garbage character) and `string(e.IPAddress)` is a no-op. `go vet` structurally cannot catch it, because `rune` *is* `int32`. No callers found, but the search was not exhaustive.
- `armotypes/networkstream.go` is the only file in `armotypes` with no `bson` tags. The new fields carry them (per `AGENTS.md`, and mirroring `Process.ChildrenMap`); the rest of the file is pre-existing work.

## Ticket

[SUB-7785](https://cyberarmor-io.atlassian.net/browse/SUB-7785) — 2-1 — armoapi-go: per-connection process reference on NetworkStreamEvent


[SUB-7785]: https://cyberarmor-io.atlassian.net/browse/SUB-7785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ