### PR TITLE
[scratch] S7 E2E — json-tag rename on Oauth2Customer.CustomerGUID (do not merge)

### DIFF
--- a/apis/datastructures.go
+++ b/apis/datastructures.go
@@ -63,7 +63,7 @@ type DBCommand struct {
 // Oauth2 verification process
 type Oauth2Customer struct {
 	CustomerName string `json:"customerName"`
-	CustomerGUID string `json:"customerGUID"`
+	CustomerGUID string `json:"customerGUID_renamed"` // S7 E2E: scratch json-tag rename (silent-drop class)
 }
 
 type LoginObject struct {


### PR DESCRIPTION
<!-- armosec-pr: v=1 via=manual -->

## Summary

**Scratch / do-not-merge.** Live E2E for the S7 context ladder (`pr-review-v1.7.0`): renames the `json` tag on `Oauth2Customer.CustomerGUID` — a struct-tag change on a shared-lib repo, which should fire the T3 trigger, escalate the review profile, and search consumer code-indexes for `CustomerGUID` call sites. Will be closed after the review run is inspected.

## Ticket

[SUB-7883](https://cyberarmor-io.atlassian.net/browse/SUB-7883) — S7 context ladder (live E2E).


[SUB-7883]: https://cyberarmor-io.atlassian.net/browse/SUB-7883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ