### PR TITLE
feat(armotypes): rule-scoped CEL state store contract

### DIFF
--- a/armotypes/correlation_test.go
+++ b/armotypes/correlation_test.go
@@ -14,9 +14,9 @@ func TestCorrelationEvidence_NodeAgentShape(t *testing.T) {
 	ts := time.Date(2026, 7, 28, 12, 0, 3, 100000000, time.UTC)
 	ev := CorrelationEvidence{
 		Name:      "mount_exec",
-		EventType: string(EventTypeExec),
+		EventType: EventTypeExec,
 		Timestamp: ts,
-		Scope:     string(StateScopeContainer),
+		Scope:     StateScopeContainer,
 		Key:       "4471",
 		Process: &Process{
 			PID: 4471, PPID: 1201,
@@ -45,9 +45,9 @@ func TestCorrelationEvidence_NodeAgentShape(t *testing.T) {
 func TestCorrelationEvidence_AdmissionShape(t *testing.T) {
 	ev := CorrelationEvidence{
 		Name:      "pod_created",
-		EventType: string(EventTypeK8sAdmission),
+		EventType: EventTypeK8sAdmission,
 		Timestamp: time.Date(2026, 7, 28, 11, 42, 10, 0, time.UTC),
-		Scope:     string(StateScopeIdentity),
+		Scope:     StateScopeIdentity,
 		Admission: &AdmissionEvidence{
 			Username:        "system:serviceaccount:kube-system:deployer",
 			Operation:       "CREATE",
@@ -94,8 +94,8 @@ func TestRuntimeAlert_CorrelationsAreTopLevel(t *testing.T) {
 		CorrelationAlert: CorrelationAlert{
 			Correlations: []CorrelationEvidence{{
 				Name:      "mount_exec",
-				EventType: string(EventTypeExec),
-				Scope:     string(StateScopeContainer),
+				EventType: EventTypeExec,
+				Scope:     StateScopeContainer,
 				Key:       "4471",
 				Process:   &Process{PID: 4471, Comm: "xmrig", Path: "/mnt/data/xmrig"},
 			}},

--- a/armotypes/correlation_test.go
+++ b/armotypes/correlation_test.go
@@ -1,0 +1,83 @@
+package armotypes
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+)
+
+func TestCorrelationEvidence_NodeAgentShape(t *testing.T) {
+	ts := time.Date(2026, 7, 28, 12, 0, 3, 100000000, time.UTC)
+	ev := CorrelationEvidence{
+		Name:      "mount_exec",
+		EventType: string(EventTypeExec),
+		Timestamp: ts,
+		Scope:     string(StateScopeContainer),
+		Key:       "4471",
+		Process: &Process{
+			PID: 4471, PPID: 1201,
+			Comm: "xmrig", Pcomm: "bash",
+			Path: "/mnt/data/xmrig", Cwd: "/",
+			Uid: ptr.To(uint32(0)), Gid: ptr.To(uint32(0)),
+			UpperLayer: ptr.To(false),
+		},
+		Values: map[string]interface{}{"argv": []interface{}{"-o", "pool.example:4444"}},
+	}
+
+	data, err := json.Marshal(ev)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"process"`)
+	assert.NotContains(t, string(data), `"admission"`,
+		"admission must be omitted on a node-agent entry")
+
+	var decoded CorrelationEvidence
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.NotNil(t, decoded.Process)
+	assert.Equal(t, uint32(4471), decoded.Process.PID)
+	assert.Nil(t, decoded.Admission)
+	assert.Equal(t, ts.UTC(), decoded.Timestamp.UTC())
+}
+
+func TestCorrelationEvidence_AdmissionShape(t *testing.T) {
+	ev := CorrelationEvidence{
+		Name:      "pod_created",
+		EventType: string(EventTypeK8sAdmission),
+		Timestamp: time.Date(2026, 7, 28, 11, 42, 10, 0, time.UTC),
+		Scope:     string(StateScopeIdentity),
+		Admission: &AdmissionEvidence{
+			Username:        "system:serviceaccount:kube-system:deployer",
+			Operation:       "CREATE",
+			Resource:        "pods",
+			Kind:            "Pod",
+			ObjectNamespace: "production",
+		},
+	}
+
+	data, err := json.Marshal(ev)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"admission"`)
+	assert.NotContains(t, string(data), `"process"`,
+		"process must be omitted on an admission entry")
+	// Key is empty for identity scope: the identity IS the subject.
+	assert.NotContains(t, string(data), `"key"`)
+	// objectName is absent on CREATE because generated names are assigned
+	// after admission.
+	assert.NotContains(t, string(data), `"objectName"`)
+
+	var decoded CorrelationEvidence
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.NotNil(t, decoded.Admission)
+	assert.Equal(t, "system:serviceaccount:kube-system:deployer", decoded.Admission.Username)
+	assert.Nil(t, decoded.Process)
+}
+
+func TestCorrelationAlert_EmptyOmitsField(t *testing.T) {
+	data, err := json.Marshal(CorrelationAlert{})
+	require.NoError(t, err)
+	assert.Equal(t, "{}", string(data),
+		"an alert with no correlations must add nothing to the payload")
+}

--- a/armotypes/correlation_test.go
+++ b/armotypes/correlation_test.go
@@ -81,3 +81,56 @@ func TestCorrelationAlert_EmptyOmitsField(t *testing.T) {
 	assert.Equal(t, "{}", string(data),
 		"an alert with no correlations must add nothing to the payload")
 }
+
+func TestRuntimeAlert_CorrelationsAreTopLevel(t *testing.T) {
+	alert := RuntimeAlert{
+		BaseRuntimeAlert: BaseRuntimeAlert{
+			AlertName:   "Process executed from mount connected to external endpoint",
+			InfectedPID: 4471,
+			Severity:    8,
+			Timestamp:   time.Date(2026, 7, 28, 12, 0, 3, 480000000, time.UTC),
+		},
+		RuleID: "R1089",
+		CorrelationAlert: CorrelationAlert{
+			Correlations: []CorrelationEvidence{{
+				Name:      "mount_exec",
+				EventType: string(EventTypeExec),
+				Scope:     string(StateScopeContainer),
+				Key:       "4471",
+				Process:   &Process{PID: 4471, Comm: "xmrig", Path: "/mnt/data/xmrig"},
+			}},
+		},
+	}
+
+	data, err := json.Marshal(alert)
+	require.NoError(t, err)
+
+	// Inlined, so "correlations" sits beside "alertName" -- not nested under a
+	// "correlationAlert" object.
+	var flat map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &flat))
+	require.Contains(t, flat, "correlations")
+	assert.NotContains(t, flat, "correlationAlert")
+	assert.Contains(t, flat, "alertName")
+
+	var decoded RuntimeAlert
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Len(t, decoded.Correlations, 1)
+	assert.Equal(t, "mount_exec", decoded.Correlations[0].Name)
+	assert.Equal(t, uint32(4471), decoded.Correlations[0].Process.PID)
+	// The triggering event's identity is untouched by correlation.
+	assert.Equal(t, uint32(4471), decoded.InfectedPID)
+	assert.Equal(t, "R1089", decoded.RuleID)
+}
+
+func TestRuntimeAlert_WithoutCorrelations_IsUnchanged(t *testing.T) {
+	alert := RuntimeAlert{
+		BaseRuntimeAlert: BaseRuntimeAlert{AlertName: "Unexpected process launched"},
+		RuleID:           "R0001",
+	}
+
+	data, err := json.Marshal(alert)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "correlations",
+		"non-correlation alerts must serialize exactly as before")
+}

--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -351,11 +351,11 @@ type CorrelationEvidence struct {
 	// Name is the state variable the entry was stored under.
 	Name string `json:"name" bson:"name"`
 	// EventType is the stream the remembered event came from.
-	EventType string `json:"eventType" bson:"eventType"`
+	EventType EventType `json:"eventType" bson:"eventType"`
 	// Timestamp is the kernel/request time of the remembered event, not the
 	// time it was observed. Ordering comparisons rely on this.
-	Timestamp time.Time `json:"timestamp" bson:"timestamp"`
-	Scope     string    `json:"scope,omitempty" bson:"scope,omitempty"`
+	Timestamp time.Time  `json:"timestamp" bson:"timestamp"`
+	Scope     StateScope `json:"scope,omitempty" bson:"scope,omitempty"`
 	// Key is the subject discriminator, empty for scope-wide markers.
 	Key string `json:"key,omitempty" bson:"key,omitempty"`
 

--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -383,6 +383,7 @@ type RuntimeAlert struct {
 	cdr.CdrAlert           `json:"cdrevent,omitempty" bson:"cdrevent"`
 	HttpRuleAlert          `json:",inline" bson:"inline"`
 	NetworkScanAlert       `json:"networkscan,inline" bson:"networkscan"`
+	CorrelationAlert       `json:",inline" bson:"inline"`
 	AlertType              AlertType           `json:"alertType" bson:"alertType"`
 	AlertSourcePlatform    AlertSourcePlatform `json:"alertSourcePlatform" bson:"alertSourcePlatform"`
 	// Rule ID

--- a/armotypes/runtimeincidents.go
+++ b/armotypes/runtimeincidents.go
@@ -327,6 +327,52 @@ type NetworkScanAlert struct {
 	Addresses []string `json:"addresses,omitempty" bson:"addresses,omitempty"`
 }
 
+// AdmissionEvidence identifies a remembered admission request. It is the
+// admission-side counterpart to Process: an admission event has no PID, and its
+// useful identity (who did what to which object) has no home in Process.
+type AdmissionEvidence struct {
+	Username        string   `json:"username" bson:"username"`
+	Groups          []string `json:"groups,omitempty" bson:"groups,omitempty"`
+	Operation       string   `json:"operation,omitempty" bson:"operation,omitempty"`
+	Resource        string   `json:"resource,omitempty" bson:"resource,omitempty"`
+	Subresource     string   `json:"subresource,omitempty" bson:"subresource,omitempty"`
+	Kind            string   `json:"kind,omitempty" bson:"kind,omitempty"`
+	ObjectName      string   `json:"objectName,omitempty" bson:"objectName,omitempty"`
+	ObjectNamespace string   `json:"objectNamespace,omitempty" bson:"objectNamespace,omitempty"`
+}
+
+// CorrelationEvidence is one remembered event that contributed to a
+// correlation alert — the "other end" of the chain, which the triggering event
+// alone cannot describe.
+//
+// Process and Admission are a tagged union: exactly one is set, determined by
+// the engine that wrote the entry (node-agent or the operator).
+type CorrelationEvidence struct {
+	// Name is the state variable the entry was stored under.
+	Name string `json:"name" bson:"name"`
+	// EventType is the stream the remembered event came from.
+	EventType string `json:"eventType" bson:"eventType"`
+	// Timestamp is the kernel/request time of the remembered event, not the
+	// time it was observed. Ordering comparisons rely on this.
+	Timestamp time.Time `json:"timestamp" bson:"timestamp"`
+	Scope     string    `json:"scope,omitempty" bson:"scope,omitempty"`
+	// Key is the subject discriminator, empty for scope-wide markers.
+	Key string `json:"key,omitempty" bson:"key,omitempty"`
+
+	Process   *Process           `json:"process,omitempty" bson:"process,omitempty"`
+	Admission *AdmissionEvidence `json:"admission,omitempty" bson:"admission,omitempty"`
+
+	// Values carries author-supplied extras from the rule's StateWrite.Value.
+	Values map[string]interface{} `json:"values,omitempty" bson:"values,omitempty"`
+}
+
+// CorrelationAlert is inlined into RuntimeAlert. Because both node-agent and
+// the operator build RuntimeAlert, this single type carries correlation
+// evidence for both engines.
+type CorrelationAlert struct {
+	Correlations []CorrelationEvidence `json:"correlations,omitempty" bson:"correlations,omitempty"`
+}
+
 type RuntimeAlert struct {
 	BaseRuntimeAlert       `json:",inline" bson:"inline"`
 	RuleAlert              `json:",inline" bson:"inline"`

--- a/armotypes/runtimerule.go
+++ b/armotypes/runtimerule.go
@@ -66,28 +66,31 @@ func RuleSeverityToString(severity int) string {
 }
 
 type RuntimeRule struct {
-	Enabled                 bool              `json:"enabled" yaml:"enabled" bson:"enabled"`
-	ID                      string            `json:"id" yaml:"id" bson:"id"`
-	Name                    string            `json:"name" yaml:"name" bson:"name"`
-	Description             string            `json:"description" yaml:"description" bson:"description"`
-	Expressions             RuleExpressions   `json:"expressions" yaml:"expressions" bson:"expressions"`
-	ProfileDependency       ProfileDependency      `json:"profileDependency" yaml:"profileDependency" bson:"profileDependency"`
-	ProfileDataRequired    *ProfileDataRequired   `json:"profileDataRequired,omitempty" yaml:"profileDataRequired,omitempty" bson:"profileDataRequired,omitempty"`
-	Severity                int               `json:"severity" bson:"severity"`
-	SeverityString          string            `json:"severityString" bson:"severityString"`
-	SupportPolicy           bool              `json:"supportPolicy" yaml:"supportPolicy" bson:"supportPolicy"`
-	Tags                    []string          `json:"tags" yaml:"tags" bson:"tags"`
-	State                   map[string]any    `json:"state,omitempty" yaml:"state,omitempty" bson:"state,omitempty"`
-	AgentVersionRequirement string            `json:"agentVersionRequirement" yaml:"agentVersionRequirement" bson:"agentVersionRequirement"`
-	IsTriggerAlert          bool              `json:"isTriggerAlert" yaml:"isTriggerAlert" bson:"isTriggerAlert"`
-	MitreTactic             string            `json:"mitreTactic" bson:"mitreTactic"`
-	MitreTechnique          string            `json:"mitreTechnique" bson:"mitreTechnique"`
-	Category                string            `json:"category" bson:"category"`
-	IncidentTypeId          string            `json:"incidentTypeId" bson:"incidentTypeId"`
+	Enabled     bool            `json:"enabled" yaml:"enabled" bson:"enabled"`
+	ID          string          `json:"id" yaml:"id" bson:"id"`
+	Name        string          `json:"name" yaml:"name" bson:"name"`
+	Description string          `json:"description" yaml:"description" bson:"description"`
+	Expressions RuleExpressions `json:"expressions" yaml:"expressions" bson:"expressions"`
+	// StateWrites declares what this rule remembers across events. Empty for
+	// the overwhelming majority of rules, which are stateless predicates.
+	StateWrites             []StateWrite         `json:"stateWrites,omitempty" yaml:"stateWrites,omitempty" bson:"stateWrites,omitempty"`
+	ProfileDependency       ProfileDependency    `json:"profileDependency" yaml:"profileDependency" bson:"profileDependency"`
+	ProfileDataRequired     *ProfileDataRequired `json:"profileDataRequired,omitempty" yaml:"profileDataRequired,omitempty" bson:"profileDataRequired,omitempty"`
+	Severity                int                  `json:"severity" bson:"severity"`
+	SeverityString          string               `json:"severityString" bson:"severityString"`
+	SupportPolicy           bool                 `json:"supportPolicy" yaml:"supportPolicy" bson:"supportPolicy"`
+	Tags                    []string             `json:"tags" yaml:"tags" bson:"tags"`
+	State                   map[string]any       `json:"state,omitempty" yaml:"state,omitempty" bson:"state,omitempty"`
+	AgentVersionRequirement string               `json:"agentVersionRequirement" yaml:"agentVersionRequirement" bson:"agentVersionRequirement"`
+	IsTriggerAlert          bool                 `json:"isTriggerAlert" yaml:"isTriggerAlert" bson:"isTriggerAlert"`
+	MitreTactic             string               `json:"mitreTactic" bson:"mitreTactic"`
+	MitreTechnique          string               `json:"mitreTechnique" bson:"mitreTechnique"`
+	Category                string               `json:"category" bson:"category"`
+	IncidentTypeId          string               `json:"incidentTypeId" bson:"incidentTypeId"`
 	// Documentation is the rendered markdown documentation for this rule,
 	// sourced from the rule's README.md in the rulelibrary repo. Empty for
 	// customer-authored rules.
-	Documentation           string            `json:"documentation,omitempty" yaml:"documentation,omitempty" bson:"documentation,omitempty"`
+	Documentation string `json:"documentation,omitempty" yaml:"documentation,omitempty" bson:"documentation,omitempty"`
 }
 
 type RuleExpressions struct {
@@ -99,6 +102,60 @@ type RuleExpressions struct {
 type RuleExpression struct {
 	EventType  EventType `json:"eventType" yaml:"eventType" bson:"eventType"`
 	Expression string    `json:"expression" yaml:"expression" bson:"expression"`
+}
+
+// StateScope names the bucket a state entry belongs to. The scope determines
+// which entries a read can see, and the engine — never the rule — resolves the
+// concrete scope ID from the event, so cross-tenant leakage is not expressible.
+//
+// container/pod/node are node-agent scopes; identity is the operator's only
+// scope (admission chains are defined by the caller who performed them).
+type StateScope string
+
+const (
+	StateScopeContainer StateScope = "container"
+	StateScopePod       StateScope = "pod"
+	StateScopeNode      StateScope = "node"
+	StateScopeIdentity  StateScope = "identity"
+)
+
+// StateWrite is one declarative write clause: on events of EventType, when the
+// When guard holds, remember a marker under Name (optionally discriminated by
+// Key) inside Scope for TTL.
+//
+// Writes are declared rather than expressed as a CEL setter so that remembering
+// is decoupled from alerting: a rule may carry a write clause for an event type
+// it never alerts on, and the guard is evaluated exactly once, unaffected by
+// boolean short-circuiting or CEL's static optimiser.
+type StateWrite struct {
+	// EventType is the event stream that drives this write. It need not match
+	// any eventType in Expressions.RuleExpression — that is what allows a rule
+	// to remember on exec and alert on network.
+	EventType EventType `json:"eventType" yaml:"eventType" bson:"eventType"`
+
+	// When is a CEL boolean guard. Empty means "always write".
+	When string `json:"when,omitempty" yaml:"when,omitempty" bson:"when,omitempty"`
+
+	Scope StateScope `json:"scope" yaml:"scope" bson:"scope"`
+
+	// Name is what kind of fact this is — a string literal, never an
+	// expression, so it stays statically analysable and safe as a metric label.
+	Name string `json:"name" yaml:"name" bson:"name"`
+
+	// Key is who the fact is about: a CEL string expression, evaluated per
+	// event. Optional — omit it for a fact that is true of the whole scope
+	// rather than one subject, which yields exactly one entry per scope.
+	Key string `json:"key,omitempty" yaml:"key,omitempty" bson:"key,omitempty"`
+
+	// Value carries optional author-supplied extras as CEL expressions keyed by
+	// name. Keys must not begin with "_", which is reserved for engine-stamped
+	// provenance. Enforced by the consuming engine at rule load.
+	Value map[string]any `json:"value,omitempty" yaml:"value,omitempty" bson:"value,omitempty"`
+
+	// TTL is a Go duration string ("10m", "30m"). The consuming engine clamps
+	// it to its configured maxTTL at load, so no rule can pin memory
+	// indefinitely.
+	TTL string `json:"ttl" yaml:"ttl" bson:"ttl"`
 }
 
 // ProfileDataPattern declares a single match pattern for a profile-data

--- a/armotypes/runtimerule.go
+++ b/armotypes/runtimerule.go
@@ -124,7 +124,43 @@ const (
 	EventTypeSSH          EventType = "ssh"
 	EventTypeHTTP         EventType = "http"
 	EventTypeK8sAdmission EventType = "k8s-admission"
+
+	// Node-telemetry event types emitted by node-agent. Added so a stateWrites
+	// clause can name any node-agent event stream, not just the subset that
+	// happened to be referenced by admission rules.
+	EventTypePtrace  EventType = "ptrace"
+	EventTypeBPF     EventType = "bpf"
+	EventTypeKmod    EventType = "kmod"
+	EventTypeUnshare EventType = "unshare"
+	EventTypeIoUring EventType = "iouring"
+	EventTypeRandomX EventType = "randomx"
+	EventTypeProcfs  EventType = "procfs"
+	EventTypeFork    EventType = "fork"
+	EventTypeExit    EventType = "exit"
+
+	// EventTypeAll is a wildcard used by rule bindings, not a real event stream.
+	EventTypeAll EventType = "all"
 )
+
+// knownEventTypes is the authoritative set of event types the rule contract
+// accepts. Kept in sync with node-agent's utils.EventType.
+var knownEventTypes = map[EventType]struct{}{
+	EventTypeExec: {}, EventTypeOpen: {}, EventTypeCapabilities: {},
+	EventTypeDNS: {}, EventTypeNetwork: {}, EventTypeSyscall: {},
+	EventTypeSymlink: {}, EventTypeHardlink: {}, EventTypeSSH: {},
+	EventTypeHTTP: {}, EventTypeK8sAdmission: {}, EventTypePtrace: {},
+	EventTypeBPF: {}, EventTypeKmod: {}, EventTypeUnshare: {},
+	EventTypeIoUring: {}, EventTypeRandomX: {}, EventTypeProcfs: {},
+	EventTypeFork: {}, EventTypeExit: {}, EventTypeAll: {},
+}
+
+// IsKnownEventType reports whether e is a recognised event type. Rule loaders
+// use this to reject a stateWrites or ruleExpression entry naming an event
+// stream that does not exist, rather than silently never matching.
+func IsKnownEventType(e EventType) bool {
+	_, ok := knownEventTypes[e]
+	return ok
+}
 
 // ProfileDataField is a tagged union: either All == true (the rule needs every
 // entry on this surface) or Patterns is non-empty (the rule needs entries

--- a/armotypes/runtimerule.go
+++ b/armotypes/runtimerule.go
@@ -211,12 +211,27 @@ var knownEventTypes = map[EventType]struct{}{
 	EventTypeFork: {}, EventTypeExit: {}, EventTypeAll: {},
 }
 
-// IsKnownEventType reports whether e is a recognised event type. Rule loaders
-// use this to reject a stateWrites or ruleExpression entry naming an event
-// stream that does not exist, rather than silently never matching.
+// IsKnownEventType reports whether e is a recognised event type, including the
+// EventTypeAll binding wildcard. Rule loaders use this to reject an entry
+// naming an event stream that does not exist, rather than silently never
+// matching.
+//
+// For state-write clauses use IsValidStateWriteEventType instead: a write must
+// be driven by a concrete stream, and EventTypeAll is not one.
 func IsKnownEventType(e EventType) bool {
 	_, ok := knownEventTypes[e]
 	return ok
+}
+
+// IsValidStateWriteEventType reports whether e may drive a StateWrite.
+//
+// This is stricter than IsKnownEventType: EventTypeAll is a rule-binding
+// wildcard rather than an event stream, so it cannot drive a write. Accepting it
+// would let `stateWrites.eventType: all` pass validation and then never match a
+// concrete event -- a rule that loads cleanly and silently never fires, which is
+// the failure mode this contract is built to avoid.
+func IsValidStateWriteEventType(e EventType) bool {
+	return e != EventTypeAll && IsKnownEventType(e)
 }
 
 // ProfileDataField is a tagged union: either All == true (the rule needs every

--- a/armotypes/runtimerule_statewrites_test.go
+++ b/armotypes/runtimerule_statewrites_test.go
@@ -1,0 +1,32 @@
+package armotypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// nodeAgentEventTypes mirrors node-agent's utils.EventType value set
+// (node-agent/pkg/utils/events.go:206-234). armotypes must define a constant
+// for every one of these, because a stateWrites clause may name any of them.
+var nodeAgentEventTypes = []string{
+	"exec", "open", "dns", "network", "http", "syscall", "capabilities",
+	"ptrace", "bpf", "kmod", "symlink", "hardlink", "unshare", "iouring",
+	"ssh", "randomx", "procfs", "fork", "exit", "all",
+}
+
+func TestEventType_CoversNodeAgentEventSet(t *testing.T) {
+	for _, want := range nodeAgentEventTypes {
+		assert.True(t, IsKnownEventType(EventType(want)),
+			"armotypes has no EventType constant for node-agent event type %q", want)
+	}
+}
+
+func TestEventType_K8sAdmissionStillKnown(t *testing.T) {
+	assert.True(t, IsKnownEventType(EventTypeK8sAdmission))
+}
+
+func TestEventType_UnknownIsRejected(t *testing.T) {
+	assert.False(t, IsKnownEventType(EventType("not-a-real-event-type")))
+	assert.False(t, IsKnownEventType(EventType("")))
+}

--- a/armotypes/runtimerule_statewrites_test.go
+++ b/armotypes/runtimerule_statewrites_test.go
@@ -1,9 +1,12 @@
 package armotypes
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 // nodeAgentEventTypes mirrors node-agent's utils.EventType value set
@@ -29,4 +32,76 @@ func TestEventType_K8sAdmissionStillKnown(t *testing.T) {
 func TestEventType_UnknownIsRejected(t *testing.T) {
 	assert.False(t, IsKnownEventType(EventType("not-a-real-event-type")))
 	assert.False(t, IsKnownEventType(EventType("")))
+}
+
+func TestRuntimeRule_StateWrites_YAMLRoundTrip(t *testing.T) {
+	const in = `
+id: R1089
+name: mount exec then external connection
+severity: 8
+profileDependency: 2
+stateWrites:
+  - eventType: exec
+    when: 'true'
+    scope: container
+    name: mount_exec
+    key: string(event.pid)
+    value:
+      argv: placeholder
+    ttl: 10m
+expressions:
+  message: "'msg'"
+  uniqueId: "'uid'"
+  ruleExpression:
+    - eventType: network
+      expression: 'state.has("mount_exec", string(event.pid))'
+`
+	var rule RuntimeRule
+	require.NoError(t, yaml.Unmarshal([]byte(in), &rule))
+
+	require.Len(t, rule.StateWrites, 1)
+	w := rule.StateWrites[0]
+	assert.Equal(t, EventTypeExec, w.EventType)
+	assert.Equal(t, StateScopeContainer, w.Scope)
+	assert.Equal(t, "mount_exec", w.Name)
+	assert.Equal(t, "string(event.pid)", w.Key)
+	assert.Equal(t, "10m", w.TTL)
+	assert.Equal(t, "true", w.When)
+	assert.Equal(t, "placeholder", w.Value["argv"])
+}
+
+func TestRuntimeRule_StateWrites_JSONRoundTrip(t *testing.T) {
+	original := RuntimeRule{
+		ID: "R1089",
+		StateWrites: []StateWrite{{
+			EventType: EventTypeK8sAdmission,
+			When:      `event.Operation == "CREATE"`,
+			Scope:     StateScopeIdentity,
+			Name:      "pod_created",
+			TTL:       "30m",
+		}},
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"stateWrites"`)
+
+	var decoded RuntimeRule
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, original.StateWrites, decoded.StateWrites)
+	// Key omitted: identity-scoped markers need no subject discriminator.
+	assert.Empty(t, decoded.StateWrites[0].Key)
+}
+
+func TestRuntimeRule_NoStateWrites_OmittedFromJSON(t *testing.T) {
+	data, err := json.Marshal(RuntimeRule{ID: "R0001"})
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "stateWrites",
+		"rules without state must serialize exactly as before")
+}
+
+func TestStateWrite_EventTypeIsValidated(t *testing.T) {
+	w := StateWrite{EventType: EventType("nonsense")}
+	assert.False(t, IsKnownEventType(w.EventType))
+	assert.True(t, IsKnownEventType(StateWrite{EventType: EventTypePtrace}.EventType))
 }

--- a/armotypes/runtimerule_statewrites_test.go
+++ b/armotypes/runtimerule_statewrites_test.go
@@ -105,3 +105,28 @@ func TestStateWrite_EventTypeIsValidated(t *testing.T) {
 	assert.False(t, IsKnownEventType(w.EventType))
 	assert.True(t, IsKnownEventType(StateWrite{EventType: EventTypePtrace}.EventType))
 }
+
+// EventTypeAll is a rule-binding wildcard, not an event stream. A state write
+// must name a concrete stream to drive it: `stateWrites.eventType: all` would
+// otherwise pass validation and then never match anything, which is precisely
+// the silently-dead-rule failure this contract exists to prevent.
+func TestIsValidStateWriteEventType_RejectsTheAllWildcard(t *testing.T) {
+	assert.True(t, IsKnownEventType(EventTypeAll),
+		"all remains valid for rule bindings")
+	assert.False(t, IsValidStateWriteEventType(EventTypeAll),
+		"but it cannot drive a state write")
+}
+
+func TestIsValidStateWriteEventType_AcceptsConcreteStreams(t *testing.T) {
+	for _, et := range []EventType{
+		EventTypeExec, EventTypeOpen, EventTypeNetwork, EventTypePtrace,
+		EventTypeKmod, EventTypeBPF, EventTypeK8sAdmission,
+	} {
+		assert.True(t, IsValidStateWriteEventType(et), "%s should drive a state write", et)
+	}
+}
+
+func TestIsValidStateWriteEventType_RejectsUnknown(t *testing.T) {
+	assert.False(t, IsValidStateWriteEventType(EventType("nonsense")))
+	assert.False(t, IsValidStateWriteEventType(EventType("")))
+}

--- a/docs/features/cel-rule-state-contract.md
+++ b/docs/features/cel-rule-state-contract.md
@@ -119,17 +119,35 @@ node-agent has 20, so `ptrace`, `bpf`, `kmod`, `unshare`, `iouring`, `randomx`,
 may name any of them.
 
 ```go
-func IsKnownEventType(e EventType) bool
+func IsKnownEventType(e EventType) bool           // includes the `all` wildcard
+func IsValidStateWriteEventType(e EventType) bool // excludes it
 ```
 
-Rule loaders use this to reject a clause naming an event stream that does not exist.
+Rule loaders use these to reject a clause naming an event stream that does not exist.
 `EventType` is a string type, so an unknown value would otherwise deserialize happily
 and produce a rule that silently never matches — the failure mode this contract works
 hardest to avoid.
 
+The two differ on **`all`**, which is a rule-binding wildcard rather than an event
+stream:
+
+- `ruleExpression` / rule bindings — `all` is meaningful, so use `IsKnownEventType`.
+- **`stateWrites` — `all` is invalid**, because a write must be driven by a concrete
+  stream. Use `IsValidStateWriteEventType`. Accepting `all` would let a clause pass
+  validation and then never match a concrete event.
+
 ## Compatibility
 
-Purely additive. No existing field was renamed, retyped, or retagged. All new fields
-are `omitempty` on `json`, `yaml` and `bson`, so rules and alerts that do not use
-correlation serialize byte-identically to before. `runtimerule_statewrites_test.go`
-and `correlation_test.go` assert this directly.
+Purely additive. No existing field was renamed, retyped, or retagged. Rules and alerts
+that do not use correlation serialize byte-identically to before —
+`runtimerule_statewrites_test.go` and `correlation_test.go` assert this directly.
+
+Tag coverage follows each file's existing convention rather than being uniform:
+
+| Types | Tags | Why |
+|---|---|---|
+| `StateWrite`, `StateScope` (`runtimerule.go`) | `json`, `yaml`, `bson` | Rules are authored as YAML in the rule libraries and persisted by the backend |
+| `CorrelationAlert`, `CorrelationEvidence`, `AdmissionEvidence` (`runtimeincidents.go`) | `json`, `bson` | Alerts are never YAML-serialized; **no** type in `runtimeincidents.go` carries a `yaml` tag |
+
+Adding `yaml` tags to the correlation types would make them the only ones in that file
+with them, implying a YAML path that does not exist.

--- a/docs/features/cel-rule-state-contract.md
+++ b/docs/features/cel-rule-state-contract.md
@@ -93,9 +93,21 @@ carries correlation evidence for both.
 triggering event cannot express. Without it, an alert would say only "a process made
 an outbound connection" and drop the exec that makes it interesting.
 
-`Process` and `Admission` are a **tagged union**: exactly one is set, determined by
-the engine that wrote the entry. An admission request has no PID, and its useful
-identity (who did what to which object) has no home in `Process`.
+`Process` and `Admission` are a **tagged union by producer discipline**: node-agent
+populates `Process`, the operator populates `Admission`. An admission request has no
+PID, and its useful identity (who did what to which object) has no home in `Process`.
+
+This is **not enforced at deserialization**, deliberately. These types are the wire and
+persistence shape of the alert pipeline, so a rejecting `UnmarshalJSON` would turn a
+producer bug into a *dropped alert* and would apply retroactively to every stored
+document. For a security product a mis-shaped alert beats a missing one, and the entry
+is still usable — `name`, `eventType`, `timestamp`, `scope` and `key` carry the
+correlation regardless. The invariant belongs where entries are constructed
+(node-agent `pkg/rulestate`, operator `admission/`).
+
+Consumers should therefore treat "both set" as a producer bug and prefer `Process`, and
+treat "neither set" as legitimate-but-sparse — a node-agent entry whose source event
+carried no process fields will have `process` absent.
 
 | Field | Meaning |
 |---|---|

--- a/docs/features/cel-rule-state-contract.md
+++ b/docs/features/cel-rule-state-contract.md
@@ -1,6 +1,6 @@
 ---
 type: feature
-status: in-progress
+status: active
 owner: ben@armosec.io
 scope: repo
 related_code:

--- a/docs/features/cel-rule-state-contract.md
+++ b/docs/features/cel-rule-state-contract.md
@@ -1,0 +1,135 @@
+---
+type: feature
+status: in-progress
+owner: ben@armosec.io
+scope: repo
+related_code:
+  - armotypes/runtimerule.go
+  - armotypes/runtimeincidents.go
+---
+
+# CEL rule state contract (cross-event correlation)
+
+Shared types that let a CEL runtime rule remember a fact from one event and read it
+back when a later event arrives, and that carry the remembered event into the alert.
+
+Consumed by **node-agent** (node telemetry) and the **operator** (`k8s-admission`).
+Both watch the same `Rules` CRD and both build `armotypes.RuntimeAlert`, so these
+types are defined here once rather than per component.
+
+Design spec: `shared-designs-and-docs/projects/2026-07-28-cel-rule-state-store/spec.md`.
+
+## Why it exists
+
+A CEL rule is otherwise a stateless predicate over a single event: it returns a
+boolean and remembers nothing. That makes any detection whose signal is *two or more
+events sharing a key within a time window* inexpressible — a process executed from a
+mount that then connects out, a web server spawning a shell whose descendant makes an
+outbound connection, or `create pod` → `exec pod` → `delete pod` by one subject.
+
+## `RuntimeRule.StateWrites`
+
+```go
+StateWrites []StateWrite `json:"stateWrites,omitempty" yaml:"stateWrites,omitempty" bson:"stateWrites,omitempty"`
+```
+
+A rule declares what it remembers. Writes are **declared, not expressed as a CEL
+setter** — a setter inside a boolean can be skipped by short-circuiting, may be
+reordered by CEL's static optimiser, and would fuse "did this rule fire?" with "did
+this rule remember something?", making write-without-alerting impossible. That last
+property is exactly what the first leg of every correlation rule needs.
+
+| Field | Meaning |
+|---|---|
+| `eventType` | The stream driving this write. Need not appear in `expressions.ruleExpression` — that is what allows remembering on `exec` and alerting on `network`. |
+| `when` | CEL boolean guard. Empty means always write. A guard may itself read state, which is how multi-step sequences are expressed without a new construct. |
+| `scope` | `container` / `pod` / `node` (node-agent) or `identity` (operator). |
+| `name` | *What kind of fact.* A string literal, never an expression, so it stays statically analysable and safe as a metric label. |
+| `key` | *Who the fact is about.* A CEL string expression. **Optional** — omit for a fact true of the whole scope, which yields one entry per scope. |
+| `value` | Optional author extras as CEL expressions. Keys must not begin with `_`, which is reserved for engine-stamped provenance. |
+| `ttl` | Go duration string. The consuming engine clamps it to its configured maximum at load, so no rule can pin memory indefinitely. |
+
+### `name` vs `key`
+
+These are the two most-confused fields. `name` is *what kind of fact*; `key` is *who
+it is about*. One container may have 50 processes that exec'd from a mount: that is
+**one** `name` with **50** `key`s. `name` is the variable, `key` indexes into it.
+
+They are kept separate because the engine must be able to hold the fact type fixed
+while varying the subject — that is what makes ancestry matching ("does any ancestor
+of this PID carry a `mount_exec` marker?") mechanically possible. Fused into one
+opaque string, the engine could not tell which substring is the PID.
+
+### `StateScope`
+
+```go
+StateScopeContainer StateScope = "container"
+StateScopePod       StateScope = "pod"
+StateScopeNode      StateScope = "node"
+StateScopeIdentity  StateScope = "identity"
+```
+
+The scope determines which entries a read can see. The **engine** resolves the
+concrete scope ID from the event — never the rule — so cross-container and
+cross-tenant leakage is not expressible regardless of what an author writes in `key`.
+
+`identity` is the operator's only scope: an admission chain is defined by *who*
+performed the sequence, so memory is bounded per caller.
+
+## `CorrelationAlert` on `RuntimeAlert`
+
+```go
+type CorrelationAlert struct {
+    Correlations []CorrelationEvidence
+}
+```
+
+Inlined into `RuntimeAlert` alongside `RuleAlert`, `MalwareAlert`, `AdmissionAlert`
+and the rest, so `correlations` appears at the **top level** of the alert payload.
+Because both node-agent and the operator build `RuntimeAlert`, this single type
+carries correlation evidence for both.
+
+`CorrelationEvidence` describes the *remembered* end of a chain — the part the
+triggering event cannot express. Without it, an alert would say only "a process made
+an outbound connection" and drop the exec that makes it interesting.
+
+`Process` and `Admission` are a **tagged union**: exactly one is set, determined by
+the engine that wrote the entry. An admission request has no PID, and its useful
+identity (who did what to which object) has no home in `Process`.
+
+| Field | Meaning |
+|---|---|
+| `name` | The state variable the entry was stored under |
+| `eventType` | Stream the remembered event came from |
+| `timestamp` | Kernel/request time of the remembered event, **not** observation time — ordering comparisons rely on this |
+| `scope`, `key` | Where it was stored; `key` empty for scope-wide markers |
+| `process` | node-agent entries (reuses `armotypes.Process`) |
+| `admission` | operator entries (`AdmissionEvidence`) |
+| `values` | Author extras from the rule's `StateWrite.Value` |
+
+`InfectedPID` and the alert's process tree continue to describe the **triggering**
+event. Correlation enriches an incident; it does not re-key it, so backend incident
+grouping is unchanged.
+
+## `EventType` and `IsKnownEventType`
+
+`EventType` previously defined only the 11 streams admission rules referenced.
+node-agent has 20, so `ptrace`, `bpf`, `kmod`, `unshare`, `iouring`, `randomx`,
+`procfs`, `fork`, `exit` and the `all` wildcard were added — a `stateWrites` clause
+may name any of them.
+
+```go
+func IsKnownEventType(e EventType) bool
+```
+
+Rule loaders use this to reject a clause naming an event stream that does not exist.
+`EventType` is a string type, so an unknown value would otherwise deserialize happily
+and produce a rule that silently never matches — the failure mode this contract works
+hardest to avoid.
+
+## Compatibility
+
+Purely additive. No existing field was renamed, retyped, or retagged. All new fields
+are `omitempty` on `json`, `yaml` and `bson`, so rules and alerts that do not use
+correlation serialize byte-identically to before. `runtimerule_statewrites_test.go`
+and `correlation_test.go` assert this directly.


### PR DESCRIPTION
Adds the shared type contract for cross-event CEL rule correlation, per
`projects/2026-07-28-cel-rule-state-store/spec.md` in shared-designs-and-docs.

Today a CEL runtime rule is a stateless predicate over a single event: it returns a
boolean and remembers nothing. That makes any detection whose signal is *two or more
events sharing a key within a time window* inexpressible — a process executed from a
mount that then connects out, a webshell chain, or `create pod` → `exec pod` →
`delete pod` by one subject. 11 triaged rules are blocked on exactly this.

These types are defined here rather than per component because **node-agent and the
operator already share both ends**: they watch the same `Rules` CRD via the same
`typesv1.RuleGvr`, and both build `armotypes.RuntimeAlert`.

## What's added

- **`StateWrite` + `RuntimeRule.StateWrites`** — the declarative write clause. Writes
  are *declared*, not expressed as a CEL setter: a setter inside a boolean can be
  skipped by short-circuiting, may be reordered by CEL's static optimiser, and would
  fuse "did this rule fire?" with "did this rule remember something?" — making
  write-without-alerting impossible, which is exactly what the first leg of every
  correlation rule needs.
- **`CorrelationAlert` / `CorrelationEvidence` / `AdmissionEvidence`** — the remembered
  end of a chain. `Process` and `Admission` form a tagged union: an admission request
  has no PID, and its who/what/which identity has no home in `Process`. Inlined into
  `RuntimeAlert` following the existing per-kind convention, so one addition covers
  both engines.
- **9 missing node-telemetry `EventType` constants** plus the `all` wildcard, and
  `IsKnownEventType`. `EventType` is a string type, so an unknown value would otherwise
  deserialize happily into a rule that silently never matches.

## Compatibility

Purely additive — no existing field renamed, retyped, or retagged. Rules and alerts that
don't use correlation serialize byte-identically. The tests assert that directly
(`TestRuntimeRule_NoStateWrites_OmittedFromJSON`,
`TestRuntimeAlert_WithoutCorrelations_IsUnchanged`).

Tag coverage follows each file's existing convention rather than being uniform: `StateWrite`
in `runtimerule.go` carries `json`/`yaml`/`bson` because rules are authored as YAML, while
the correlation types in `runtimeincidents.go` carry `json`/`bson` only — **no** type in that
file has a `yaml` tag, because alerts are never YAML-serialized.

`ProfileDataField` / `ProfileDataRequired` are deliberately **untouched**: node-agent
keeps its stricter `FieldRequirement` semantics (including the `Declared` flag) by
shadowing, so changing this backend-shared type isn't required.

## Verification

- `go build ./...` clean
- `go test ./...` — 480 tests pass across 11 packages
- `go test -race ./armotypes/` clean

## Reviewer notes

- The `runtimerule.go` diff includes gofmt realignment of the `RuntimeRule` struct
  block. That block was already non-compliant on `main`; adding a field to it makes
  gofmt's column choice for the new line depend on the whole block, so it can't be left
  half-formatted. Every removed line reappears modulo whitespace. The other four
  unformatted files in `armotypes/` are untouched.
- Docs: `docs/features/cel-rule-state-contract.md`.

Follow-ups in other repos (not this PR): node-agent embeds `RuntimeRule` and implements
the store; the operator implements the admission side with `identity` scope.

AI-skills: superpowers:brainstorming,superpowers:writing-plans,superpowers:executing-plans | cmds: /rate-limit-options
